### PR TITLE
Fix API endpoint and add .gitignore

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-RAPIDAPI_KEY=
-RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.env
+card_prices.csv
+ceny_kart_*.xlsx
+name

--- a/card_prices.csv
+++ b/card_prices.csv
@@ -1,3 +1,0 @@
-name,number,set,price
-Pikachu,25,Base Set,10.0
-Charizard,4,Base Set,50.0

--- a/main.py
+++ b/main.py
@@ -249,17 +249,20 @@ class CardEditorApp:
         set_input = set_name.strip().lower()
 
         try:
-            url = "https://www.tcggo.com/api/cards/"
-            params = {
-                "name": name_input,
-                "number": number_input,
-                "set": set_input,
-            }
             headers = {}
             if RAPIDAPI_KEY and RAPIDAPI_HOST:
+                url = f"https://{RAPIDAPI_HOST}/cards/search"
+                params = {"search": name_input}
                 headers = {
                     "X-RapidAPI-Key": RAPIDAPI_KEY,
                     "X-RapidAPI-Host": RAPIDAPI_HOST,
+                }
+            else:
+                url = "https://www.tcggo.com/api/cards/"
+                params = {
+                    "name": name_input,
+                    "number": number_input,
+                    "set": set_input,
                 }
             response = requests.get(url, params=params, headers=headers)
             if response.status_code != 200:

--- a/name
+++ b/name
@@ -1,1 +1,0 @@
-kartoteka


### PR DESCRIPTION
## Summary
- change TCG price lookup to use the RapidAPI host if configured
- add `.gitignore` for common local files
- drop accidental files from version control

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686e494bb574832f93e5f709289d964a