### PR TITLE
Fix merging CSV product codes

### DIFF
--- a/main.py
+++ b/main.py
@@ -2191,6 +2191,7 @@ class CardEditorApp:
                 # Backwards compatibility: old files stored location in product_code
                 if "warehouse_code" not in row and re.match(r"k\d+r\d+p\d+", str(row.get("product_code", "")).lower()):
                     row["warehouse_code"] = row["product_code"]
+                    row["product_code"] = ""
                     if "warehouse_code" not in fieldnames:
                         fieldnames.append("warehouse_code")
                 rows.append(row)
@@ -2232,6 +2233,22 @@ class CardEditorApp:
                 if warehouse:
                     new_row["warehouses"].add(warehouse)
                 combined[key] = new_row
+
+        for row in combined.values():
+            map_key = (
+                f"{row.get('nazwa', '').strip()}|{row.get('numer', '').strip()}|{row.get('set', '').strip()}"
+            )
+            code_str = str(row.get("product_code", "")).strip()
+            if map_key not in self.product_code_map:
+                if code_str.isdigit():
+                    code_int = int(code_str)
+                    self.product_code_map[map_key] = code_int
+                    if code_int >= self.next_product_code:
+                        self.next_product_code = code_int + 1
+                else:
+                    self.product_code_map[map_key] = self.next_product_code
+                    self.next_product_code += 1
+            row["product_code"] = self.product_code_map[map_key]
 
         if qty_field is None:
             qty_field = "ilość"

--- a/tests/test_csv_import.py
+++ b/tests/test_csv_import.py
@@ -1,0 +1,41 @@
+import csv
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+import sys
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import main
+
+
+def run_load_csv(tmp_path, csv_content):
+    in_path = tmp_path / "in.csv"
+    out_path = tmp_path / "out.csv"
+    in_path.write_text(csv_content, encoding="utf-8")
+
+    dummy = SimpleNamespace(product_code_map={}, next_product_code=1)
+
+    with patch("tkinter.filedialog.askopenfilename", return_value=str(in_path)), \
+         patch("tkinter.filedialog.asksaveasfilename", return_value=str(out_path)), \
+         patch("tkinter.messagebox.showinfo"), \
+         patch("tkinter.messagebox.askyesno", return_value=False):
+        main.CardEditorApp.load_csv_data(dummy)
+
+    with open(out_path, newline="", encoding="utf-8") as f:
+        return list(csv.DictReader(f, delimiter=";")), dummy
+
+
+def test_old_csv_location_pattern(tmp_path):
+    rows, dummy = run_load_csv(
+        tmp_path,
+        "product_code;nazwa;numer;set;stock\n"
+        "K1R1P1;Pikachu;1;Base;1\n"
+        "K1R1P1;Pikachu;1;Base;1\n",
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["warehouse_code"] == "K1R1P1"
+    assert row["product_code"] == "1"
+    assert dummy.product_code_map == {"Pikachu|1|Base": 1}
+    assert dummy.next_product_code == 2


### PR DESCRIPTION
## Summary
- clear `product_code` when migrating old CSV warehouse codes
- assign sequential product codes when merging CSV rows
- test importing an old CSV that stores location in `product_code`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e2b80e1b8832f8a7d8ba2cec14234