### PR TITLE
Add inventory CSV append feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ OPENAI_API_KEY=
 FTP_HOST=example.com
 FTP_USER=username
 FTP_PASSWORD=secret
+INVENTORY_CSV=magazyn.csv

--- a/README.md
+++ b/README.md
@@ -41,10 +41,12 @@ OPENAI_API_KEY=sk-...
 FTP_HOST=example.com
 FTP_USER=username
 FTP_PASSWORD=secret
+INVENTORY_CSV=magazyn.csv
 BASE_IMAGE_URL=https://your-store.shop/upload/images
 ```
 
 The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` enables automatic recognition of card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
+`INVENTORY_CSV` controls where the local inventory CSV is written.
 
 ## Running the App
 Execute the main script with Python 3:
@@ -94,7 +96,7 @@ Use the **Porządkuj** button to open a window with actions against your Shoper 
 The welcome screen displays a small dashboard with store statistics fetched from your Shoper account: counts of new orders, pending shipments or payments and recent sales totals. To populate these fields the token must have permissions to read orders and statistics. Active product count is taken from the sales statistics when available, otherwise the application queries the inventory to determine the total number of products. Use the **Pokaż szczegóły** button to open the Shoper window with full functionality.
 
 ### CSV and image upload
-After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to FTP using the credentials from `.env`. The exported CSV includes `images 1` and `warehouse_code` columns with the remote image path and storage location. Use the **FTP Obrazy** button on the welcome screen to upload a folder of images to the configured FTP server.
+After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to FTP using the credentials from `.env`. The exported CSV includes `images 1` and `warehouse_code` columns with the remote image path and storage location. A copy of every row is also appended to the file specified in `INVENTORY_CSV` so the full stock list remains in one place. Use the **FTP Obrazy** button on the welcome screen to upload a folder of images to the configured FTP server.
 
 ## License
 This project is licensed under the terms of the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- append inventory data to `INVENTORY_CSV` on export
- expose `INVENTORY_CSV` in `.env.example`
- document new variable and behaviour in README
- test that exporting appends rows to inventory file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836dfcc7ec832fab54029772a6561f