### PR TITLE
Improve start location prompt

### DIFF
--- a/tests/test_next_free_location.py
+++ b/tests/test_next_free_location.py
@@ -41,8 +41,7 @@ def test_load_images_sets_start(monkeypatch, tmp_path):
     img.write_bytes(b"data")
 
     monkeypatch.setattr(ui.filedialog, "askdirectory", lambda: str(tmp_path))
-    seq = iter([2, 1, 5])
-    monkeypatch.setattr(ui.simpledialog, "askinteger", lambda *a, **k: next(seq))
+    monkeypatch.setattr(ui, "prompt_start_location", lambda *a, **k: (2, 1, 5))
 
     dummy = SimpleNamespace(
         start_frame=None,


### PR DESCRIPTION
## Summary
- prompt for box, column and position in a single dialog
- show next warehouse code above the current scan
- update tests for new prompt

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881ce1b9368832f94c16a8014695e38