### PR TITLE
Improve inventory CSV header handling

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -83,6 +83,11 @@ def normalize(text: str, keep_spaces: bool = False) -> str:
     return text.strip()
 
 
+def norm_header(name: str) -> str:
+    """Return a normalized column name."""
+    return name.strip().lower()
+
+
 
 
 # Wczytanie danych setów
@@ -1427,9 +1432,11 @@ class CardEditorApp:
             except csv.Error:
                 dialect = csv.excel
             reader = csv.DictReader(f, dialect=dialect)
-            rows = list(reader)
+            rows = [
+                {norm_header(k): v for k, v in r.items()} for r in reader
+            ]
 
-        headers = [h.strip().lower() for h in (reader.fieldnames or [])]
+        headers = [norm_header(h) for h in (reader.fieldnames or [])]
         if "nazwa_karty" not in headers:
             if "name" in headers:
                 for row in rows:

--- a/tests/test_read_inventory_rows.py
+++ b/tests/test_read_inventory_rows.py
@@ -46,3 +46,16 @@ def test_read_inventory_rows_name_without_number(tmp_path):
     assert rows[0]["nazwa_karty"] == "Trainer Card"
     assert rows[0]["numer_karty"] == ""
 
+
+def test_read_inventory_rows_normalized_headers(tmp_path):
+    csv_path = tmp_path / "inv.csv"
+    csv_path.write_text(
+        "Product_Code;Nazwa_Karty;Numer_Karty;Cena_Początkowa\n1;A;1;5\n",
+        encoding="utf-8",
+    )
+    dummy = SimpleNamespace()
+    rows = ui.CardEditorApp.read_inventory_rows(dummy, [], str(csv_path))
+    assert rows[0]["nazwa_karty"] == "A"
+    assert rows[0]["numer_karty"] == "1"
+    assert rows[0]["cena_początkowa"] == "5"
+


### PR DESCRIPTION
## Summary
- normalize column names when reading inventory CSV
- add regression test for case-insensitive headers

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68877e5a32c0832f80a71d60f3175500