### PR TITLE
Add attribute push to Shoper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Use the **Porządkuj** button to open a window with actions against your Shoper 
 ### Dashboard
 The welcome screen displays a small dashboard with store statistics fetched from your Shoper account: counts of new orders, pending shipments or payments and recent sales totals. To populate these fields the token must have permissions to read orders and statistics. Active product count is taken from the sales statistics when available, otherwise the application queries the inventory to determine the total number of products. Use the **Pokaż szczegóły** button to open the Shoper window with full functionality.
 
+### Product attributes
+When a card is sent to Shoper via **Wyślij produkt** the application also posts a `Typ` attribute for the new product. The attribute ID is looked up using `GET /attributes` on first use and cached for later calls. The value is built from all enabled type checkboxes (`Common`, `Holo`, `Reverse`, `Pokeball`, `Masterball`, `Stamp`) combined with the selected suffix (`EX`, `GX`, `V`, `VMAX`, `VSTAR`, `Shiny`, `Promo`).
+
 ### Inventory CSV format
 The auction queue reads cards from `magazyn.csv`. Preferred headers are
 `nazwa_karty`, `numer_karty`, `cena_początkowa`, `kwota_przebicia` and

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -998,6 +998,36 @@ class CardEditorApp:
 
             payload = self._build_shoper_payload(card)
             data = self.shoper_client.add_product(payload)
+            product_id = data.get("product_id") or data.get("id")
+            try:
+                attr_values = [
+                    name
+                    for name, var in self.type_vars.items()
+                    if getattr(var, "get", lambda: False)()
+                ]
+                suffix_var = self.entries.get("suffix")
+                if suffix_var is not None:
+                    suffix_val = getattr(suffix_var, "get", lambda: "")().strip()
+                    if suffix_val:
+                        attr_values.append(suffix_val)
+                if product_id and attr_values:
+                    cache = getattr(self, "_attribute_cache", {})
+                    attr_id = cache.get("Typ")
+                    if attr_id is None:
+                        attrs = self.shoper_client.get_attributes()
+                        for a in attrs.get("list", attrs):
+                            name = a.get("name")
+                            aid = a.get("attribute_id")
+                            if name and aid is not None:
+                                cache[name] = aid
+                        attr_id = cache.get("Typ")
+                        self._attribute_cache = cache
+                    if attr_id is not None:
+                        self.shoper_client.add_product_attribute(
+                            product_id, attr_id, attr_values
+                        )
+            except Exception:
+                pass
             if isinstance(widget, tk.Text):
                 widget.delete("1.0", tk.END)
                 widget.insert(tk.END, json.dumps(data, indent=2, ensure_ascii=False))

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -103,3 +103,16 @@ class ShoperClient:
         with open(file_path, "rb") as fh:
             files = {"file": (os.path.basename(file_path), fh, "text/csv")}
             return self.post("import/csv", files=files)
+
+    def get_attributes(self):
+        """Return a list of product attributes."""
+        return self.get("attributes")
+
+    def add_product_attribute(self, product_id, attribute_id, values):
+        """Assign a product attribute to a product."""
+        payload = {
+            "product_id": product_id,
+            "attribute_id": attribute_id,
+            "values": values,
+        }
+        return self.post("products-attributes", json=payload)

--- a/tests/test_push_product_attribute.py
+++ b/tests/test_push_product_attribute.py
@@ -1,0 +1,50 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+    def get(self):
+        return self.value
+
+class DummyText:
+    def delete(self, *a, **k):
+        pass
+    def insert(self, *a, **k):
+        pass
+
+
+def test_push_product_posts_attribute(monkeypatch):
+    fake_client = SimpleNamespace(
+        add_product=lambda data: {"product_id": 3},
+        get_attributes=lambda: {"list": [{"attribute_id": 2, "name": "Typ"}]},
+        add_product_attribute=MagicMock(),
+    )
+
+    dummy = SimpleNamespace(
+        output_data=[{"foo": "bar"}],
+        index=0,
+        save_current_data=lambda: None,
+        _build_shoper_payload=lambda card: {"name": "x"},
+        shoper_client=fake_client,
+        type_vars={"Reverse": DummyVar(True)},
+        entries={"suffix": DummyVar("V")},
+    )
+
+    monkeypatch.setattr(ui.messagebox, "showerror", lambda *a, **k: None)
+    monkeypatch.setattr(ui.messagebox, "showinfo", lambda *a, **k: None)
+    monkeypatch.setattr(ui.tk, "Text", DummyText, raising=False)
+    monkeypatch.setattr(ui.tk, "END", "end", raising=False)
+
+    widget = DummyText()
+    ui.CardEditorApp.push_product(dummy, widget)
+
+    fake_client.add_product_attribute.assert_called_once_with(3, 2, ["Reverse", "V"])

--- a/tests/test_shoper_client.py
+++ b/tests/test_shoper_client.py
@@ -7,3 +7,27 @@ def test_env_vars_trimmed(monkeypatch):
     client = ShoperClient()
     assert client.base_url == "https://example.com/webapi/rest"
     assert client.token == "tok"
+
+
+def test_client_endpoints(monkeypatch):
+    client = ShoperClient(base_url="https://shop", token="tok")
+    captured = {}
+
+    def fake_get(endpoint, **kwargs):
+        captured["get"] = endpoint
+        return {}
+
+    def fake_post(endpoint, **kwargs):
+        captured["post"] = (endpoint, kwargs.get("json"))
+        return {}
+
+    monkeypatch.setattr(client, "get", fake_get)
+    monkeypatch.setattr(client, "post", fake_post)
+
+    client.get_attributes()
+    client.add_product_attribute(1, 2, ["val"]) 
+
+    assert captured["get"] == "attributes"
+    assert captured["post"][0] == "products-attributes"
+    assert captured["post"][1]["product_id"] == 1
+    assert captured["post"][1]["attribute_id"] == 2


### PR DESCRIPTION
## Summary
- support new attributes endpoints in `shoper_client.py`
- push selected card type as product attribute when uploading a card
- test that new endpoints are called correctly and `push_product` posts attributes
- document attribute behaviour in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c318cad0832f9c85eff4071e3864