### PR TITLE
Add scan mode tracking with confirmation dialog

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -334,6 +334,7 @@ class CardEditorApp:
         self.loading_label = None
         self.price_pool_total = 0.0
         self.pool_total_label = None
+        self.in_scan = False
         self.show_loading_screen()
         threading.Thread(target=self.startup_tasks, daemon=True).start()
 
@@ -1581,6 +1582,12 @@ class CardEditorApp:
             self.pool_total_label.config(text="Suma puli: 0.00")
 
     def back_to_welcome(self):
+        if getattr(self, "in_scan", False):
+            if not messagebox.askyesno(
+                "Potwierdzenie", "Czy na pewno chcesz przerwać?"
+            ):
+                return
+        self.in_scan = False
         if getattr(self, "pricing_frame", None):
             self.pricing_frame.destroy()
             self.pricing_frame = None
@@ -1990,10 +1997,12 @@ class CardEditorApp:
             if not folder:
                 return
             self.scan_folder_var.set(folder)
+        self.in_scan = True
         self.starting_idx = (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
         CardEditorApp.load_images(self, folder)
 
     def load_images(self, folder):
+        self.in_scan = True
         if self.start_frame is not None:
             self.start_frame.destroy()
             self.start_frame = None
@@ -2908,6 +2917,7 @@ class CardEditorApp:
         csv_utils.load_csv_data(self)
 
     def export_csv(self):
+        self.in_scan = False
         csv_utils.export_csv(self)
 
     def upload_images_dialog(self):

--- a/tests/test_back_to_welcome.py
+++ b/tests/test_back_to_welcome.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+def test_back_to_welcome_requires_confirmation():
+    dummy = SimpleNamespace(
+        pricing_frame=None,
+        shoper_frame=None,
+        frame=None,
+        magazyn_frame=None,
+        location_frame=None,
+        setup_welcome_screen=MagicMock(),
+        in_scan=True,
+    )
+
+    with patch("tkinter.messagebox.askyesno", return_value=False) as ask:
+        ui.CardEditorApp.back_to_welcome(dummy)
+        ask.assert_called_once_with(
+            "Potwierdzenie", "Czy na pewno chcesz przerwać?"
+        )
+    dummy.setup_welcome_screen.assert_not_called()
+    assert dummy.in_scan
+


### PR DESCRIPTION
## Summary
- track when the card editor is in scan mode
- set scan mode when browsing or loading scans
- clear scan mode when exporting or returning to welcome screen
- show confirmation dialog when leaving the scan editor
- test confirmation behavior when cancelling exit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688362528a60832fb2e21c6c9f4498d2