### PR TITLE
Add CSV import merging duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 - Save collected data to a CSV file
 - Autocomplete set selection (press <kbd>Tab</kbd> to accept a suggestion) and additional rarity checkboxes
 - Toggle the **Reverse** switch on the pricing screen when pricing a reverse card
+- Import CSV files and merge duplicates automatically
 
 ## Requirements
 Install dependencies from `requirements.txt`:
@@ -52,6 +53,12 @@ python main.py
 
 The interface will allow you to load scans, fetch prices from the local database
 or the API, and export results to CSV.
+
+### Importing CSV files
+Use the **Import CSV** button on the welcome screen to merge an existing CSV
+file. Rows that share the `nazwa`, `numer` and `set` columns are combined and
+their quantity summed. If the file lacks a `stock` column, the merged output adds
+an `ilość` column with the calculated totals.
 
 ### Cache
 Every time you press **Zapisz i dalej**, the entered values are stored in a


### PR DESCRIPTION
## Summary
- add `load_csv_data` method that merges duplicates when importing CSV
- hook the new method from the welcome screen as **Import CSV** button
- document the new capability in README

## Testing
- `python -m py_compile main.py shoper_client.py`

------
https://chatgpt.com/codex/tasks/task_e_6876433c9784832f91950d59c124326b