### PR TITLE
Add variant selection and updated price logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 - Load images from a folder and review them one by one
 - Fetch card prices from a local database (`card_prices.csv`)
 - Automatically query the TCGGO API when a price is missing
-- Optionally fetch prices for reverse or holo variants
+- Prices for "Holo" or "Reverse" variants are calculated by multiplying the
+  base price by **3.5**
+- View alternative API results via the **Inne warianty** button
 - Convert API prices from EUR to PLN using a 1.23 multiplier rounded to two decimals
 - Save collected data to a CSV file
 - Autocomplete set selection (press <kbd>Tab</kbd> to accept a suggestion) and additional rarity checkboxes


### PR DESCRIPTION
## Summary
- show variants in a new window and allow price selection
- multiply holo or reverse prices by 3.5
- adjust window size to 1500x900
- document new behaviour in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686faabd7990832fbcc20e585d010e8f