### PR TITLE
Optimize set update

### DIFF
--- a/main.py
+++ b/main.py
@@ -1512,6 +1512,7 @@ class CardEditorApp:
 
     def show_loading_screen(self):
         """Display a temporary loading screen during startup."""
+        self.root.minsize(1000, 700)
         self.loading_frame = ctk.CTkFrame(self.root, fg_color=BG_COLOR)
         self.loading_frame.pack(expand=True, fill="both")
         logo_path = os.path.join(os.path.dirname(__file__), "logo.png")
@@ -1533,6 +1534,41 @@ class CardEditorApp:
         self.loading_label.pack(pady=10)
         self.root.update()
 
+    def download_set_symbols(self, sets):
+        """Download logos for the provided set definitions."""
+        os.makedirs(SET_LOGO_DIR, exist_ok=True)
+        for item in sets:
+            name = item.get("name")
+            code = item.get("code")
+            if not code:
+                continue
+            symbol_url = f"https://images.pokemontcg.io/{code}/symbol.png"
+            try:
+                res = requests.get(symbol_url, timeout=10)
+                if res.status_code == 404:
+                    alt = re.sub(r"(^sv)0(\d$)", r"\1\2", code)
+                    if alt != code:
+                        alt_url = f"https://images.pokemontcg.io/{alt}/symbol.png"
+                        res = requests.get(alt_url, timeout=10)
+                        if res.status_code == 200:
+                            symbol_url = alt_url
+                if res.status_code == 200:
+                    parsed_path = urlparse(symbol_url).path
+                    ext = os.path.splitext(parsed_path)[1] or ".png"
+                    safe = code.replace("/", "_")
+                    path = os.path.join(SET_LOGO_DIR, f"{safe}{ext}")
+                    with open(path, "wb") as fh:
+                        fh.write(res.content)
+                else:
+                    if res.status_code == 404:
+                        print(f"[WARN] Symbol not found for {name}: {symbol_url}")
+                    else:
+                        print(
+                            f"[ERROR] Failed to download symbol for {name} from {symbol_url}: {res.status_code}"
+                        )
+            except requests.RequestException as exc:
+                print(f"[ERROR] {name}: {exc}")
+
     def update_sets(self):
         """Check remote API for new sets and update local files."""
         try:
@@ -1552,6 +1588,7 @@ class CardEditorApp:
             return
 
         added = 0
+        new_items = []
         for item in remote:
             series = item.get("series") or "Other"
             code = item.get("id")
@@ -1562,17 +1599,19 @@ class CardEditorApp:
             if not any(s.get("code") == code for s in group):
                 group.append({"name": name, "code": code})
                 added += 1
+                new_items.append({"name": name, "code": code})
 
         if added:
             with open("tcg_sets.json", "w", encoding="utf-8") as f:
                 json.dump(current_sets, f, indent=2, ensure_ascii=False)
             reload_sets()
-            self.loading_label.configure(text="Pobieram symbole setów...")
+            names = ", ".join(item["name"] for item in new_items)
+            self.loading_label.configure(
+                text=f"Pobieram symbole setów ({added})..."
+            )
             self.root.update()
-            try:
-                subprocess.run([sys.executable, "download_set_logos.py"], check=False)
-            except Exception:
-                pass
+            self.download_set_symbols(new_items)
+            print(f"[INFO] Dodano {added} setów: {names}")
 
     def log(self, message: str):
         if self.log_widget:


### PR DESCRIPTION
## Summary
- avoid resetting the window size when checking for updates
- download set logos only for new sets found
- keep track of new sets and display how many were added

## Testing
- `python -m py_compile main.py download_set_logos.py ftp_client.py shoper_client.py`

------
https://chatgpt.com/codex/tasks/task_e_687dece66f80832fbac537024fa13002