### PR TITLE
Fix JSON parsing in download_set_logos

### DIFF
--- a/download_set_logos.py
+++ b/download_set_logos.py
@@ -22,7 +22,8 @@ for file in SET_FILES:
             if res.status_code != 200:
                 print(f"[ERROR] Failed to fetch {name}: {res.status_code}")
                 continue
-            data = res.json().get("data", res.json())
+            json_data = res.json()
+            data = json_data.get("data", json_data)
             images = data.get("images") or {}
             symbol_url = (
                 images.get("symbol")


### PR DESCRIPTION
## Summary
- avoid calling `res.json()` multiple times in `download_set_logos.py`

## Testing
- `python -m py_compile download_set_logos.py`


------
https://chatgpt.com/codex/tasks/task_e_687be276356c832f9b3ee69fd96ff5db