### PR TITLE
Support per-session CSV

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -9,6 +9,67 @@ FTP_USER = os.getenv("FTP_USER")
 FTP_PASSWORD = os.getenv("FTP_PASSWORD")
 INVENTORY_CSV = os.getenv("INVENTORY_CSV", "magazyn.csv")
 
+# column order for inventory CSV files
+INVENTORY_FIELDNAMES = [
+    "product_code",
+    "active",
+    "name",
+    "price",
+    "vat",
+    "unit",
+    "category",
+    "producer",
+    "other_price",
+    "pkwiu",
+    "weight",
+    "priority",
+    "short_description",
+    "description",
+    "stock",
+    "stock_warnlevel",
+    "availability",
+    "views",
+    "rank",
+    "rank_votes",
+    "images 1",
+    "warehouse_code",
+]
+
+
+def format_inventory_row(row):
+    """Return a row formatted for the inventory CSV."""
+    suffix = row.get("suffix", "").strip()
+    name_parts = [row["nazwa"]]
+    if suffix:
+        name_parts.append(suffix)
+    name_parts.append(row["numer"])
+    formatted_name = " ".join(name_parts)
+
+    return {
+        "product_code": row["product_code"],
+        "active": row.get("active", 1),
+        "name": formatted_name,
+        "price": row["cena"],
+        "vat": row.get("vat", "23%"),
+        "unit": row.get("unit", "szt."),
+        "category": row["category"],
+        "producer": row["producer"],
+        "other_price": row.get("other_price", ""),
+        "pkwiu": row.get("pkwiu", ""),
+        "weight": row.get("weight", 0.01),
+        "priority": row.get("priority", 0),
+        "short_description": row["short_description"],
+        "description": row["description"],
+        "stock": row.get("stock", 1),
+        "stock_warnlevel": row.get("stock_warnlevel", 0),
+        "availability": row.get("availability", 1),
+        "views": row.get("views", ""),
+        "rank": row.get("rank", ""),
+        "rank_votes": row.get("rank_votes", ""),
+        "images 1": row.get("image1", row.get("images", "")),
+        "warehouse_code": row.get("warehouse_code", ""),
+    }
+
 
 def load_csv_data(app):
     """Load a CSV file and merge duplicate rows."""
@@ -146,68 +207,13 @@ def export_csv(app):
             combined[key] = row.copy()
             combined[key]["stock"] = 1
 
-    fieldnames = [
-        "product_code",
-        "active",
-        "name",
-        "price",
-        "vat",
-        "unit",
-        "category",
-        "producer",
-        "other_price",
-        "pkwiu",
-        "weight",
-        "priority",
-        "short_description",
-        "description",
-        "stock",
-        "stock_warnlevel",
-        "availability",
-        "views",
-        "rank",
-        "rank_votes",
-        "images 1",
-    ]
-    fieldnames.append("warehouse_code")
+    fieldnames = INVENTORY_FIELDNAMES
 
     with open(file_path, mode="w", encoding="utf-8", newline="") as file:
         writer = csv.DictWriter(file, fieldnames=fieldnames, delimiter=";")
         writer.writeheader()
         for row in combined.values():
-            suffix = row.get("suffix", "").strip()
-            name_parts = [row["nazwa"]]
-            if suffix:
-                name_parts.append(suffix)
-            name_parts.append(row["numer"])
-            formatted_name = " ".join(name_parts)
-
-            writer.writerow(
-                {
-                    "product_code": row["product_code"],
-                    "active": row.get("active", 1),
-                    "name": formatted_name,
-                    "price": row["cena"],
-                    "vat": row.get("vat", "23%"),
-                    "unit": row.get("unit", "szt."),
-                    "category": row["category"],
-                    "producer": row["producer"],
-                    "other_price": row.get("other_price", ""),
-                    "pkwiu": row.get("pkwiu", ""),
-                    "weight": row.get("weight", 0.01),
-                    "priority": row.get("priority", 0),
-                    "short_description": row["short_description"],
-                    "description": row["description"],
-                    "stock": row["stock"],
-                    "stock_warnlevel": row.get("stock_warnlevel", 0),
-                    "availability": row.get("availability", 1),
-                    "views": row.get("views", ""),
-                    "rank": row.get("rank", ""),
-                    "rank_votes": row.get("rank_votes", ""),
-                    "images 1": row.get("image1", row.get("images", "")),
-                    "warehouse_code": row.get("warehouse_code", ""),
-                }
-            )
+            writer.writerow(format_inventory_row(row))
     append_inventory_csv(app)
     messagebox.showinfo("Sukces", "Plik CSV został zapisany.")
     if messagebox.askyesno("Wysyłka", "Czy wysłać plik do Shoper?"):
@@ -217,30 +223,7 @@ def export_csv(app):
 
 def append_inventory_csv(app, path: str = INVENTORY_CSV):
     """Append all collected rows to the inventory CSV."""
-    fieldnames = [
-        "product_code",
-        "active",
-        "name",
-        "price",
-        "vat",
-        "unit",
-        "category",
-        "producer",
-        "other_price",
-        "pkwiu",
-        "weight",
-        "priority",
-        "short_description",
-        "description",
-        "stock",
-        "stock_warnlevel",
-        "availability",
-        "views",
-        "rank",
-        "rank_votes",
-        "images 1",
-        "warehouse_code",
-    ]
+    fieldnames = INVENTORY_FIELDNAMES
 
     file_exists = os.path.exists(path)
     with open(path, "a", encoding="utf-8", newline="") as f:
