### PR TITLE
Add Shoper search and order view

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ the same card is loaded, the application pre-fills the form with the cached
 data so you do not need to type them again.
 
 ### Shoper integration
-Use the **Porządkuj** button to open a window with basic actions against your
-Shoper store. You can list uploaded scans, send product data and check current
-inventory. Make sure the Shoper credentials are set in `.env` before launching
-the application.
+Use the **Porządkuj** button to open a window with actions against your Shoper
+store. The interface now lets you search products with sorting options and view
+new orders. Each order item is matched with the generated `product_code` so you
+can quickly locate it in storage. Make sure the Shoper credentials are set in
+`.env` before launching the application.

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -44,3 +44,23 @@ class ShoperClient:
 
     def get_inventory(self):
         return self.get("products")
+
+    def search_products(self, filters=None, sort=None, page=1, per_page=50):
+        """Search products with optional filters and sorting."""
+        params = {"page": page, "per-page": per_page}
+        if filters:
+            params.update(filters)
+        if sort:
+            params["sort"] = sort
+        return self.get("products", params=params)
+
+    def list_orders(self, filters=None, page=1, per_page=20):
+        """Return a list of orders filtered by status or other fields."""
+        params = {"page": page, "per-page": per_page}
+        if filters:
+            params.update(filters)
+        return self.get("orders", params=params)
+
+    def get_order(self, order_id):
+        """Retrieve a single order by id."""
+        return self.get(f"orders/{order_id}")


### PR DESCRIPTION
## Summary
- implement search and orders helpers in `ShoperClient`
- extend the Shoper window with product search fields and order display
- show storage location hints based on `product_code`
- document the new Shoper features in README

## Testing
- `python -m py_compile main.py shoper_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6876139dc884832f8ffbd4a95518d09b