### PR TITLE
Update inventory view and OpenAI prompt

### DIFF
--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -48,7 +48,7 @@ def test_show_card_uses_analyzer(tmp_path):
 
     with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
          patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
-         patch.object(ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": "Base", "suffix": "V"}) as mock_analyze:
+        patch.object(ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "suffix": "V"}) as mock_analyze:
         ui.CardEditorApp.show_card(dummy)
 
     folder = os.path.basename(img.parent)
@@ -56,7 +56,7 @@ def test_show_card_uses_analyzer(tmp_path):
     mock_analyze.assert_called_once_with(expected_url)
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "001")
-    set_var.set.assert_called_with("Base")
+    set_var.set.assert_called_with("")
     suffix_var.set.assert_called_with("V")
 
 
@@ -72,7 +72,7 @@ def test_analyze_card_image_bad_json(monkeypatch, capsys):
         result = ui.analyze_card_image("/tmp/img.jpg")
     output = capsys.readouterr().out
 
-    assert result == {"name": "", "number": "", "set": "", "suffix": ""}
+    assert result == {"name": "", "number": "", "suffix": ""}
     assert "analyze_card_image failed to decode JSON" in output
     assert "not json" in output
 
@@ -81,7 +81,7 @@ def test_analyze_card_image_code_block(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     importlib.reload(ui)
 
-    content = "```json\n{\"name\": \"Pikachu\", \"number\": \"037/159\", \"set\": \"Base\"}\n```"
+    content = "```json\n{\"name\": \"Pikachu\", \"number\": \"037/159\"}\n```"
     resp = SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
     )
@@ -89,7 +89,7 @@ def test_analyze_card_image_code_block(monkeypatch):
     with patch("openai.chat.completions.create", return_value=resp):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
-    assert result == {"name": "Pikachu", "number": "37", "set": "Base", "suffix": ""}
+    assert result == {"name": "Pikachu", "number": "37", "suffix": ""}
 
 
 def test_analyze_card_image_translate_name(monkeypatch):
@@ -100,7 +100,7 @@ def test_analyze_card_image_translate_name(monkeypatch):
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
-                    content='{"name": "\u30d4\u30ab\u30c1\u30e5\u30a6", "number": "037/159", "set": "Base"}'
+                    content='{"name": "\u30d4\u30ab\u30c1\u30e5\u30a6", "number": "037/159"}'
                 )
             )
         ]
@@ -112,7 +112,7 @@ def test_analyze_card_image_translate_name(monkeypatch):
     with patch("openai.chat.completions.create", side_effect=[resp_analyze, resp_translate]) as mock_create:
         result = ui.analyze_card_image("/tmp/img.jpg", translate_name=True)
 
-    assert result == {"name": "Pikachu", "number": "37", "set": "Base", "suffix": ""}
+    assert result == {"name": "Pikachu", "number": "37", "suffix": ""}
     assert mock_create.call_count == 2
 
 
@@ -151,7 +151,7 @@ def test_analyze_and_fill_translates_for_jp(monkeypatch):
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
-                    content='{"name": "\u30d4\u30ab\u30c1\u30e5\u30a6", "number": "001", "set": "Base"}'
+                    content='{"name": "\u30d4\u30ab\u30c1\u30e5\u30a6", "number": "001"}'
                 )
             )
         ]


### PR DESCRIPTION
## Summary
- rename `Inwentarz` tab to `Stan magazynowy`
- show products from `magazyn.csv` instead of the Shoper API
- add helper `load_inventory_csv`
- adjust OpenAI vision request to only return card name and number
- update tests for new OpenAI behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a13d6054832fba15f29e058d2b2c