### PR TITLE
Fix missing image in pricing search

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 - Load images from a folder and review them one by one
 - Fetch card prices from a local database (`card_prices.csv`)
 - Automatically query the TCGGO API when a price is missing
+- Display card images when available, falling back to `image`,
+  `imageUrl` or `image_url` if `images.large` is not provided
 - Prices for "Holo" or "Reverse" variants are calculated by multiplying the
   base price by **3.5**
 - View alternative API results via the **Inne warianty** button

--- a/main.py
+++ b/main.py
@@ -834,8 +834,14 @@ class CardEditorApp:
                         or images.get("logo_url")
                         or set_info.get("logo")
                     )
+                    image_url = (
+                        card.get("images", {}).get("large")
+                        or card.get("image")
+                        or card.get("imageUrl")
+                        or card.get("image_url")
+                    )
                     return {
-                        "image_url": card.get("images", {}).get("large"),
+                        "image_url": image_url,
                         "set_logo_url": set_logo,
                         "price_eur": round(float(price_eur), 2),
                         "eur_pln_rate": round(base_rate, 4),


### PR DESCRIPTION
## Summary
- handle more possible card image fields when fetching pricing info
- document image retrieval fallback in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6874bb99c448832f9ee7499bf819ffae