### PR TITLE
Add Shoper dashboard stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,12 @@ sorting options and view new orders. Each order item is matched with the
 generated `product_code` so you can quickly locate it in storage. Make sure the
 Shoper credentials are set in `.env` before launching the application.
 
+### Dashboard
+The welcome screen displays a small dashboard with store statistics fetched from
+your Shoper account: counts of new orders, pending shipments or payments and
+recent sales totals. To populate these fields the token must have permissions to
+read orders and statistics. Use the **Pokaż szczegóły** button to open the Shoper
+window with full functionality.
+
 ## License
 This project is licensed under the terms of the [MIT License](LICENSE).

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -61,3 +61,17 @@ class ShoperClient:
     def get_order(self, order_id):
         """Retrieve a single order by id."""
         return self.get(f"orders/{order_id}")
+
+    # New helper methods for dashboard statistics
+    def get_orders(self, status=None, filters=None, page=1, per_page=20):
+        """Return orders optionally filtered by status and other criteria."""
+        params = {"page": page, "per-page": per_page}
+        if filters:
+            params.update(filters)
+        if status:
+            params["filters[status]"] = status
+        return self.get("orders", params=params)
+
+    def get_sales_stats(self, params=None):
+        """Return sales statistics using the built-in Shoper endpoint."""
+        return self.get("orders/stats", params=params or {})


### PR DESCRIPTION
## Summary
- add helper methods in `ShoperClient`
- show store statistics on the welcome screen
- provide new `load_store_stats` method
- document dashboard functionality

## Testing
- `python -m py_compile main.py shoper_client.py`

------
https://chatgpt.com/codex/tasks/task_e_687752adeff8832f93d18dfd1a4398fe