### PR TITLE
Implement next_free_location helper

### DIFF
--- a/tests/test_delivery_id.py
+++ b/tests/test_delivery_id.py
@@ -39,6 +39,7 @@ def test_delivery_id_used(monkeypatch):
         file_to_key={},
         product_code_map={},
         next_product_code=1,
+        next_free_location=lambda: "K1R1P1",
         generate_location=lambda idx: "K1R1P1",
         output_data=[None],
         get_price_from_db=lambda *a: None,

--- a/tests/test_next_free_location.py
+++ b/tests/test_next_free_location.py
@@ -1,0 +1,27 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import main
+importlib.reload(main)
+
+
+def test_next_free_location_sequential():
+    dummy = SimpleNamespace(
+        output_data=[
+            {"warehouse_code": "K01R1P0001"},
+            None,
+            {"warehouse_code": "K01R1P0003"},
+        ],
+    )
+    dummy.generate_location = lambda idx: main.CardEditorApp.generate_location(dummy, idx)
+    first = main.CardEditorApp.next_free_location(dummy)
+    assert first == "K01R1P0002"
+    dummy.output_data.append({"warehouse_code": first})
+    second = main.CardEditorApp.next_free_location(dummy)
+    assert second == "K01R1P0004"
+

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -34,6 +34,7 @@ def make_dummy():
         file_to_key={},
         product_code_map={},
         next_product_code=1,
+        next_free_location=lambda: "K1R1P1",
         generate_location=lambda idx: "K1R1P1",
         output_data=[None],
         get_price_from_db=lambda *a: None,


### PR DESCRIPTION
## Summary
- add `next_free_location` helper to compute next unused warehouse location
- use `next_free_location` in `save_current_data`
- test new helper and adjust existing tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb1e209f0832f9a84bbf52afcf22a