### PR TITLE
Document BASE_IMAGE_URL usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ OPENAI_API_KEY=sk-...
 FTP_HOST=example.com
 FTP_USER=username
 FTP_PASSWORD=secret
+BASE_IMAGE_URL=https://your-store.shop/upload/images
 ```
 
-The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` enables automatic recognition of card details from scans.
+The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` enables automatic recognition of card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links.
 
 ## Running the App
 Execute the main script with Python 3:

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -27,7 +27,7 @@ import io
 
 load_dotenv()
 
-BASE_IMAGE_URL = "https://sklep839679.shoparena.pl/upload/images"
+BASE_IMAGE_URL = os.getenv("BASE_IMAGE_URL", "https://sklep839679.shoparena.pl/upload/images")
 
 RAPIDAPI_KEY = os.getenv("RAPIDAPI_KEY")
 RAPIDAPI_HOST = os.getenv("RAPIDAPI_HOST")


### PR DESCRIPTION
## Summary
- load BASE_IMAGE_URL from the environment
- explain BASE_IMAGE_URL in README and show example

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688205ee2f04832fb3903bff2bbf10a5