### PR TITLE
Handle images 1 column

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ file. Rows that share the `nazwa`, `numer` and `set` columns are combined and
 their quantity summed. The importer recognises quantity columns named
 `stock`, `ilość`, `ilosc`, `quantity` or `qty` (case and spacing are ignored).
 If no such column is found, the merged output adds an `ilość` column with the
-calculated totals.
+calculated totals. The exporter names the first image column `images 1` and the
+importer accepts both `image1` and `images 1` when loading existing files.
 
 ### Cache
 Every time you press **Zapisz i dalej**, the entered values are stored in a

--- a/main.py
+++ b/main.py
@@ -2178,10 +2178,16 @@ class CardEditorApp:
             reader = csv.DictReader(f, dialect=dialect)
 
             # Normalize header names for easier handling later on
-            fieldnames = [fn.strip().lower() for fn in reader.fieldnames or []]
+            def norm_header(name: str) -> str:
+                normalized = name.strip().lower()
+                if normalized == "images 1":
+                    return "image1"
+                return normalized
+
+            fieldnames = [norm_header(fn) for fn in reader.fieldnames or []]
             rows = []
             for raw_row in reader:
-                row = { (k.strip().lower() if k else k): v for k, v in raw_row.items() }
+                row = { (norm_header(k) if k else k): v for k, v in raw_row.items() }
                 # Backwards compatibility: old files stored location in product_code
                 if "warehouse_code" not in row and re.match(r"k\d+r\d+p\d+", str(row.get("product_code", "")).lower()):
                     row["warehouse_code"] = row["product_code"]
@@ -2273,7 +2279,7 @@ class CardEditorApp:
             "description",
             "price",
             "availability",
-            "image1",
+            "images 1",
             "stock",
             "currency",
         ]
@@ -2300,7 +2306,7 @@ class CardEditorApp:
                         "description": row["description"],
                         "price": row["cena"],
                         "availability": row["availability"],
-                        "image1": row.get("image1", row.get("images", "")),
+                        "images 1": row.get("image1", row.get("images", "")),
                         "stock": row["stock"],
                         "currency": "zł",
                     }


### PR DESCRIPTION
## Summary
- export CSV with `images 1` header
- accept `images 1` as a synonym for `image1` when importing
- document new column name

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_687e246f4af4832fb6402978f56048f5