### PR TITLE
Ensure editor UI is created before loading scans

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1715,6 +1715,7 @@ class CardEditorApp:
         if self.start_frame is not None:
             self.start_frame.destroy()
             self.start_frame = None
+        if getattr(self, "frame", None) is None:
             self.setup_editor_ui()
         self.folder_path = folder
         self.folder_name = os.path.basename(folder)


### PR DESCRIPTION
## Summary
- do not rely on `start_frame` for editor initialization
- create the editor UI whenever the frame is missing

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688267a49354832f9ae1703e8e946ec8