### PR TITLE
Trim Shoper env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ FTP_PASSWORD=secret
 BASE_IMAGE_URL=https://your-store.shop/upload/images
 ```
 
-The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` enables automatic recognition of card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links.
+The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` enables automatic recognition of card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
 
 ## Running the App
 Execute the main script with Python 3:

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -6,11 +6,13 @@ class ShoperClient:
     """Minimal wrapper for Shoper REST API."""
 
     def __init__(self, base_url=None, token=None):
-        self.base_url = (base_url or os.getenv("SHOPER_API_URL", "")).rstrip("/")
+        env_url = os.getenv("SHOPER_API_URL", "").strip()
+        self.base_url = (base_url or env_url).rstrip("/")
         # Ensure the URL points to the REST endpoint
         if self.base_url and not self.base_url.endswith("/webapi/rest"):
             self.base_url = f"{self.base_url}/webapi/rest"
-        self.token = token or os.getenv("SHOPER_API_TOKEN")
+        env_token = os.getenv("SHOPER_API_TOKEN", "").strip()
+        self.token = token or env_token
         if not self.base_url or not self.token:
             raise ValueError("SHOPER_API_URL or SHOPER_API_TOKEN not set")
         self.session = requests.Session()

--- a/tests/test_shoper_client.py
+++ b/tests/test_shoper_client.py
@@ -1,0 +1,9 @@
+from shoper_client import ShoperClient
+
+
+def test_env_vars_trimmed(monkeypatch):
+    monkeypatch.setenv("SHOPER_API_URL", " https://example.com  ")
+    monkeypatch.setenv("SHOPER_API_TOKEN", "  tok  ")
+    client = ShoperClient()
+    assert client.base_url == "https://example.com/webapi/rest"
+    assert client.token == "tok"


### PR DESCRIPTION
## Summary
- handle whitespace when reading Shoper credentials
- document trimming of Shoper variables in README
- test that whitespace doesn't prevent client initialisation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a539dd24832f8890acf80f65f7a1