### PR TITLE
Improve set filtering

### DIFF
--- a/main.py
+++ b/main.py
@@ -138,6 +138,7 @@ class CardEditorApp:
         else:
             filtered = all_sets
         self.set_dropdown['values'] = sorted(filtered)
+        self.set_dropdown.event_generate("<Down>")
 
     def load_images(self):
         folder = filedialog.askdirectory()


### PR DESCRIPTION
## Summary
- show set dropdown as soon as filtering happens

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686e43c351f8832f98f58e2f3d8bc6b2