### PR TITLE
Fix VAT and unit formatting in CSV exports

### DIFF
--- a/main.py
+++ b/main.py
@@ -2090,8 +2090,8 @@ class CardEditorApp:
         data["product_code"] = self.product_code_map[key]
         data["warehouse_code"] = self.generate_location(product_idx)
         data["active"] = 1
-        data["vat"] = 23
-        data["unit"] = "szt"
+        data["vat"] = "23%"
+        data["unit"] = "szt."
         data["category"] = f"Karty Pokémon > {data['set']}"
         data["producer"] = "Pokémon"
         data["other_price"] = ""
@@ -2354,8 +2354,8 @@ class CardEditorApp:
                         "active": row.get("active", 1),
                         "name": formatted_name,
                         "price": row["cena"],
-                        "vat": row.get("vat", 23),
-                        "unit": row.get("unit", "szt"),
+                        "vat": row.get("vat", "23%"),
+                        "unit": row.get("unit", "szt."),
                         "category": row["category"],
                         "producer": row["producer"],
                         "other_price": row.get("other_price", ""),

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -39,6 +39,9 @@ def test_export_includes_warehouse(tmp_path):
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
         assert "warehouse_code" in reader.fieldnames
-        assert rows[0]["warehouse_code"] == "K1R1P1"
+        row = rows[0]
+        assert row["warehouse_code"] == "K1R1P1"
+        assert row["vat"] == "23%"
+        assert row["unit"] == "szt."
 
 


### PR DESCRIPTION
## Summary
- default VAT value uses `%` symbol
- default unit value ends with a period
- adjust export CSV logic to output these formats
- add regression test for VAT and unit values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9fefab1c832f99180d376579ef38