### PR TITLE
Fix set dropdown option handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -1183,9 +1183,9 @@ class CardEditorApp:
     def update_set_options(self, event=None):
         lang = self.lang_var.get().strip().upper()
         if lang == "JP":
-            self.set_dropdown["values"] = sorted(tcg_sets_jp)
+            self.set_dropdown.configure(values=sorted(tcg_sets_jp))
         else:
-            self.set_dropdown["values"] = sorted(tcg_sets_eng)
+            self.set_dropdown.configure(values=sorted(tcg_sets_eng))
 
     def filter_sets(self, event=None):
         typed = self.set_var.get().lower()
@@ -1195,7 +1195,7 @@ class CardEditorApp:
             filtered = [s for s in all_sets if typed in s.lower()]
         else:
             filtered = all_sets
-        self.set_dropdown["values"] = sorted(filtered)
+        self.set_dropdown.configure(values=sorted(filtered))
 
     def autocomplete_set(self, event=None):
         typed = self.set_var.get().lower()


### PR DESCRIPTION
## Summary
- use `configure(values=...)` when updating the set dropdown
- update filtering logic accordingly

## Testing
- `python -m py_compile main.py`
- `xvfb-run -a python - <<'EOF'
import customtkinter as ctk, main
root = ctk.CTk(); root.withdraw(); app = main.CardEditorApp(root); app.setup_editor_ui(); print('values count:', len(app.set_dropdown.cget('values'))); root.destroy()
EOF`
- `xvfb-run -a python - <<'EOF'
import customtkinter as ctk, main
root = ctk.CTk(); root.withdraw(); app = main.CardEditorApp(root); app.setup_editor_ui(); app.set_var.set('An'); event=type('event',(),{'widget':app.set_dropdown})(); app.autocomplete_set(event); print('result:', app.set_var.get()); root.destroy()
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68791074d060832fae988635a53e1635