### PR TITLE
Remove API key placeholder

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-RAPIDAPI_KEY=c6f8dff191mshe22c98cfa3266b2p14b79cjsn8c3969eca4f2
+RAPIDAPI_KEY=
 RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com

--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ pip install -r requirements.txt
 
 Ensure a `card_prices.csv` file with columns `name`, `number`, `set` and `price` exists in the project directory.
 
+Create a `.env` file with your RapidAPI credentials:
+
+```bash
+RAPIDAPI_KEY=your-key-here
+RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
+```
+
 
 ## Running
 Execute the main script with Python 3:


### PR DESCRIPTION
## Summary
- strip personal key from `.env`
- document required `.env` variables in README

## Testing
- `python -m py_compile main.py`
- `pytest -q`
- `python main.py` *(fails: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_686cb89c7f40832f9bd49489988257d8