### PR TITLE
Add reverse toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 - Convert API prices from EUR to PLN using a 1.23 multiplier rounded to two decimals
 - Save collected data to a CSV file
 - Autocomplete set selection (press <kbd>Tab</kbd> to accept a suggestion) and additional rarity checkboxes
+- Toggle the **Reverse** switch on the pricing screen when pricing a reverse card
 
 ## Requirements
 Install dependencies from `requirements.txt`:

--- a/main.py
+++ b/main.py
@@ -170,8 +170,11 @@ class CardEditorApp:
         ).grid(row=0, column=2, sticky="w")
 
         self.price_reverse_var = tk.BooleanVar()
-        tk.Checkbutton(
-            self.pricing_frame, text="Reverse", variable=self.price_reverse_var
+        ttk.Checkbutton(
+            self.pricing_frame,
+            text="Reverse",
+            variable=self.price_reverse_var,
+            bootstyle="round-toggle",
         ).grid(row=1, column=2, sticky="w")
 
         ttk.Button(


### PR DESCRIPTION
## Summary
- use a round toggle for the Reverse option on the pricing screen
- document the new toggle feature

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68727c049330832fb9fa195fc57df5be