### PR TITLE
Show full names for English sets

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ PRICE_DB_PATH = "card_prices.csv"
 
 # Wczytanie danych setów
 with open("tcg_sets.json", encoding="utf-8") as f:
-    tcg_sets_eng = list(json.load(f).values())
+    tcg_sets_eng = list(json.load(f).keys())
 
 with open("tcg_sets_jp.json", encoding="utf-8") as f:
     tcg_sets_jp = list(json.load(f).keys())


### PR DESCRIPTION
## Summary
- display the full English TCG set names in the dropdown

## Testing
- `python -m py_compile main.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686c27a9f134832f91631375c2a9a546