### PR TITLE
Add images 1 column to CSV handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ window with full functionality.
 After exporting a CSV file the application prompts to send it directly to Shoper.
 When Shoper API credentials are configured the file is uploaded via the REST API.
 If not, the exporter falls back to FTP using the credentials from `.env`.
+The exported CSV includes an `images 1` column containing the path to the remote image.
 Use the **FTP Obrazy** button on the welcome screen to upload a folder of images
 to the configured FTP server.
 

--- a/main.py
+++ b/main.py
@@ -2265,6 +2265,11 @@ class CardEditorApp:
             if qty_field not in fieldnames:
                 fieldnames.append(qty_field)
 
+        if "image1" in fieldnames:
+            fieldnames[fieldnames.index("image1")] = "images 1"
+        elif "images 1" not in fieldnames:
+            fieldnames.append("images 1")
+
         save_path = filedialog.asksaveasfilename(
             defaultextension=".csv", filetypes=[("CSV files", "*.csv")]
         )
@@ -2278,6 +2283,7 @@ class CardEditorApp:
                 row_out = row.copy()
                 row_out[qty_field] = row_out.pop("qty")
                 row_out["warehouse_code"] = ";".join(sorted(row_out.pop("warehouses", [])))
+                row_out["images 1"] = row_out.get("image1", row_out.get("images", ""))
                 if qty_field != "stock":
                     row_out.pop("stock", None)
                 if qty_field != "ilość":
@@ -2325,6 +2331,7 @@ class CardEditorApp:
             "views",
             "rank",
             "rank_votes",
+            "images 1",
         ]
 
         with open(file_path, mode="w", encoding="utf-8", newline="") as file:
@@ -2360,6 +2367,7 @@ class CardEditorApp:
                         "views": row.get("views", ""),
                         "rank": row.get("rank", ""),
                         "rank_votes": row.get("rank_votes", ""),
+                        "images 1": row.get("image1", row.get("images", "")),
                     }
                 )
         messagebox.showinfo("Sukces", "Plik CSV został zapisany.")


### PR DESCRIPTION
## Summary
- include `images 1` column when exporting CSV
- preserve the column when merging CSV files
- document the new column in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e765de8bc832fab6f8cdde3bc4673