### PR TITLE
Implement card data cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ python main.py
 
 The interface will allow you to load scans, fetch prices from the local database
 or the API, and export results to CSV.
+
+### Cache
+Every time you press **Zapisz i dalej**, the entered values are stored in a
+temporary cache under a key composed of `name|number|set`. When another scan of
+the same card is loaded, the application pre-fills the form with the cached
+data so you do not need to type them again.


### PR DESCRIPTION
## Summary
- keep previously entered card data in a `card_cache`
- reuse cached values when a matching scan is loaded
- document cache mechanism in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6874a56f0dc0832fbf45b0872fbcae78