### PR TITLE
Add customizable delivery id

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ RAPIDAPI_KEY=your-key-here
 RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
 SHOPER_API_URL=https://your-store.shop/webapi/rest
 SHOPER_API_TOKEN=your-token
+SHOPER_DELIVERY_ID=1
 ```
 
 The `RAPIDAPI_*` variables are used when a card price is not found in the local
 database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper
 store for the **Porządkuj** window. The application expects the `/webapi/rest`
-endpoint and will append it automatically if it is missing.
+endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID`
+sets the default shipping method id for exported CSV files.
 `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads.
 
 

--- a/main.py
+++ b/main.py
@@ -34,6 +34,7 @@ SHOPER_API_TOKEN = os.getenv("SHOPER_API_TOKEN")
 FTP_HOST = os.getenv("FTP_HOST")
 FTP_USER = os.getenv("FTP_USER")
 FTP_PASSWORD = os.getenv("FTP_PASSWORD")
+SHOPER_DELIVERY_ID = int(os.getenv("SHOPER_DELIVERY_ID", "1"))
 
 PRICE_DB_PATH = "card_prices.csv"
 PRICE_MULTIPLIER = 1.23
@@ -2111,7 +2112,7 @@ class CardEditorApp:
         data["description"] = f"<p>{desc_html}</p>"
         data["stock_warnlevel"] = 0
         data["availability"] = 1
-        data["delivery"] = 1
+        data["delivery"] = SHOPER_DELIVERY_ID
         data["views"] = ""
         data["rank"] = ""
         data["rank_votes"] = ""

--- a/tests/test_delivery_id.py
+++ b/tests/test_delivery_id.py
@@ -1,0 +1,50 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str((Path(__file__).resolve().parents[1])))
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+def test_delivery_id_used(monkeypatch):
+    monkeypatch.setenv("SHOPER_DELIVERY_ID", "7")
+    import main
+    importlib.reload(main)
+
+    dummy = SimpleNamespace(
+        entries={
+            "nazwa": DummyVar("Pikachu"),
+            "numer": DummyVar("1"),
+            "set": DummyVar("Base"),
+            "język": DummyVar("ENG"),
+            "stan": DummyVar("NM"),
+            "suffix": DummyVar(""),
+            "cena": DummyVar("")
+        },
+        type_vars={"Reverse": DummyVar(False), "Holo": DummyVar(False)},
+        rarity_vars={},
+        card_cache={},
+        cards=["/tmp/pika.jpg"],
+        index=0,
+        folder_name="folder",
+        file_to_key={},
+        product_code_map={},
+        next_product_code=1,
+        generate_location=lambda idx: "K1R1P1",
+        output_data=[None],
+        get_price_from_db=lambda *a: None,
+        fetch_card_price=lambda *a: None,
+    )
+
+    main.CardEditorApp.save_current_data(dummy)
+    assert dummy.output_data[0]["delivery"] == 7
+


### PR DESCRIPTION
## Summary
- read `SHOPER_DELIVERY_ID` from environment during startup
- use this value instead of a hard-coded delivery id
- document the new variable in README
- test that the value is respected when saving product data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e313c9a60832f98c2168e03f7fd6c