@@ -250,39 +233,7 @@ def append_inventory_csv(app, path: str = INVENTORY_CSV):
         for row in app.output_data:
             if row is None:
                 continue
-            suffix = row.get("suffix", "").strip()
-            name_parts = [row["nazwa"]]
-            if suffix:
-                name_parts.append(suffix)
-            name_parts.append(row["numer"])
-            formatted_name = " ".join(name_parts)
-
-            writer.writerow(
-                {
-                    "product_code": row["product_code"],
-                    "active": row.get("active", 1),
-                    "name": formatted_name,
-                    "price": row["cena"],
-                    "vat": row.get("vat", "23%"),
-                    "unit": row.get("unit", "szt."),
-                    "category": row["category"],
-                    "producer": row["producer"],
-                    "other_price": row.get("other_price", ""),
-                    "pkwiu": row.get("pkwiu", ""),
-                    "weight": row.get("weight", 0.01),
-                    "priority": row.get("priority", 0),
-                    "short_description": row["short_description"],
-                    "description": row["description"],
-                    "stock": 1,
-                    "stock_warnlevel": row.get("stock_warnlevel", 0),
-                    "availability": row.get("availability", 1),
-                    "views": row.get("views", ""),
-                    "rank": row.get("rank", ""),
-                    "rank_votes": row.get("rank_votes", ""),
-                    "images 1": row.get("image1", row.get("images", "")),
-                    "warehouse_code": row.get("warehouse_code", ""),
-                }
-            )
+            writer.writerow(format_inventory_row(row))
 
 
 def send_csv_to_shoper(app, file_path: str):

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2621,6 +2621,22 @@ class CardEditorApp:
             if not folder:
                 return
             self.scan_folder_var.set(folder)
+        csv_path = getattr(self, "session_csv_path", None)
+        if not csv_path:
+            try:
+                csv_path = filedialog.asksaveasfilename(
+                    defaultextension=".csv", filetypes=[("CSV files", "*.csv")]
+                )
+            except tk.TclError:  # no display
+                csv_path = os.path.join(folder, "session.csv")
+            if not csv_path:
+                return
+            self.session_csv_path = csv_path
+            with open(csv_path, "w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(
+                    f, fieldnames=csv_utils.INVENTORY_FIELDNAMES, delimiter=";"
+                )
+                writer.writeheader()
         self.in_scan = True
         self.starting_idx = (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
         CardEditorApp.load_images(self, folder)
@@ -3517,6 +3533,14 @@ class CardEditorApp:
                 data["cena"] = ""
 
         self.output_data[self.index] = data
+        if getattr(self, "session_csv_path", None):
+            with open(self.session_csv_path, "a", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(
+                    f,
+                    fieldnames=csv_utils.INVENTORY_FIELDNAMES,
+                    delimiter=";",
+                )
+                writer.writerow(csv_utils.format_inventory_row(data))
 
     def save_and_next(self):
         """Save the current card data and display the next scan."""

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -1,0 +1,84 @@
+import csv
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+import kartoteka.csv_utils as csv_utils
+
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+def make_dummy():
+    return SimpleNamespace(
+        entries={
+            "nazwa": DummyVar("Charizard"),
+            "numer": DummyVar("4"),
+            "set": DummyVar("Base"),
+            "język": DummyVar("ENG"),
+            "stan": DummyVar("NM"),
+            "suffix": DummyVar(""),
+            "cena": DummyVar("")
+        },
+        type_vars={"Reverse": DummyVar(False), "Holo": DummyVar(False)},
+        rarity_vars={},
+        card_cache={},
+        cards=["/tmp/char.jpg"],
+        index=0,
+        folder_name="folder",
+        file_to_key={},
+        product_code_map={},
+        next_product_code=1,
+        next_free_location=lambda: "K1R1P1",
+        generate_location=lambda idx: "K1R1P1",
+        output_data=[None],
+        get_price_from_db=lambda *a: None,
+        fetch_card_price=lambda *a: None,
+    )
+
+
+def test_session_csv_created(tmp_path):
+    session_path = tmp_path / "session.csv"
+    dummy = SimpleNamespace(
+        start_box_var=DummyVar("1"),
+        start_col_var=DummyVar("1"),
+        start_pos_var=DummyVar("1"),
+        scan_folder_var=DummyVar("folder"),
+        load_images=lambda self, folder: None,
+    )
+
+    with patch.object(ui.CardEditorApp, "load_images", lambda self, folder: None), \
+         patch("tkinter.filedialog.asksaveasfilename", return_value=str(session_path)):
+        ui.CardEditorApp.browse_scans(dummy)
+
+    assert dummy.session_csv_path == str(session_path)
+    with open(session_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        assert reader.fieldnames == csv_utils.INVENTORY_FIELDNAMES
+
+
+def test_save_current_appends_session(tmp_path):
+    session_path = tmp_path / "session.csv"
+    dummy = make_dummy()
+    dummy.session_csv_path = str(session_path)
+    with open(session_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=csv_utils.INVENTORY_FIELDNAMES, delimiter=";")
+        writer.writeheader()
+
+    ui.CardEditorApp.save_current_data(dummy)
+
+    with open(session_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+        assert len(rows) == 1
+        assert rows[0]["name"]
+


### PR DESCRIPTION
## Summary
- log card rows to a new session CSV during scanning
- share inventory header/formatting helpers
- test that session CSV files are created and updated

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d3a16818832f8b535fdc8f911cfe