### PR TITLE
Focus name field after loading card

### DIFF
--- a/main.py
+++ b/main.py
@@ -248,6 +248,9 @@ class CardEditorApp:
         for var in self.rarity_vars.values():
             var.set(False)
 
+        # focus the name entry so the user can start typing immediately
+        self.entries["nazwa"].focus_set()
+
     def generate_location(self, idx):
         pos = idx % 1000 + 1
         row = (idx // 1000) % 4 + 1


### PR DESCRIPTION
## Summary
- ensure the name entry is focused when a card is displayed

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686f76578940832f894e71bffd12ad74