### PR TITLE
Add Tooltip utility for dashboard cards

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from dotenv import load_dotenv
 
 from shoper_client import ShoperClient
+from tooltip import Tooltip
 import webbrowser
 from urllib.parse import urlencode
 import io
@@ -255,28 +256,6 @@ class CardEditorApp:
             bootstyle="secondary",
         )
 
-    def show_tooltip(self, widget, text: str):
-        """Display a small tooltip near the given widget."""
-        if hasattr(self, "_tooltip") and self._tooltip:
-            self._tooltip.destroy()
-        x = widget.winfo_rootx() + 10
-        y = widget.winfo_rooty() + widget.winfo_height() + 10
-        self._tooltip = tk.Toplevel(widget)
-        self._tooltip.wm_overrideredirect(True)
-        tk.Label(
-            self._tooltip,
-            text=text,
-            background="lightyellow",
-            relief="solid",
-            borderwidth=1,
-            font=("Helvetica", 10),
-        ).pack()
-        self._tooltip.wm_geometry(f"+{x}+{y}")
-
-    def hide_tooltip(self, *_):
-        if hasattr(self, "_tooltip") and self._tooltip:
-            self._tooltip.destroy()
-            self._tooltip = None
 
     def create_stat_card(self, parent, title, value, icon, color, info, progress=None):
         """Create a small dashboard card with optional tooltip and progress bar."""
@@ -291,8 +270,7 @@ class CardEditorApp:
             bar["value"] = max(0, min(100, progress * 100))
             bar.pack(fill="x", padx=5, pady=(0, 5))
         for w in (frame,) + tuple(frame.winfo_children()):
-            w.bind("<Enter>", lambda e, f=frame, t=info: self.show_tooltip(f, t))
-            w.bind("<Leave>", self.hide_tooltip)
+            Tooltip(w, info)
         return frame
 
     def load_store_stats(self):

--- a/tooltip.py
+++ b/tooltip.py
@@ -1,0 +1,33 @@
+import tkinter as tk
+
+class Tooltip:
+    """Display a tooltip for a given widget."""
+
+    def __init__(self, widget, text: str):
+        self.widget = widget
+        self.text = text
+        self.tipwindow = None
+        widget.bind("<Enter>", self.show)
+        widget.bind("<Leave>", self.hide)
+
+    def show(self, event=None):
+        if self.tipwindow or not self.text:
+            return
+        x = self.widget.winfo_rootx() + 10
+        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 10
+        self.tipwindow = tw = tk.Toplevel(self.widget)
+        tw.wm_overrideredirect(True)
+        tk.Label(
+            tw,
+            text=self.text,
+            background="lightyellow",
+            relief="solid",
+            borderwidth=1,
+            font=("Helvetica", 10),
+        ).pack()
+        tw.wm_geometry("+%d+%d" % (x, y))
+
+    def hide(self, event=None):
+        if self.tipwindow:
+            self.tipwindow.destroy()
+            self.tipwindow = None


### PR DESCRIPTION
## Summary
- create a simple `Tooltip` utility
- use `Tooltip` in `create_stat_card`
- remove obsolete tooltip methods

## Testing
- `python -m py_compile main.py tooltip.py`

------
https://chatgpt.com/codex/tasks/task_e_687762088e2c832f9686dbd5fc175f1e