### PR TITLE
Change customtkinter theme to dark

### DIFF
--- a/main.py
+++ b/main.py
@@ -1864,7 +1864,7 @@ class CardEditorApp:
 
 if __name__ == "__main__":
     root = ctk.CTk()
-    ctk.set_appearance_mode("System")
+    ctk.set_appearance_mode("dark")
     ctk.set_default_color_theme("blue")
     app = CardEditorApp(root)
     root.mainloop()


### PR DESCRIPTION
## Summary
- default the CustomTkinter UI theme to dark mode

## Testing
- `pip install -r requirements.txt`
- `python3 main.py` *(fails: `_tkinter.TclError: no display name and no $DISPLAY environment variable`)*

------
https://chatgpt.com/codex/tasks/task_e_6877932ee2ec832fa754e54aea973559