### PR TITLE
Add rarity checkboxes and set autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 - Load images from a folder and review them one by one
 - Fetch card prices from a local database (`card_prices.csv`)
 - Save collected data to a CSV file
+- Autocomplete set selection and additional rarity checkboxes
 
 ## Requirements
 Install dependencies from `requirements.txt`:


### PR DESCRIPTION
## Summary
- add rarity checkboxes to the editor
- enable autocomplete suggestions for set selection
- document new features in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686c347cadb4832f976f81d4e9dd2703