### PR TITLE
Gracefully handle failed order stats

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -703,25 +703,26 @@ class CardEditorApp:
             stats["open_returns"] = len(open_ret.get("list", open_ret))
 
             sales = self.shoper_client.get_sales_stats()
-            for key, default in {
-                "today": 0,
-                "week": 0,
-                "month": 0,
-                "avg_order_value": 0,
-                "active_products": 0,
-            }.items():
-                try:
-                    value = int(float(sales.get(key, default)))
-                except (TypeError, ValueError):
-                    value = default
-                stats_key = {
-                    "today": "sales_today",
-                    "week": "sales_week",
-                    "month": "sales_month",
-                    "avg_order_value": "avg_order_value",
-                    "active_products": "active_cards",
-                }[key]
-                stats[stats_key] = value
+            if sales:
+                for key, default in {
+                    "today": 0,
+                    "week": 0,
+                    "month": 0,
+                    "avg_order_value": 0,
+                    "active_products": 0,
+                }.items():
+                    try:
+                        value = int(float(sales.get(key, default)))
+                    except (TypeError, ValueError):
+                        value = default
+                    stats_key = {
+                        "today": "sales_today",
+                        "week": "sales_week",
+                        "month": "sales_month",
+                        "avg_order_value": "avg_order_value",
+                        "active_products": "active_cards",
+                    }[key]
+                    stats[stats_key] = value
         except Exception as exc:  # pragma: no cover - network failure
             print(f"[WARNING] store stats failed: {exc}")
         return stats

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -88,7 +88,11 @@ class ShoperClient:
 
     def get_sales_stats(self, params=None):
         """Return sales statistics using the built-in Shoper endpoint."""
-        return self.get("orders/stats", params=params or {})
+        try:
+            return self.get("orders/stats", params=params or {})
+        except RuntimeError:  # pragma: no cover - network failure
+            print("[INFO] orders/stats unavailable")
+            return {}
 
     def import_csv(self, file_path):
         """Upload a CSV file using the Shoper API."""


### PR DESCRIPTION
## Summary
- avoid propagating `RuntimeError` from `/orders/stats`
- load other stats even if sales stats are missing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688297b2c6ac832fa9a6c0fe5dc7691e