### PR TITLE
Improve Shoper API connection check

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -734,7 +734,9 @@ class CardEditorApp:
         # Quick connection test to provide clearer error messages
         try:
             # use a known endpoint to verify the connection
-            self.shoper_client.get_inventory()
+            resp = self.shoper_client.get_inventory()
+            if not resp:
+                raise RuntimeError("404")
         except Exception as exc:
             msg = str(exc)
             if "404" in msg:


### PR DESCRIPTION
## Summary
- check for empty response when verifying Shoper API connectivity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829e9cd864832faadd2e83931ac484