### PR TITLE
Add starting location selection

### DIFF
--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -32,7 +32,7 @@ def next_free_location(app):
             idx = (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
             used.add(idx)
 
-    idx = 0
+    idx = getattr(app, "starting_idx", 0)
     while idx in used:
         idx += 1
     return generate_location(idx)

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -234,6 +234,7 @@ class CardEditorApp:
         self.folder_name = ""
         self.folder_path = ""
         self.progress_var = tk.StringVar(value="0/0")
+        self.starting_idx = 0
         self.start_frame = None
         self.shoper_frame = None
         self.pricing_frame = None
@@ -1514,6 +1515,22 @@ class CardEditorApp:
         folder = filedialog.askdirectory()
         if not folder:
             return
+
+        box = simpledialog.askinteger("Początkowa lokalizacja", "Karton", minvalue=1, initialvalue=1)
+        if box is None:
+            return
+        column = simpledialog.askinteger(
+            "Początkowa lokalizacja", "Kolumna", minvalue=1, maxvalue=4, initialvalue=1
+        )
+        if column is None:
+            return
+        pos = simpledialog.askinteger(
+            "Początkowa lokalizacja", "Pozycja", minvalue=1, initialvalue=1
+        )
+        if pos is None:
+            return
+
+        self.starting_idx = (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
         if self.start_frame is not None:
             self.start_frame.destroy()
             self.start_frame = None

--- a/tests/test_next_free_location.py
+++ b/tests/test_next_free_location.py
@@ -25,3 +25,36 @@ def test_next_free_location_sequential():
     second = ui.CardEditorApp.next_free_location(dummy)
     assert second == "K01R1P0004"
 
+
+def test_next_free_location_from_start_idx():
+    dummy = SimpleNamespace(
+        output_data=[{"warehouse_code": "K01R1P0001"}],
+        starting_idx=(2 - 1) * 4000 + (1 - 1) * 1000 + (1 - 1),
+    )
+    dummy.generate_location = lambda idx: ui.CardEditorApp.generate_location(dummy, idx)
+    first = ui.CardEditorApp.next_free_location(dummy)
+    assert first == "K02R1P0001"
+
+
+def test_load_images_sets_start(monkeypatch, tmp_path):
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"data")
+
+    monkeypatch.setattr(ui.filedialog, "askdirectory", lambda: str(tmp_path))
+    seq = iter([2, 1, 5])
+    monkeypatch.setattr(ui.simpledialog, "askinteger", lambda *a, **k: next(seq))
+
+    dummy = SimpleNamespace(
+        start_frame=None,
+        setup_editor_ui=lambda: None,
+        progress_var=SimpleNamespace(set=lambda *a, **k: None),
+        log=lambda *a, **k: None,
+        show_card=lambda *a, **k: None,
+    )
+
+    ui.CardEditorApp.load_images(dummy)
+
+    expected = (2 - 1) * 4000 + (1 - 1) * 1000 + (5 - 1)
+    assert dummy.starting_idx == expected
+    assert ui.CardEditorApp.next_free_location(dummy) == "K02R1P0005"
+


### PR DESCRIPTION
## Summary
- allow specifying starting carton, row and position when loading images
- store starting index in the UI app
- search for next free location beginning from `starting_idx`
- test starting index behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881c79ef25c832f888496932fa72744