### PR TITLE
Add warehouse code field

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,10 @@ data so you do not need to type them again.
 Use the **Porządkuj** button to open a window with actions against your Shoper
 store. The interface now lets you search products by name or card number, apply
 sorting options and view new orders. Each order item is matched with the
-generated `product_code` so you can quickly locate it in storage. Make sure the
-Shoper credentials are set in `.env` before launching the application.
+`warehouse_code` so you can quickly locate it in storage. Every card is assigned
+its own `warehouse_code` while the per-product `product_code` stays the same for
+duplicates. Make sure the Shoper credentials are set in `.env` before launching
+the application.
 
 ### Dashboard
 The welcome screen displays a small dashboard with store statistics fetched from


### PR DESCRIPTION
## Summary
- track unique warehouse codes per card
- keep a per-product mapping for `product_code`
- export/import CSV files with new `warehouse_code`
- include the new field when showing orders and computing storage stats

## Testing
- `python -m py_compile main.py ftp_client.py shoper_client.py`

------
https://chatgpt.com/codex/tasks/task_e_687e217d8518832fa334724147dda649