### PR TITLE
Improve auction queue loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ Use the **Porządkuj** button to open a window with actions against your Shoper 
 ### Dashboard
 The welcome screen displays a small dashboard with store statistics fetched from your Shoper account: counts of new orders, pending shipments or payments and recent sales totals. To populate these fields the token must have permissions to read orders and statistics. Active product count is taken from the sales statistics when available, otherwise the application queries the inventory to determine the total number of products. Use the **Pokaż szczegóły** button to open the Shoper window with full functionality.
 
+### Inventory CSV format
+The auction queue reads cards from `magazyn.csv`. Preferred headers are
+`nazwa_karty`, `numer_karty`, `cena_początkowa`, `kwota_przebicia` and
+`czas_trwania`. When these columns are missing the loader also accepts a Shoper
+export with `name` and `price`. The last token of `name` is interpreted as the
+card number and the remaining text becomes the card name. Missing bidding step
+and duration values default to `1` and `60` seconds respectively.
+
 ### CSV and image upload
 After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to FTP using the credentials from `.env`. The exported CSV includes `images 1` and `warehouse_code` columns with the remote image path and storage location. A copy of every row is also appended to the file specified in `INVENTORY_CSV` so the full stock list remains in one place. Use the **FTP Obrazy** button on the welcome screen to upload a folder of images to the configured FTP server.
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1052,6 +1052,9 @@ class CardEditorApp:
                 "Błąd", f"Nie znaleziono pliku {csv_utils.INVENTORY_CSV}"
             )
             self.auction_queue = []
+        except ValueError as exc:
+            messagebox.showerror("Błąd", str(exc))
+            self.auction_queue = []
         except Exception as exc:
             messagebox.showerror("Błąd", str(exc))
             self.auction_queue = []
@@ -1183,14 +1186,14 @@ class CardEditorApp:
                     "",
                     "end",
                     values=(
-                        row["nazwa_karty"],
-                        row["cena_początkowa"],
+                        row.get("nazwa_karty"),
+                        row.get("cena_początkowa"),
                     ),
                 )
             if self.auction_queue:
                 nxt = self.auction_queue[0]
                 self.info_var.set(
-                    f"Następna karta: {nxt['nazwa_karty']} ({nxt['numer_karty']})"
+                    f"Następna karta: {nxt.get('nazwa_karty')} ({nxt.get('numer_karty')})"
                 )
             else:
                 self.info_var.set("Brak kart w kolejce")
@@ -1250,7 +1253,9 @@ class CardEditorApp:
             idx = tree.index(sel[0])
             if 0 <= idx < len(self.auction_queue):
                 row = self.auction_queue[idx]
-                path = row.get("images 1") or find_scan(row["nazwa_karty"], row["numer_karty"])
+                path = row.get("images 1") or find_scan(
+                    row.get("nazwa_karty", ""), row.get("numer_karty", "")
+                )
                 load_image(path)
 
         def add_row():
@@ -1323,12 +1328,12 @@ class CardEditorApp:
                 bot.aukcje_kolejka.clear()
                 for r in self.auction_queue:
                     aukcja = bot.Aukcja(
-                        r["nazwa_karty"],
-                        r["numer_karty"],
-                        r["opis"],
-                        r["cena_początkowa"],
-                        r["kwota_przebicia"],
-                        r["czas_trwania"],
+                        r.get("nazwa_karty"),
+                        r.get("numer_karty"),
+                        r.get("opis"),
+                        r.get("cena_początkowa"),
+                        r.get("kwota_przebicia"),
+                        r.get("czas_trwania"),
                     )
                     bot.aukcje_kolejka.append(aukcja)
             except Exception:
@@ -1405,15 +1410,35 @@ class CardEditorApp:
     def _load_auction_queue(self):
         """Load auction queue from ``magazyn.csv`` into ``self.auction_queue``."""
         path = csv_utils.INVENTORY_CSV
-        with open(path, newline="", encoding="utf-8") as f:
-            reader = csv.DictReader(f, delimiter=";")
-            self.auction_queue = list(reader)
+        self.auction_queue = self.read_inventory_rows([], path)
 
     def read_inventory_rows(self, codes, path=csv_utils.INVENTORY_CSV):
         """Return rows from ``path`` filtered by ``codes``."""
         with open(path, newline="", encoding="utf-8") as f:
-            reader = csv.DictReader(f, delimiter=";")
+            sample = f.read(2048)
+            f.seek(0)
+            try:
+                dialect = csv.Sniffer().sniff(sample, delimiters=";,")
+            except csv.Error:
+                dialect = csv.excel
+            reader = csv.DictReader(f, dialect=dialect)
             rows = list(reader)
+
+        headers = [h.strip().lower() for h in (reader.fieldnames or [])]
+        if "nazwa_karty" not in headers:
+            if "name" in headers:
+                for row in rows:
+                    if "nazwa_karty" not in row:
+                        parts = str(row.get("name", "")).strip().rsplit(" ", 1)
+                        if len(parts) == 2:
+                            row["nazwa_karty"], row["numer_karty"] = parts
+                        else:
+                            raise ValueError("Nie rozpoznano formatu pliku CSV")
+                    row["cena_początkowa"] = row.get("price", row.get("cena_początkowa", "0"))
+                    row.setdefault("kwota_przebicia", "1")
+                    row.setdefault("czas_trwania", "60")
+            else:
+                raise ValueError("Nie rozpoznano formatu pliku CSV")
         if codes:
             wanted = {str(c) for c in codes}
             rows = [r for r in rows if str(r.get("product_code")) in wanted]

--- a/tests/test_read_inventory_rows.py
+++ b/tests/test_read_inventory_rows.py
@@ -20,3 +20,17 @@ def test_read_inventory_rows_filters(tmp_path):
     assert rows[0]["nazwa_karty"] == "A"
     rows_all = ui.CardEditorApp.read_inventory_rows(dummy, [], str(csv_path))
     assert len(rows_all) == 2
+
+def test_read_inventory_rows_alt_headers(tmp_path):
+    csv_path = tmp_path / "inv.csv"
+    csv_path.write_text(
+        "product_code;name;price\n1;A 1;9\n", encoding="utf-8"
+    )
+    dummy = SimpleNamespace()
+    rows = ui.CardEditorApp.read_inventory_rows(dummy, [], str(csv_path))
+    assert rows[0]["nazwa_karty"] == "A"
+    assert rows[0]["numer_karty"] == "1"
+    assert rows[0]["cena_początkowa"] == "9"
+    assert rows[0]["kwota_przebicia"] == "1"
+    assert rows[0]["czas_trwania"] == "60"
+


### PR DESCRIPTION
## Summary
- load auction queue using `read_inventory_rows`
- support Shoper CSV exports without auction headers
- handle missing CSV fields safely in the UI
- document inventory CSV requirements
- test alternative header handling

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68876f678cfc832fbf414005fca4390e