### PR TITLE
Improve CSV import handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ the cheatsheet can load the images.
 ### Importing CSV files
 Use the **Import CSV** button on the welcome screen to merge an existing CSV
 file. Rows that share the `nazwa`, `numer` and `set` columns are combined and
-their quantity summed. If the file lacks a `stock` column, the merged output adds
-an `ilość` column with the calculated totals.
+their quantity summed. The importer recognises quantity columns named
+`stock`, `ilość`, `ilosc`, `quantity` or `qty` (case and spacing are ignored).
+If no such column is found, the merged output adds an `ilość` column with the
+calculated totals.
 
 ### Cache
 Every time you press **Zapisz i dalej**, the entered values are stored in a


### PR DESCRIPTION
## Summary
- normalize header names in `load_csv_data`
- detect `quantity` and `qty` columns when merging CSVs
- document supported quantity column names

## Testing
- `python -m py_compile main.py shoper_client.py download_set_logos.py tooltip.py`

------
https://chatgpt.com/codex/tasks/task_e_687a353c2280832fb5bd0a467082663c