### PR TITLE
Add env-based config and basic docs

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-RAPIDAPI_KEY = "c6f8dff191mshe22c98cfa3266b2p14b79cjsn8c3969eca4f2"
-RAPIDAPI_HOST = "pokemon-tcg-api.p.rapidapi.com"
+RAPIDAPI_KEY=c6f8dff191mshe22c98cfa3266b2p14b79cjsn8c3969eca4f2
+RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Kartoteka
+
+A small tkinter application for organizing Pokémon card scans and exporting data to CSV.
+
+## Features
+- Load images from a folder and review them one by one
+- Fetch card prices from [TCGGO](https://www.tcggo.com/) API
+- Save collected data to a CSV file
+
+## Requirements
+Install dependencies from `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+The application also reads API credentials from a `.env` file:
+
+```
+RAPIDAPI_KEY=<your RapidAPI key>
+RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
+```
+
+## Running
+Execute the main script with Python 3:
+
+```bash
+python main.py
+```
+
+The interface will allow you to load scans, fetch prices and export results to CSV.

--- a/main.py
+++ b/main.py
@@ -6,6 +6,12 @@ import csv
 import json
 import requests
 from collections import defaultdict
+from dotenv import load_dotenv
+
+load_dotenv()
+
+RAPIDAPI_KEY = os.getenv("RAPIDAPI_KEY")
+RAPIDAPI_HOST = os.getenv("RAPIDAPI_HOST")
 
 # Wczytanie danych setów
 with open("tcg_sets.json", encoding="utf-8") as f:
@@ -13,9 +19,6 @@ with open("tcg_sets.json", encoding="utf-8") as f:
 
 with open("tcg_sets_jp.json", encoding="utf-8") as f:
     tcg_sets_jp = list(json.load(f).keys())
-
-RAPIDAPI_KEY = "c6f8dff191mshe22c98cfa3266b2p14b79cjsn8c3969eca4f2"
-RAPIDAPI_HOST = "pokemon-tcg-api.p.rapidapi.com"
 
 class CardEditorApp:
     def __init__(self, root):
@@ -157,7 +160,18 @@ class CardEditorApp:
 
         try:
             url = "https://www.tcggo.com/api/cards/"
-            response = requests.get(url)
+            params = {
+                "name": name_input,
+                "number": number_input,
+                "set": set_input,
+            }
+            headers = {}
+            if RAPIDAPI_KEY and RAPIDAPI_HOST:
+                headers = {
+                    "X-RapidAPI-Key": RAPIDAPI_KEY,
+                    "X-RapidAPI-Host": RAPIDAPI_HOST,
+                }
+            response = requests.get(url, params=params, headers=headers)
             if response.status_code != 200:
                 print(f"[ERROR] API error: {response.status_code}")
                 return None
@@ -223,7 +237,7 @@ class CardEditorApp:
         return 4.5
 
     def save_and_next(self):
-        data = {k: v.get() if isinstance(v, (tk.Entry, tk.StringVar)) else v.get() for k, v in self.entries.items()}
+        data = {k: v.get() for k, v in self.entries.items()}
         key = f"{data['nazwa']}|{data['numer']}|{data['set']}"
         self.card_counts[key] += 1
         data['ilość'] = self.card_counts[key]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Pillow
+requests
+python-dotenv


### PR DESCRIPTION
## Summary
- load API credentials from a `.env` file using `python-dotenv`
- simplify saving entry data
- add README with setup instructions
- add requirements.txt with runtime dependencies
- replace example `.env`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686bcbb08d10832f8e4e31638ab5dbbb