### PR TITLE
Support JP set file

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -314,6 +314,7 @@ class CardEditorApp:
         self.price_db = self.load_price_db()
         self.folder_name = ""
         self.folder_path = ""
+        self.sets_file = "tcg_sets.json"
         self.progress_var = tk.StringVar(value="0/0")
         self.start_box_var = tk.StringVar(value="1")
         self.start_col_var = tk.StringVar(value="1")
@@ -1881,8 +1882,10 @@ class CardEditorApp:
     def update_set_options(self, event=None):
         lang = self.lang_var.get().strip().upper()
         if lang == "JP":
+            self.sets_file = "tcg_sets_jp.json"
             self.set_dropdown.configure(values=tcg_sets_jp)
         else:
+            self.sets_file = "tcg_sets.json"
             self.set_dropdown.configure(values=tcg_sets_eng)
         if getattr(self, "cheat_frame", None) is not None:
             self.create_cheat_frame()
@@ -2339,7 +2342,7 @@ class CardEditorApp:
         try:
             self.loading_label.configure(text="Sprawdzanie nowych setów...")
             self.root.update()
-            with open("tcg_sets.json", encoding="utf-8") as f:
+            with open(self.sets_file, encoding="utf-8") as f:
                 current_sets = json.load(f)
         except Exception:
             current_sets = {}
@@ -2376,7 +2379,7 @@ class CardEditorApp:
             new_items.append({"name": name, "code": code})
 
         if added:
-            with open("tcg_sets.json", "w", encoding="utf-8") as f:
+            with open(self.sets_file, "w", encoding="utf-8") as f:
                 json.dump(current_sets, f, indent=2, ensure_ascii=False)
             reload_sets()
             names = ", ".join(item["name"] for item in new_items)

--- a/tests/test_sets_file.py
+++ b/tests/test_sets_file.py
@@ -1,0 +1,76 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+
+def make_dummy(tmp_path, sets_file):
+    return SimpleNamespace(
+        sets_file=str(sets_file),
+        loading_label=SimpleNamespace(configure=lambda *a, **k: None),
+        root=SimpleNamespace(update=lambda *a, **k: None),
+        download_set_symbols=MagicMock(),
+    )
+
+
+def test_update_set_options_sets_file_jp():
+    dummy = SimpleNamespace(
+        lang_var=SimpleNamespace(get=lambda: "JP"),
+        set_dropdown=MagicMock(),
+        cheat_frame=None,
+        sets_file="tcg_sets.json",
+    )
+    ui.CardEditorApp.update_set_options(dummy)
+    assert dummy.sets_file == "tcg_sets_jp.json"
+    dummy.set_dropdown.configure.assert_called_with(values=ui.tcg_sets_jp)
+
+
+def test_update_set_options_sets_file_eng():
+    dummy = SimpleNamespace(
+        lang_var=SimpleNamespace(get=lambda: "ENG"),
+        set_dropdown=MagicMock(),
+        cheat_frame=None,
+        sets_file="tcg_sets_jp.json",
+    )
+    ui.CardEditorApp.update_set_options(dummy)
+    assert dummy.sets_file == "tcg_sets.json"
+    dummy.set_dropdown.configure.assert_called_with(values=ui.tcg_sets_eng)
+
+
+def run_update_sets(tmp_path, filename):
+    sets_file = tmp_path / filename
+    sets_file.write_text("{}", encoding="utf-8")
+    dummy = make_dummy(tmp_path, sets_file)
+
+    resp = SimpleNamespace(
+        status_code=200,
+        json=lambda: {"data": [{"series": "X", "id": "CODE", "name": "Name"}]},
+        raise_for_status=lambda: None,
+    )
+    with patch("requests.get", return_value=resp), patch.object(ui, "reload_sets") as reload_mock:
+        ui.CardEditorApp.update_sets(dummy)
+        reload_mock.assert_called_once()
+
+    data = json.loads(sets_file.read_text(encoding="utf-8"))
+    # expect inserted under "X" with code and name
+    assert "X" in data
+    assert {"name": "Name", "code": "CODE"} in data["X"]
+    dummy.download_set_symbols.assert_called_once_with([{"name": "Name", "code": "CODE"}])
+
+
+
+def test_update_sets_eng(tmp_path):
+    run_update_sets(tmp_path, "tcg_sets.json")
+
+
+
+def test_update_sets_jp(tmp_path):
+    run_update_sets(tmp_path, "tcg_sets_jp.json")
+


### PR DESCRIPTION
## Summary
- allow `CardEditorApp` to track the active JSON file for set definitions
- switch between ENG and JP set data when language changes
- update sets using whichever file is active
- test both English and Japanese paths

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688364c6bcbc832faff2bda5f1fbc7fc