### PR TITLE
Fix pricing UI window size

### DIFF
--- a/main.py
+++ b/main.py
@@ -148,6 +148,7 @@ class CardEditorApp:
         if getattr(self, "pricing_frame", None):
             self.pricing_frame.destroy()
         self.root.geometry("800x600")
+        self.root.resizable(False, False)
         self.pricing_frame = tk.Frame(self.root)
         self.pricing_frame.pack(expand=True, fill="both", padx=10, pady=10)
 


### PR DESCRIPTION
## Summary
- prevent resizing when using the pricing UI

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68726b833cd4832fbc8c98e66b012b7a