### PR TITLE
Fix missing import for urlparse

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ import sys
 from shoper_client import ShoperClient
 from ftp_client import FTPClient
 import webbrowser
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 import io
 
 load_dotenv()


### PR DESCRIPTION
## Summary
- fix missing `urlparse` import in `main.py`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687df0683ad4832fb85bb537bbe30b9e