### PR TITLE
Add browse_scans with start location inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Execute the main script with Python 3:
 python main.py
 ```
 
-The interface will allow you to load scans, fetch prices from the local database or the API, and export results to CSV.
+The interface will allow you to load scans, fetch prices from the local database
+or the API, and export results to CSV.  Use the **Skanuj** button to reveal a
+panel for entering the starting box, column and position.  After clicking
+**Dalej** and selecting a folder of images the application loads the scans
+starting from the specified location.
 
 ## Running Tests
 The automated tests are written with `pytest` and mock out all GUI components,

--- a/tests/test_next_free_location.py
+++ b/tests/test_next_free_location.py
@@ -41,7 +41,6 @@ def test_load_images_sets_start(monkeypatch, tmp_path):
     img.write_bytes(b"data")
 
     monkeypatch.setattr(ui.filedialog, "askdirectory", lambda: str(tmp_path))
-    monkeypatch.setattr(ui, "prompt_start_location", lambda *a, **k: (2, 1, 5))
 
     dummy = SimpleNamespace(
         start_frame=None,
@@ -49,9 +48,12 @@ def test_load_images_sets_start(monkeypatch, tmp_path):
         progress_var=SimpleNamespace(set=lambda *a, **k: None),
         log=lambda *a, **k: None,
         show_card=lambda *a, **k: None,
+        start_box_var=SimpleNamespace(get=lambda: 2),
+        start_col_var=SimpleNamespace(get=lambda: 1),
+        start_pos_var=SimpleNamespace(get=lambda: 5),
     )
 
-    ui.CardEditorApp.load_images(dummy)
+    ui.CardEditorApp.browse_scans(dummy)
 
     expected = (2 - 1) * 4000 + (1 - 1) * 1000 + (5 - 1)
     assert dummy.starting_idx == expected


### PR DESCRIPTION
## Summary
- add IntVars for starting location
- show a location panel with entries and box image
- validate the inputs in `browse_scans`
- drop obsolete `LocationDialog` helper
- update test to use the new workflow
- document new scan workflow in README

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d35267ec832fa7595f9f7d68c360