### PR TITLE
Improve warehouse occupancy counting

### DIFF
--- a/main.py
+++ b/main.py
@@ -766,14 +766,18 @@ class CardEditorApp:
         """Return dictionary of used slots per box column."""
         occ = {b: {c: 0 for c in range(1, 5)} for b in range(1, 9)}
         for row in self.output_data:
-            code = row.get("warehouse_code") or ""
-            m = re.match(r"K(\d+)R(\d)P(\d+)", code)
-            if not m:
-                continue
-            box = int(m.group(1))
-            c = int(m.group(2))
-            if box in occ and c in occ[box]:
-                occ[box][c] += 1
+            codes = str(row.get("warehouse_code") or "").split(";")
+            for code in codes:
+                code = code.strip()
+                if not code:
+                    continue
+                m = re.match(r"K(\d+)R(\d)P(\d+)", code)
+                if not m:
+                    continue
+                box = int(m.group(1))
+                c = int(m.group(2))
+                if box in occ and c in occ[box]:
+                    occ[box][c] += 1
         return occ
 
     def refresh_magazyn(self):

--- a/tests/test_column_occupancy.py
+++ b/tests/test_column_occupancy.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_split_codes_counted():
+    import main
+    importlib.reload(main)
+    dummy = SimpleNamespace(output_data=[{"warehouse_code": "K1R1P1;K1R1P2"}])
+    occ = main.CardEditorApp.compute_column_occupancy(dummy)
+    assert occ[1][1] == 2


### PR DESCRIPTION
## Summary
- count occupancy for all codes in semicolon-separated `warehouse_code`
- test computing occupancy with multiple codes for a single row

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb0b63010832fbf94d449dd0f69de