### PR TITLE
Handle xPRE cards and add variant multipliers

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -41,6 +41,8 @@ SHOPER_DELIVERY_ID = int(os.getenv("SHOPER_DELIVERY_ID", "1"))
 PRICE_DB_PATH = "card_prices.csv"
 PRICE_MULTIPLIER = 1.23
 HOLO_REVERSE_MULTIPLIER = 3.5
+POKEBALL_MULTIPLIER = 5
+MASTERBALL_MULTIPLIER = 10
 SET_LOGO_DIR = "set_logos"
 
 # custom theme colors in grayscale
@@ -1302,7 +1304,7 @@ class CardEditorApp:
         self.type_vars = {}
         self.type_frame = ctk.CTkFrame(self.info_frame)
         self.type_frame.grid(row=start_row + 4, column=1, columnspan=7, sticky="w", **grid_opts)
-        types = ["Common", "Holo", "Reverse"]
+        types = ["Common", "Holo", "Reverse", "Pokeball", "Masterball", "Stamp"]
         for t in types:
             var = tk.BooleanVar()
             self.type_vars[t] = var
@@ -1828,7 +1830,10 @@ class CardEditorApp:
         name_input = normalize(name)
         number_input = number.strip().lower()
         set_input = set_name.strip().lower()
-        set_code = get_set_code(set_name)
+        if set_input == "prismatic evolutions: additionals":
+            set_code = "xpre"
+        else:
+            set_code = get_set_code(set_name)
 
         try:
             headers = {}
@@ -1905,7 +1910,10 @@ class CardEditorApp:
         name_input = normalize(name)
         number_input = number.strip().lower()
         set_input = set_name.strip().lower()
-        set_code = get_set_code(set_name)
+        if set_input == "prismatic evolutions: additionals":
+            set_code = "xpre"
+        else:
+            set_code = get_set_code(set_name)
 
         try:
             headers = {}
@@ -1977,7 +1985,10 @@ class CardEditorApp:
         name_input = normalize(name)
         number_input = number.strip().lower()
         set_input = set_name.strip().lower()
-        set_code = get_set_code(set_name)
+        if set_input == "prismatic evolutions: additionals":
+            set_code = "xpre"
+        else:
+            set_code = get_set_code(set_name)
 
         try:
             headers = {}
@@ -2163,15 +2174,23 @@ class CardEditorApp:
         return 4.265
 
     def apply_variant_multiplier(self, price, is_reverse=False, is_holo=False):
-        """Apply holo/reverse multiplier when needed."""
+        """Apply holo/reverse or special variant multiplier when needed."""
         if price is None:
             return None
+        multiplier = 1
         if is_reverse or is_holo:
-            try:
-                return round(float(price) * HOLO_REVERSE_MULTIPLIER, 2)
-            except (TypeError, ValueError):
-                return price
-        return price
+            multiplier *= HOLO_REVERSE_MULTIPLIER
+
+        types = getattr(self, "type_vars", {})
+        try:
+            if types.get("Masterball") and types["Masterball"].get():
+                multiplier *= MASTERBALL_MULTIPLIER
+            elif types.get("Pokeball") and types["Pokeball"].get():
+                multiplier *= POKEBALL_MULTIPLIER
+
+            return round(float(price) * multiplier, 2)
+        except (TypeError, ValueError):
+            return price
 
     def save_current_data(self):
         """Store the data for the currently displayed card without changing

--- a/tcg_sets.json
+++ b/tcg_sets.json
@@ -53,6 +53,10 @@
       "code": "sv8pt5"
     },
     {
+      "name": "Prismatic Evolutions: Additionals",
+      "code": "xpre"
+    },
+    {
       "name": "Journey Together",
       "code": "sv9"
     },

--- a/tests/test_variant_multiplier.py
+++ b/tests/test_variant_multiplier.py
@@ -1,0 +1,34 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+    def get(self):
+        return self.value
+
+def test_get_set_code_additionals():
+    assert ui.get_set_code("Prismatic Evolutions: Additionals") == "xpre"
+
+def test_apply_variant_multiplier_balls():
+    dummy = SimpleNamespace(type_vars={
+        "Pokeball": DummyVar(True),
+        "Masterball": DummyVar(False)
+    })
+    price = ui.CardEditorApp.apply_variant_multiplier(dummy, 10)
+    assert price == 10 * ui.POKEBALL_MULTIPLIER
+
+    dummy = SimpleNamespace(type_vars={
+        "Pokeball": DummyVar(False),
+        "Masterball": DummyVar(True)
+    })
+    price = ui.CardEditorApp.apply_variant_multiplier(dummy, 10)
+    assert price == 10 * ui.MASTERBALL_MULTIPLIER


### PR DESCRIPTION
## Summary
- add Prismatic Evolutions: Additionals to English sets
- extend card type checkboxes with Pokeball/Masterball/Stamp
- introduce Pokeball and Masterball multipliers
- apply multipliers based on selected card type
- handle the Additionals set code when querying the API
- test the new set code and multipliers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9bd63398832fb30fcac75ff98ced