### PR TITLE
Handle Shoper REST path automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ SHOPER_API_TOKEN=your-token
 
 The `RAPIDAPI_*` variables are used when a card price is not found in the local
 database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper
-store for the **Porządkuj** window. Ensure that `SHOPER_API_URL` includes the
-`/webapi/rest` prefix, as required by the official Shoper documentation.
+store for the **Porządkuj** window. The application expects the `/webapi/rest`
+endpoint and will append it automatically if it is missing.
 
 
 ## Running

--- a/main.py
+++ b/main.py
@@ -162,6 +162,21 @@ class CardEditorApp:
         if not self.shoper_client:
             messagebox.showerror("Błąd", "Brak konfiguracji Shoper API")
             return
+        # Quick connection test to provide clearer error messages
+        try:
+            self.shoper_client.list_scans()
+        except Exception as exc:
+            msg = str(exc)
+            if "404" in msg:
+                messagebox.showerror(
+                    "Błąd",
+                    "Nie znaleziono endpointu Shoper API (brak '/webapi/rest'?)",
+                )
+            else:
+                messagebox.showerror(
+                    "Błąd", f"Połączenie z Shoper API nie powiodło się: {msg}"
+                )
+            return
         if self.start_frame is not None:
             self.start_frame.destroy()
             self.start_frame = None

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -7,6 +7,9 @@ class ShoperClient:
 
     def __init__(self, base_url=None, token=None):
         self.base_url = (base_url or os.getenv("SHOPER_API_URL", "")).rstrip("/")
+        # Ensure the URL points to the REST endpoint
+        if self.base_url and not self.base_url.endswith("/webapi/rest"):
+            self.base_url = f"{self.base_url}/webapi/rest"
         self.token = token or os.getenv("SHOPER_API_TOKEN")
         if not self.base_url or not self.token:
             raise ValueError("SHOPER_API_URL or SHOPER_API_TOKEN not set")


### PR DESCRIPTION
## Summary
- append `/webapi/rest` automatically when creating `ShoperClient`
- check connection when opening the Shoper window and show a clearer error
- update README to reflect automatic REST path handling

## Testing
- `python -m py_compile main.py shoper_client.py download_set_logos.py`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687612e10024832fa7aa25b067052fde