### PR TITLE
Add warehouse_code export column

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ window with full functionality.
 After exporting a CSV file the application prompts to send it directly to Shoper.
 When Shoper API credentials are configured the file is uploaded via the REST API.
 If not, the exporter falls back to FTP using the credentials from `.env`.
-The exported CSV includes an `images 1` column containing the path to the remote image.
+The exported CSV includes `images 1` and `warehouse_code` columns with the remote image path and storage location.
 Use the **FTP Obrazy** button on the welcome screen to upload a folder of images
 to the configured FTP server.
 

--- a/main.py
+++ b/main.py
@@ -2335,6 +2335,7 @@ class CardEditorApp:
             "rank_votes",
             "images 1",
         ]
+        fieldnames.append("warehouse_code")
 
         with open(file_path, mode="w", encoding="utf-8", newline="") as file:
             writer = csv.DictWriter(file, fieldnames=fieldnames, delimiter=";")
@@ -2370,6 +2371,7 @@ class CardEditorApp:
                         "rank": row.get("rank", ""),
                         "rank_votes": row.get("rank_votes", ""),
                         "images 1": row.get("image1", row.get("images", "")),
+                        "warehouse_code": row.get("warehouse_code", ""),
                     }
                 )
         messagebox.showinfo("Sukces", "Plik CSV został zapisany.")

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -1,0 +1,44 @@
+import csv
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock
+
+import sys
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import main
+
+
+def test_export_includes_warehouse(tmp_path):
+    out_path = tmp_path / "out.csv"
+
+    dummy = SimpleNamespace(
+        output_data=[{
+            "nazwa": "Pikachu",
+            "numer": "1",
+            "set": "Base",
+            "suffix": "",
+            "product_code": 1,
+            "cena": "10",
+            "category": "Karty",
+            "producer": "Pokemon",
+            "short_description": "s",
+            "description": "d",
+            "warehouse_code": "K1R1P1",
+            "image1": "img.jpg",
+        }]
+    )
+    dummy.back_to_welcome = lambda: None
+
+    with patch("tkinter.filedialog.asksaveasfilename", return_value=str(out_path)), \
+         patch("tkinter.messagebox.showinfo"), \
+         patch("tkinter.messagebox.askyesno", return_value=False):
+        main.CardEditorApp.export_csv(dummy)
+
+    with open(out_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+        assert "warehouse_code" in reader.fieldnames
+        assert rows[0]["warehouse_code"] == "K1R1P1"
+
+


### PR DESCRIPTION
## Summary
- export `warehouse_code` in CSV output
- test the warehouse code export
- document new column in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8cfacf20832fa02c93233652553d