### PR TITLE
Fix logo download script to use symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ or the API, and export results to CSV.
 
 ### Cheatsheet
 Press the **Ściąga** button on the editor window to open a scrollable cheat sheet
-with the names and codes of all card sets. When set logos are available they are
-displayed alongside the entries.
+with the names and codes of all card sets. When set symbols are available they
+are displayed alongside the entries.
 
-To fetch the logos run:
+To fetch the symbols run:
 
 ```bash
 python download_set_logos.py

--- a/download_set_logos.py
+++ b/download_set_logos.py
@@ -24,20 +24,24 @@ for file in SET_FILES:
                 continue
             data = res.json().get("data", res.json())
             images = data.get("images") or {}
-            logo_url = images.get("logo") or images.get("logoUrl") or images.get("logo_url")
-            if not logo_url:
-                print(f"[WARN] No logo for {name}")
+            symbol_url = (
+                images.get("symbol")
+                or images.get("symbolUrl")
+                or images.get("symbol_url")
+            )
+            if not symbol_url:
+                print(f"[WARN] No symbol for {name}")
                 continue
-            img_res = requests.get(logo_url, timeout=10)
+            img_res = requests.get(symbol_url, timeout=10)
             if img_res.status_code == 200:
-                ext = os.path.splitext(logo_url)[1] or ".png"
+                ext = os.path.splitext(symbol_url)[1] or ".png"
                 safe_name = code.replace("/", "_")
                 path = os.path.join(LOGO_DIR, f"{safe_name}{ext}")
                 with open(path, "wb") as out:
                     out.write(img_res.content)
                 print(f"Saved {path}")
             else:
-                print(f"[ERROR] Failed to download logo for {name}")
+                print(f"[ERROR] Failed to download symbol for {name}")
         except requests.RequestException as e:
             print(f"[ERROR] {name}: {e}")
 


### PR DESCRIPTION
## Summary
- fetch set symbols instead of logos in `download_set_logos.py`
- update README to reference set symbols

## Testing
- `python -m py_compile download_set_logos.py main.py shoper_client.py tooltip.py`


------
https://chatgpt.com/codex/tasks/task_e_687a312710d4832f8a51835a1df1a569