### PR TITLE
Update CSV format for Shoper export

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ file. Rows that share the `nazwa`, `numer` and `set` columns are combined and
 their quantity summed. The importer recognises quantity columns named
 `stock`, `ilość`, `ilosc`, `quantity` or `qty` (case and spacing are ignored).
 If no such column is found, the merged output adds an `ilość` column with the
-calculated totals. The exporter names the first image column `images 1` and the
-importer accepts both `image1` and `images 1` when loading existing files.
+calculated totals. The importer accepts both `image1` and the legacy `images 1`
+column when loading existing files.
 All unique `warehouse_code` values from the merged rows are preserved and
 joined with semicolons so you can still locate every individual card after
 deduplication.

--- a/main.py
+++ b/main.py
@@ -2297,17 +2297,25 @@ class CardEditorApp:
 
         fieldnames = [
             "product_code",
-            "warehouse_code",
+            "active",
+            "name",
+            "price",
+            "vat",
+            "unit",
             "category",
             "producer",
-            "name",
+            "other_price",
+            "pkwiu",
+            "weight",
+            "priority",
             "short_description",
             "description",
-            "price",
-            "availability",
-            "images 1",
             "stock",
-            "currency",
+            "stock_warnlevel",
+            "availability",
+            "views",
+            "rank",
+            "rank_votes",
         ]
 
         with open(file_path, mode="w", encoding="utf-8", newline="") as file:
@@ -2324,17 +2332,25 @@ class CardEditorApp:
                 writer.writerow(
                     {
                         "product_code": row["product_code"],
-                        "warehouse_code": row.get("warehouse_code", ""),
+                        "active": row.get("active", 1),
+                        "name": formatted_name,
+                        "price": row["cena"],
+                        "vat": row.get("vat", 23),
+                        "unit": row.get("unit", "szt"),
                         "category": row["category"],
                         "producer": row["producer"],
-                        "name": formatted_name,
+                        "other_price": row.get("other_price", ""),
+                        "pkwiu": row.get("pkwiu", ""),
+                        "weight": row.get("weight", 0.01),
+                        "priority": row.get("priority", 0),
                         "short_description": row["short_description"],
                         "description": row["description"],
-                        "price": row["cena"],
-                        "availability": row["availability"],
-                        "images 1": row.get("image1", row.get("images", "")),
                         "stock": row["stock"],
-                        "currency": "zł",
+                        "stock_warnlevel": row.get("stock_warnlevel", 0),
+                        "availability": row.get("availability", 1),
+                        "views": row.get("views", ""),
+                        "rank": row.get("rank", ""),
+                        "rank_votes": row.get("rank_votes", ""),
                     }
                 )
         messagebox.showinfo("Sukces", "Plik CSV został zapisany.")


### PR DESCRIPTION
## Summary
- adjust CSV export columns to new Shoper format
- clarify README about legacy `images 1` column

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e35b24274832f965c3d5b9971d7dd