### PR TITLE
Handle multiple warehouse locations in import

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ their quantity summed. The importer recognises quantity columns named
 If no such column is found, the merged output adds an `ilość` column with the
 calculated totals. The exporter names the first image column `images 1` and the
 importer accepts both `image1` and `images 1` when loading existing files.
+All unique `warehouse_code` values from the merged rows are preserved and
+joined with semicolons so you can still locate every individual card after
+deduplication.
 
 ### Cache
 Every time you press **Zapisz i dalej**, the entered values are stored in a

--- a/main.py
+++ b/main.py
@@ -2219,11 +2219,18 @@ class CardEditorApp:
                 except ValueError:
                     qty = 1
 
+            warehouse = str(row.get("warehouse_code", "")).strip()
+
             if key in combined:
                 combined[key]["qty"] += qty
+                if warehouse:
+                    combined[key]["warehouses"].add(warehouse)
             else:
                 new_row = row.copy()
                 new_row["qty"] = qty
+                new_row["warehouses"] = set()
+                if warehouse:
+                    new_row["warehouses"].add(warehouse)
                 combined[key] = new_row
 
         if qty_field is None:
@@ -2243,6 +2250,7 @@ class CardEditorApp:
             for row in combined.values():
                 row_out = row.copy()
                 row_out[qty_field] = row_out.pop("qty")
+                row_out["warehouse_code"] = ";".join(sorted(row_out.pop("warehouses", [])))
                 if qty_field != "stock":
                     row_out.pop("stock", None)
                 if qty_field != "ilość":


### PR DESCRIPTION
## Summary
- preserve unique `warehouse_code` values when merging CSV rows
- output the collected codes joined by semicolons
- document the feature in the README

## Testing
- `python -m py_compile main.py`
- `python -m py_compile ftp_client.py shoper_client.py download_set_logos.py tooltip.py`


------
https://chatgpt.com/codex/tasks/task_e_687e25a698ac832f8017f99f05181877