### PR TITLE
Fix CSV extra value handling

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -85,6 +85,8 @@ def normalize(text: str, keep_spaces: bool = False) -> str:
 
 def norm_header(name: str) -> str:
     """Return a normalized column name."""
+    if name is None:
+        return ""
     return name.strip().lower()
 
 
@@ -1433,7 +1435,8 @@ class CardEditorApp:
                 dialect = csv.excel
             reader = csv.DictReader(f, dialect=dialect)
             rows = [
-                {norm_header(k): v for k, v in r.items()} for r in reader
+                {norm_header(k): v for k, v in r.items() if k is not None}
+                for r in reader
             ]
 
         headers = [norm_header(h) for h in (reader.fieldnames or [])]

--- a/tests/test_read_inventory_rows.py
+++ b/tests/test_read_inventory_rows.py
@@ -59,3 +59,13 @@ def test_read_inventory_rows_normalized_headers(tmp_path):
     assert rows[0]["numer_karty"] == "1"
     assert rows[0]["cena_początkowa"] == "5"
 
+
+def test_read_inventory_rows_extra_values_ignored(tmp_path):
+    csv_path = tmp_path / "inv.csv"
+    csv_path.write_text(
+        'product_code;nazwa_karty\n"1";"A";"extra"\n', encoding="utf-8"
+    )
+    dummy = SimpleNamespace()
+    rows = ui.CardEditorApp.read_inventory_rows(dummy, [], str(csv_path))
+    assert rows == [{"product_code": "1", "nazwa_karty": "A"}]
+


### PR DESCRIPTION
## Summary
- handle `None` column names in `norm_header`
- ignore `None` keys when parsing CSV rows
- test that extra CSV values are ignored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887807340b8832f9d1268f47f0f083e