### PR TITLE
Add folder selector and scan animation

### DIFF
--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -42,6 +42,10 @@ def test_show_card_uses_analyzer(tmp_path):
         update_set_options=lambda *a, **k: None,
     )
 
+    dummy.start_scan_animation = lambda *a, **k: None
+    dummy.stop_scan_animation = lambda *a, **k: None
+    dummy._analyze_and_fill = lambda url, idx: ui.CardEditorApp._apply_analysis_result(dummy, ui.analyze_card_image(url), idx)
+
     with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
          patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
          patch.object(ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": "Base", "suffix": "V"}) as mock_analyze:

--- a/tests/test_next_free_location.py
+++ b/tests/test_next_free_location.py
@@ -51,6 +51,7 @@ def test_load_images_sets_start(monkeypatch, tmp_path):
         start_box_var=SimpleNamespace(get=lambda: 2),
         start_col_var=SimpleNamespace(get=lambda: 1),
         start_pos_var=SimpleNamespace(get=lambda: 5),
+        scan_folder_var=SimpleNamespace(get=lambda: "", set=lambda v: None),
     )
 
     ui.CardEditorApp.browse_scans(dummy)


### PR DESCRIPTION
## Summary
- allow picking scan folder directly on the start screen
- show scan animation while images are analysed
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882165b8088832f85ce7b3e3ca5c07c