### PR TITLE
Implement column repacking

### DIFF
--- a/tests/test_repack_column.py
+++ b/tests/test_repack_column.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import main
+importlib.reload(main)
+
+
+def test_repack_after_removal():
+    dummy = SimpleNamespace(
+        output_data=[
+            {"warehouse_code": "K01R1P0001"},
+            {"warehouse_code": "K01R1P0003"},
+        ],
+        mag_canvases=[],
+        mag_box_photo=SimpleNamespace(width=lambda: 0, height=lambda: 0),
+        refresh_magazyn=lambda: None,
+    )
+    main.CardEditorApp.repack_column(dummy, 1, 1)
+    assert dummy.output_data[1]["warehouse_code"] == "K01R1P0002"
+
+
+def test_repack_within_row():
+    dummy = SimpleNamespace(
+        output_data=[{"warehouse_code": "K01R1P0001;K01R1P0003"}],
+        mag_canvases=[],
+        mag_box_photo=SimpleNamespace(width=lambda: 0, height=lambda: 0),
+        refresh_magazyn=lambda: None,
+    )
+    main.CardEditorApp.repack_column(dummy, 1, 1)
+    assert dummy.output_data[0]["warehouse_code"] == "K01R1P0001;K01R1P0002"


### PR DESCRIPTION
## Summary
- add `repack_column` to renumber locations without gaps
- provide helper `remove_warehouse_code` for deletions
- refresh warehouse view after repack
- test column repacking logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb51dbc20832f9e99a73d3030b0d3