### PR TITLE
Improve error logs when downloading set logos

### DIFF
--- a/download_set_logos.py
+++ b/download_set_logos.py
@@ -41,7 +41,12 @@ for file in SET_FILES:
                     out.write(img_res.content)
                 print(f"Saved {path}")
             else:
-                print(f"[ERROR] Failed to download symbol for {name}")
+                if img_res.status_code == 404:
+                    print(f"[WARN] Symbol not found for {name}: {symbol_url}")
+                else:
+                    print(
+                        f"[ERROR] Failed to download symbol for {name} from {symbol_url}: {img_res.status_code}"
+                    )
         except requests.RequestException as e:
             print(f"[ERROR] {name}: {e}")
 


### PR DESCRIPTION
## Summary
- add more details when failing to download set logo symbols
- warn when symbol URL returns 404

## Testing
- `python -m py_compile download_set_logos.py`


------
https://chatgpt.com/codex/tasks/task_e_687bda6ac860832f8a21b0705070c060