### PR TITLE
Fix CSV name field

### DIFF
--- a/main.py
+++ b/main.py
@@ -443,11 +443,18 @@ class CardEditorApp:
             writer = csv.DictWriter(file, fieldnames=fieldnames, delimiter=";")
             writer.writeheader()
             for row in combined.values():
+                suffix = row.get("suffix", "").strip()
+                name_parts = [row["nazwa"]]
+                if suffix:
+                    name_parts.append(suffix)
+                name_parts.append(row["numer"])
+                formatted_name = " ".join(name_parts)
+
                 writer.writerow(
                     {
                         "product_code": row["product_code"],
                         "active": row["active"],
-                        "name": f"{row['nazwa']} {row['numer']} {row['set']}",
+                        "name": formatted_name,
                         "price": row["cena"],
                         "vat": row["vat"],
                         "unit": row["unit"],


### PR DESCRIPTION
## Summary
- build formatted card name from card, suffix and number
- omit the card set from the name field when exporting to CSV

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686e3ee65564832f96dc997847c39c67