### PR TITLE
Enable GPT image analysis from remote URL

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -223,6 +223,15 @@ def analyze_card_image(path: str):
     """Return card details recognized from the image using OpenAI."""
     if not OPENAI_API_KEY:
         return {"name": "", "number": "", "set": ""}
+
+    parsed = urlparse(path)
+    if parsed.scheme in ("http", "https"):
+        url = path
+    else:
+        folder = os.path.basename(os.path.dirname(path))
+        filename = os.path.basename(path)
+        url = f"{BASE_IMAGE_URL}/{folder}/{filename}"
+
     try:
         resp = openai.ChatCompletion.create(
             model="gpt-4-vision-preview",
@@ -238,7 +247,7 @@ def analyze_card_image(path: str):
                         },
                         {
                             "type": "image_url",
-                            "image_url": {"url": f"file://{path}"},
+                            "image_url": {"url": url},
                         },
                     ],
                 }
@@ -1688,7 +1697,9 @@ class CardEditorApp:
                     self.rarity_vars[name].set(val)
             self.update_set_options()
 
-        result = analyze_card_image(image_path)
+        folder = os.path.basename(os.path.dirname(image_path))
+        remote_url = f"{BASE_IMAGE_URL}/{folder}/{os.path.basename(image_path)}"
+        result = analyze_card_image(remote_url)
         if result:
             name = result.get("name", "")
             number = result.get("number", "")

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 from pathlib import Path
+import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 import tkinter as tk
@@ -45,7 +46,9 @@ def test_show_card_uses_analyzer(tmp_path):
          patch.object(ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": "Base"}) as mock_analyze:
         ui.CardEditorApp.show_card(dummy)
 
-    mock_analyze.assert_called_once_with(str(img))
+    folder = os.path.basename(img.parent)
+    expected_url = f"{ui.BASE_IMAGE_URL}/{folder}/{img.name}"
+    mock_analyze.assert_called_once_with(expected_url)
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "001")
     set_var.set.assert_called_with("Base")


### PR DESCRIPTION
## Summary
- build the image URL automatically and use it with OpenAI API
- expect the generated URL in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f7c4dcdc832f98ab0db30a14453e