### PR TITLE
Add API fallback for card prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 ## Features
 - Load images from a folder and review them one by one
 - Fetch card prices from a local database (`card_prices.csv`)
+- Automatically query the TCGGO API when a price is missing
 - Save collected data to a CSV file
 - Autocomplete set selection and additional rarity checkboxes
 
@@ -24,6 +25,10 @@ RAPIDAPI_KEY=your-key-here
 RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
 ```
 
+These credentials are used when a card price is not found in the local
+database. A valid `RAPIDAPI_KEY` allows the application to query the API
+and fill in the missing price automatically.
+
 
 ## Running
 Execute the main script with Python 3:
@@ -32,4 +37,5 @@ Execute the main script with Python 3:
 python main.py
 ```
 
-The interface will allow you to load scans, fetch prices from the local database and export results to CSV.
+The interface will allow you to load scans, fetch prices from the local database
+or the API, and export results to CSV.

--- a/main.py
+++ b/main.py
@@ -310,11 +310,19 @@ class CardEditorApp:
         set_name = self.entries['set'].get()
 
         cena = self.get_price_from_db(name, number, set_name)
-        if cena:
+        if cena is not None:
             self.entries['cena'].delete(0, tk.END)
             self.entries['cena'].insert(0, str(cena))
         else:
-            messagebox.showinfo("Brak wyników", "Nie znaleziono ceny dla podanej karty w bazie danych.")
+            fetched = self.fetch_card_price(name, number, set_name)
+            if fetched is not None:
+                self.entries['cena'].delete(0, tk.END)
+                self.entries['cena'].insert(0, str(fetched))
+            else:
+                messagebox.showinfo(
+                    "Brak wyników",
+                    "Nie znaleziono ceny dla podanej karty w bazie danych.",
+                )
 
 
     def get_exchange_rate(self):
@@ -398,10 +406,14 @@ class CardEditorApp:
 
         # Automatyczne pobranie ceny z bazy
         cena_local = self.get_price_from_db(data['nazwa'], data['numer'], data['set'])
-        if cena_local:
+        if cena_local is not None:
             data["cena"] = str(cena_local)
         else:
-            data["cena"] = ""
+            fetched = self.fetch_card_price(data['nazwa'], data['numer'], data['set'])
+            if fetched is not None:
+                data["cena"] = str(fetched)
+            else:
+                data["cena"] = ""
 
         self.output_data.append(data)
         self.index += 1


### PR DESCRIPTION
## Summary
- fetch card price from API when local db is missing
- do the same when saving entries
- document API fallback in README

## Testing
- `python -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4ae41234832fb88454594ed2d5f3