### PR TITLE
Enable inventory lookup in show_card

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1461,6 +1461,42 @@ class CardEditorApp:
             rows = [r for r in rows if str(r.get("product_code")) in wanted]
         return rows
 
+    def lookup_inventory_entry(self, key):
+        """Return first row from ``INVENTORY_CSV`` matching ``key``."""
+        try:
+            name, number, set_name = key.split("|", 2)
+        except ValueError:
+            return None
+
+        try:
+            with open(csv_utils.INVENTORY_CSV, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter=";")
+                for raw in reader:
+                    row = {norm_header(k): v for k, v in raw.items() if k is not None}
+                    row_name = (row.get("nazwa") or row.get("nazwa_karty") or row.get("name") or "").strip()
+                    row_number = (
+                        row.get("numer")
+                        or row.get("numer_karty")
+                        or row.get("number")
+                        or ""
+                    ).strip()
+                    row_set = row.get("set", "").strip()
+                    if (
+                        row_name == name and row_number == number and row_set == set_name
+                    ):
+                        result = {
+                            "nazwa": row_name,
+                            "numer": row_number,
+                            "set": row_set,
+                        }
+                        if "suffix" in row and row.get("suffix"):
+                            result["suffix"] = row.get("suffix", "").strip()
+                        return result
+        except FileNotFoundError:
+            return None
+
+        return None
+
     def _update_auction_status(self):
         """Update status panel with info from ``aktualna_aukcja.json``."""
         path = os.path.join("templates", "aktualna_aukcja.json")
@@ -2593,6 +2629,7 @@ class CardEditorApp:
         cache_key = self.file_to_key.get(os.path.basename(image_path))
         if not cache_key:
             cache_key = self._guess_key_from_filename(image_path)
+        inv_entry = self.lookup_inventory_entry(cache_key) if cache_key else None
         image = Image.open(image_path)
         image.thumbnail((400, 560))
         self.current_card_image = image.copy()
@@ -2626,6 +2663,7 @@ class CardEditorApp:
         for var in self.type_vars.values():
             var.set(False)
 
+        skip_analysis = False
         if cache_key and cache_key in self.card_cache:
             cached = self.card_cache[cache_key]
             for field, value in cached.get("entries", {}).items():
@@ -2642,14 +2680,24 @@ class CardEditorApp:
                     self.rarity_vars[name].set(val)
             self.update_set_options()
 
+        elif inv_entry:
+            self.entries["nazwa"].insert(0, inv_entry.get("nazwa", ""))
+            self.entries["numer"].insert(0, inv_entry.get("numer", ""))
+            self.entries["set"].set(inv_entry.get("set", ""))
+            if "suffix" in inv_entry:
+                self.entries.get("suffix").set(inv_entry.get("suffix", ""))
+            self.update_set_options()
+            skip_analysis = True
+
         folder = os.path.basename(os.path.dirname(image_path))
         remote_url = f"{BASE_IMAGE_URL}/{folder}/{os.path.basename(image_path)}"
-        self.start_scan_animation()
-        threading.Thread(
-            target=self._analyze_and_fill,
-            args=(remote_url, self.index),
-            daemon=True,
-        ).start()
+        if not skip_analysis:
+            self.start_scan_animation()
+            threading.Thread(
+                target=self._analyze_and_fill,
+                args=(remote_url, self.index),
+                daemon=True,
+            ).start()
 
         # focus the name entry so the user can start typing immediately
         self.entries["nazwa"].focus_set()

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -39,6 +39,7 @@ def test_show_card_uses_analyzer(tmp_path):
         card_cache={},
         file_to_key={},
         _guess_key_from_filename=lambda *a, **k: None,
+        lookup_inventory_entry=lambda *a, **k: None,
         update_set_options=lambda *a, **k: None,
     )
 
@@ -164,4 +165,64 @@ def test_analyze_and_fill_translates_for_jp(monkeypatch):
         ui.CardEditorApp._analyze_and_fill(dummy, "http://x", 0)
 
     name_entry.insert.assert_called_with(0, "Pikachu")
+
+
+def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;numer;set;suffix\nPikachu;001;Base;EX\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("INVENTORY_CSV", str(csv_path))
+    import importlib
+    import kartoteka.csv_utils as csv_utils
+    importlib.reload(csv_utils)
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    img = tmp_path / "card.jpg"
+    img.write_bytes(b"data")
+
+    name_entry = MagicMock()
+    num_entry = MagicMock()
+    set_var = MagicMock()
+    suffix_var = MagicMock()
+    name_entry.delete = MagicMock()
+    name_entry.insert = MagicMock()
+    name_entry.focus_set = MagicMock()
+    num_entry.delete = MagicMock()
+    num_entry.insert = MagicMock()
+    set_var.set = MagicMock()
+    suffix_var.set = MagicMock()
+
+    dummy = SimpleNamespace(
+        cards=[str(img)],
+        index=0,
+        image_objects=[],
+        image_label=MagicMock(),
+        progress_var=SimpleNamespace(set=lambda *a, **k: None),
+        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var, "suffix": suffix_var},
+        rarity_vars={},
+        type_vars={},
+        card_cache={},
+        file_to_key={img.name: "Pikachu|001|Base"},
+        _guess_key_from_filename=lambda *a, **k: None,
+        update_set_options=lambda *a, **k: None,
+    )
+
+    dummy.lookup_inventory_entry = ui.CardEditorApp.lookup_inventory_entry.__get__(dummy, ui.CardEditorApp)
+
+    dummy.start_scan_animation = lambda *a, **k: None
+    dummy.stop_scan_animation = lambda *a, **k: None
+
+    with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
+         patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
+         patch.object(ui, "analyze_card_image", return_value={}) as mock_analyze:
+        ui.CardEditorApp.show_card(dummy)
+
+    mock_analyze.assert_not_called()
+    name_entry.insert.assert_called_with(0, "Pikachu")
+    num_entry.insert.assert_called_with(0, "001")
+    set_var.set.assert_called_with("Base")
+    suffix_var.set.assert_called_with("EX")
 


### PR DESCRIPTION
## Summary
- implement `lookup_inventory_entry` to read inventory CSV and find matching card
- fill card fields from inventory before analyzing images
- test that analyzer is skipped when entry exists in inventory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68886f3c03ac832f87731904e7522bd3