### PR TITLE
Add token sharing warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ INVENTORY_CSV=magazyn.csv
 BASE_IMAGE_URL=https://your-store.shop/upload/images
 ```
 
+**Warning:** This file may contain private API keys and tokens. It is excluded
+from version control via `.gitignore` and should never be shared publicly.
+
 The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` enables automatic recognition of card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
 `INVENTORY_CSV` controls where the local inventory CSV is written.
 


### PR DESCRIPTION
## Summary
- warn users not to share tokens or the `.env` file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688722d3d814832f83f0de1ffec40aa3