### PR TITLE
Fix API price rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 - Load images from a folder and review them one by one
 - Fetch card prices from a local database (`card_prices.csv`)
 - Automatically query the TCGGO API when a price is missing
-- Convert API prices from EUR to PLN using a 1.23 multiplier
+- Convert API prices from EUR to PLN using a 1.23 multiplier rounded to two decimals
 - Save collected data to a CSV file
 - Autocomplete set selection (press <kbd>Tab</kbd> to accept a suggestion) and additional rarity checkboxes
 

--- a/main.py
+++ b/main.py
@@ -442,7 +442,7 @@ class CardEditorApp:
                 price_eur = best.get("prices", {}).get("cardmarket", {}).get("30d_average", 0)
                 if price_eur:
                     eur_pln = self.get_exchange_rate()
-                    price_pln = round(float(price_eur) * eur_pln * PRICE_MULTIPLIER)
+                    price_pln = round(float(price_eur) * eur_pln * PRICE_MULTIPLIER, 2)
                     print(f"[INFO] Cena {best.get('name')} ({number_input}, {set_input}) = {price_pln} PLN")
                     return price_pln
 


### PR DESCRIPTION
## Summary
- keep two decimal places when converting API prices
- clarify README about rounding

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686f8c623cf8832f9935d60562373cb4