### PR TITLE
Allow auction CSV rows without card numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ The auction queue reads cards from `magazyn.csv`. Preferred headers are
 `nazwa_karty`, `numer_karty`, `cena_początkowa`, `kwota_przebicia` and
 `czas_trwania`. When these columns are missing the loader also accepts a Shoper
 export with `name` and `price`. The last token of `name` is interpreted as the
-card number and the remaining text becomes the card name. Missing bidding step
-and duration values default to `1` and `60` seconds respectively.
+card number and the remaining text becomes the card name. If no number is
+present the entire value is used as the card name and the number field is left
+empty. Missing bidding step and duration values default to `1` and `60` seconds
+respectively.
 
 ### CSV and image upload
 After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to FTP using the credentials from `.env`. The exported CSV includes `images 1` and `warehouse_code` columns with the remote image path and storage location. A copy of every row is also appended to the file specified in `INVENTORY_CSV` so the full stock list remains in one place. Use the **FTP Obrazy** button on the welcome screen to upload a folder of images to the configured FTP server.

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1429,11 +1429,13 @@ class CardEditorApp:
             if "name" in headers:
                 for row in rows:
                     if "nazwa_karty" not in row:
-                        parts = str(row.get("name", "")).strip().rsplit(" ", 1)
-                        if len(parts) == 2:
+                        name_val = str(row.get("name", "")).strip()
+                        parts = name_val.rsplit(" ", 1)
+                        if len(parts) == 2 and re.search(r"\d", parts[1]):
                             row["nazwa_karty"], row["numer_karty"] = parts
                         else:
-                            raise ValueError("Nie rozpoznano formatu pliku CSV")
+                            row["nazwa_karty"] = name_val
+                            row["numer_karty"] = ""
                     row["cena_początkowa"] = row.get("price", row.get("cena_początkowa", "0"))
                     row.setdefault("kwota_przebicia", "1")
                     row.setdefault("czas_trwania", "60")

--- a/tests/test_read_inventory_rows.py
+++ b/tests/test_read_inventory_rows.py
@@ -34,3 +34,15 @@ def test_read_inventory_rows_alt_headers(tmp_path):
     assert rows[0]["kwota_przebicia"] == "1"
     assert rows[0]["czas_trwania"] == "60"
 
+
+def test_read_inventory_rows_name_without_number(tmp_path):
+    csv_path = tmp_path / "inv.csv"
+    csv_path.write_text(
+        "product_code;name;price\n1;Trainer Card;5\n",
+        encoding="utf-8",
+    )
+    dummy = SimpleNamespace()
+    rows = ui.CardEditorApp.read_inventory_rows(dummy, [], str(csv_path))
+    assert rows[0]["nazwa_karty"] == "Trainer Card"
+    assert rows[0]["numer_karty"] == ""
+


### PR DESCRIPTION
## Summary
- parse `name` values without a trailing number when loading auction queues
- document the fallback in the README
- test reading inventory rows that lack card numbers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875ec009b0832fa708655c3897b4c2