### PR TITLE
Add auction import from selected inventory rows

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1280,6 +1280,29 @@ class CardEditorApp:
                     self.auction_queue.pop(idx)
             refresh_tree()
 
+        def import_selected():
+            rows = []
+            treeview = getattr(self, "inventory_tree", None)
+            if treeview and str(treeview.winfo_exists()) == "1":
+                codes = [treeview.item(i, "values")[0] for i in treeview.selection()]
+                if codes:
+                    try:
+                        rows = self.read_inventory_rows(codes, csv_utils.INVENTORY_CSV)
+                    except Exception as exc:
+                        messagebox.showerror("Błąd", str(exc))
+                        return
+            if not rows:
+                path = filedialog.askopenfilename(filetypes=[("CSV files", "*.csv")])
+                if not path:
+                    return
+                try:
+                    rows = self.read_inventory_rows([], path)
+                except Exception as exc:
+                    messagebox.showerror("Błąd", str(exc))
+                    return
+            self.auction_queue.extend(rows)
+            refresh_tree()
+
         def save_queue():
             fieldnames = [
                 "nazwa_karty",
@@ -1317,6 +1340,9 @@ class CardEditorApp:
         self.create_button(btn_frame, text="Dodaj", command=add_row).pack(
             side="left", padx=5
         )
+        self.create_button(
+            btn_frame, text="Wczytaj zaznaczone", command=import_selected
+        ).pack(side="left", padx=5)
         self.create_button(
             btn_frame, text="Usuń zaznaczone", command=remove_selected
         ).pack(side="left", padx=5)
@@ -1371,6 +1397,16 @@ class CardEditorApp:
         with open(path, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f, delimiter=";")
             self.auction_queue = list(reader)
+
+    def read_inventory_rows(self, codes, path=csv_utils.INVENTORY_CSV):
+        """Return rows from ``path`` filtered by ``codes``."""
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter=";")
+            rows = list(reader)
+        if codes:
+            wanted = {str(c) for c in codes}
+            rows = [r for r in rows if str(r.get("product_code")) in wanted]
+        return rows
 
     def _update_auction_status(self):
         """Update status panel with info from ``aktualna_aukcja.json``."""

--- a/tests/test_read_inventory_rows.py
+++ b/tests/test_read_inventory_rows.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import importlib
+import sys
+sys.modules.setdefault("customtkinter", MagicMock())
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+def test_read_inventory_rows_filters(tmp_path):
+    csv_path = tmp_path / "inv.csv"
+    csv_path.write_text(
+        "product_code;nazwa_karty;numer_karty;cena_początkowa\n1;A;1;10\n2;B;2;20\n",
+        encoding="utf-8",
+    )
+    dummy = SimpleNamespace()
+    rows = ui.CardEditorApp.read_inventory_rows(dummy, ["1"], str(csv_path))
+    assert len(rows) == 1
+    assert rows[0]["nazwa_karty"] == "A"
+    rows_all = ui.CardEditorApp.read_inventory_rows(dummy, [], str(csv_path))
+    assert len(rows_all) == 2


### PR DESCRIPTION
## Summary
- allow importing selected rows from inventory into auction queue
- expose helper method to read inventory data
- test reading inventory rows from CSV

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6887637ae03c832f8b88d02bf44c6b6c