### PR TITLE
Fix UI progress label placement

### DIFF
--- a/main.py
+++ b/main.py
@@ -776,7 +776,7 @@ class CardEditorApp:
         self.image_label.grid(row=2, column=0, rowspan=12, sticky="nsew")
         # Display only a textual progress indicator below the card image
         self.progress_label = ttk.Label(self.frame, textvariable=self.progress_var)
-        self.progress_label.grid(row=13, column=0, pady=5, sticky="ew")
+        self.progress_label.grid(row=14, column=0, pady=5, sticky="ew")
 
         # Container for card information fields
         self.info_frame = ttk.LabelFrame(self.frame, text="Informacje o karcie")


### PR DESCRIPTION
## Summary
- move the progress indicator to row 14 to stay below the image
- retain the image area spanning rows 2-13

## Testing
- `pytest -q`
- `timeout 5 xvfb-run -a python main.py` (manual UI check)

------
https://chatgpt.com/codex/tasks/task_e_6877744612dc832f8aa46347b0b5cc75