### PR TITLE
Run Discord bot on background thread

### DIFF
--- a/kartoteka/bot.py
+++ b/kartoteka/bot.py
@@ -662,4 +662,7 @@ async def on_reaction_add(reaction, user):
         if channel:
             await channel.send(f"Użytkownik {user} zaznaczył OK.")
 
-bot.run(TOKEN)
+
+def run_bot() -> None:
+    """Start the Discord bot."""
+    bot.run(TOKEN)

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1025,6 +1025,14 @@ class CardEditorApp:
         if getattr(self, "auction_frame", None):
             self.auction_frame.destroy()
 
+        try:
+            import bot
+            if not getattr(bot, "_thread_started", False):
+                threading.Thread(target=bot.run_bot, daemon=True).start()
+                bot._thread_started = True
+        except Exception as e:
+            messagebox.showerror("Błąd", str(e))
+
         self.root.minsize(1000, 700)
         self.auction_frame = tk.Frame(
             self.root, bg=self.root.cget("background")


### PR DESCRIPTION
## Summary
- avoid running the Discord bot on import
- start the bot in a thread when the auction module opens

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875829ff08832f86f18a4678bf53e5