### PR TITLE
Update ttkbootstrap requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Install dependencies from `requirements.txt`:
 pip install -r requirements.txt
 ```
 
+The application uses built-in icons available starting from `ttkbootstrap` 1.10,
+so ensure a recent version is installed.
+
 Ensure a `card_prices.csv` file with columns `name`, `number`, `set` and `price` exists in the project directory.
 
 Create a `.env` file with your RapidAPI credentials:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Pillow
 requests
 python-dotenv
-ttkbootstrap
+ttkbootstrap>=1.10


### PR DESCRIPTION
## Summary
- require `ttkbootstrap>=1.10` so Icon.load is available
- note in README that a recent ttkbootstrap is needed for built-in icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f53786eb4832fa990e0459ff06b49