### PR TITLE
Add OpenAI-based card analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+RAPIDAPI_KEY=your-key-here
+RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
+SHOPER_API_URL=https://your-store.shop/webapi/rest
+SHOPER_API_TOKEN=your-token
+SHOPER_DELIVERY_ID=1
+OPENAI_API_KEY=
+FTP_HOST=example.com
+FTP_USER=username
+FTP_PASSWORD=secret

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
 SHOPER_API_URL=https://your-store.shop/webapi/rest
 SHOPER_API_TOKEN=your-token
 SHOPER_DELIVERY_ID=1
+OPENAI_API_KEY=sk-...
 FTP_HOST=example.com
 FTP_USER=username
 FTP_PASSWORD=secret
 ```
 
-The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads.
+The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` enables automatic recognition of card details from scans.
 
 ## Running the App
 Execute the main script with Python 3:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Pillow
 requests
 python-dotenv
 customtkinter
+openai

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import tkinter as tk
+
+sys.modules["customtkinter"] = SimpleNamespace(CTkEntry=tk.Entry)
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+
+def test_show_card_uses_analyzer(tmp_path):
+    img = tmp_path / "card.jpg"
+    img.write_bytes(b"data")
+
+    name_entry = MagicMock()
+    num_entry = MagicMock()
+    set_var = MagicMock()
+    name_entry.delete = MagicMock()
+    name_entry.insert = MagicMock()
+    name_entry.focus_set = MagicMock()
+    num_entry.delete = MagicMock()
+    num_entry.insert = MagicMock()
+    set_var.set = MagicMock()
+
+    dummy = SimpleNamespace(
+        cards=[str(img)],
+        index=0,
+        image_objects=[],
+        image_label=MagicMock(),
+        progress_var=SimpleNamespace(set=lambda *a, **k: None),
+        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var},
+        rarity_vars={},
+        type_vars={},
+        card_cache={},
+        file_to_key={},
+        _guess_key_from_filename=lambda *a, **k: None,
+        update_set_options=lambda *a, **k: None,
+    )
+
+    with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
+         patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
+         patch.object(ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": "Base"}) as mock_analyze:
+        ui.CardEditorApp.show_card(dummy)
+
+    mock_analyze.assert_called_once_with(str(img))
+    name_entry.insert.assert_called_with(0, "Pika")
+    num_entry.insert.assert_called_with(0, "001")
+    set_var.set.assert_called_with("Base")
+


### PR DESCRIPTION
## Summary
- include `openai` in requirements
- add example `.env` with `OPENAI_API_KEY`
- document the API key in README
- implement `analyze_card_image` and call it from `show_card`
- test that the analyzer is invoked when displaying a card

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881e609e314832f921063046b596217