### PR TITLE
Improve description HTML generation

### DIFF
--- a/main.py
+++ b/main.py
@@ -2098,27 +2098,31 @@ class CardEditorApp:
         data["pkwiu"] = ""
         data["weight"] = 0.01
         data["priority"] = 0
-        data["short_description"] = f"Stan: {data['stan']}, Język: {data['język']}"
-        desc = (
-            f"🃏 {data['nazwa']} – Pokémon TCG\n"
-            f"🔹 Set: {data['set']}\n"
-            f"🔹 Numer karty: {data['numer']}\n"
-            f"🔹 Typ karty: {data['typ']}\n"
-            f"🔹 Stan: {data['stan']}\n"
-            "\n"
-            "Opis produktu:\n"
-            f"Karta {data['nazwa']} pochodzi z zestawu {data['set']}, idealna dla kolekcjonerów oraz graczy Pokémon TCG. To doskonały wybór, jeśli uzupełniasz swój master set albo szukasz konkretnej karty do talii.\n"
-            "\n"
-            "Każda karta jest dokładnie sprawdzana przed wysyłką i odpowiednio zabezpieczana – trafia do Ciebie w idealnym stanie, gotowa do gry lub kolekcji.\n"
-            "\n"
-            "📦 Szybka wysyłka i bezpieczne pakowanie!\n"
-            "🛡️ Zdjęcia przedstawiają rzeczywisty produkt lub jego odpowiednik.\n"
-            "\n"
-            "🧾 Wskazówka: Jeśli szukasz więcej kart z tego setu – sprawdź pozostałe oferty!"
+
+        name = html.escape(data["nazwa"])
+        number = html.escape(data["numer"])
+        set_name = html.escape(data["set"])
+        card_type = html.escape(data["typ"])
+        condition = html.escape(data["stan"])
+
+        data["short_description"] = (
+            f"<p><strong>{name}</strong></p>"
+            "<ul>"
+            f"<li>Zestaw: {set_name}</li>"
+            f"<li>Numer karty: {number}</li>"
+            f"<li>Typ: {card_type}</li>"
+            f"<li>Stan: {condition}</li>"
+            "</ul>"
         )
-        desc_html = html.escape(desc)
-        desc_html = desc_html.replace("\n\n", "</p><p>").replace("\n", "<br/>")
-        data["description"] = f"<p>{desc_html}</p>"
+
+        desc_paragraphs = [
+            f"{name} – Pokémon TCG",
+            f"Karta pochodzi z zestawu {set_name} i ma numer {number}. Typ karty: {card_type}. Stan: {condition}.",
+            "Każda karta jest dokładnie sprawdzana przed wysyłką i odpowiednio zabezpieczana – trafia do Ciebie w idealnym stanie, gotowa do gry lub kolekcji.",
+            "Zdjęcia przedstawiają rzeczywisty produkt lub jego odpowiednik. Jeśli szukasz więcej kart z tego setu – sprawdź pozostałe oferty.",
+        ]
+        data["description"] = "".join(f"<p>{p}</p>" for p in desc_paragraphs)
+
         data["stock_warnlevel"] = 0
         data["availability"] = 1
         data["delivery"] = SHOPER_DELIVERY_ID

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -1,0 +1,53 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+    def get(self):
+        return self.value
+
+
+def make_dummy():
+    return SimpleNamespace(
+        entries={
+            "nazwa": DummyVar("Charizard"),
+            "numer": DummyVar("4"),
+            "set": DummyVar("Base"),
+            "język": DummyVar("ENG"),
+            "stan": DummyVar("NM"),
+            "suffix": DummyVar(""),
+            "cena": DummyVar("")
+        },
+        type_vars={"Reverse": DummyVar(False), "Holo": DummyVar(False)},
+        rarity_vars={},
+        card_cache={},
+        cards=["/tmp/char.jpg"],
+        index=0,
+        folder_name="folder",
+        file_to_key={},
+        product_code_map={},
+        next_product_code=1,
+        generate_location=lambda idx: "K1R1P1",
+        output_data=[None],
+        get_price_from_db=lambda *a: None,
+        fetch_card_price=lambda *a: None,
+    )
+
+
+def test_html_generated():
+    import main
+    importlib.reload(main)
+    dummy = make_dummy()
+    main.CardEditorApp.save_current_data(dummy)
+    data = dummy.output_data[0]
+    assert "<ul>" in data["short_description"]
+    assert data["short_description"].startswith("<p><strong>")
+    assert "<li>" in data["short_description"]
+    assert data["description"].count("<p>") >= 2


### PR DESCRIPTION
## Summary
- generate HTML content in `save_current_data`
- escape user values when creating short and long descriptions
- test that HTML is produced when saving card data

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e78bb9d08832fac8d94ca05e026cb