### PR TITLE
Add psa10_price column to inventory exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ When a card is sent to Shoper via **Wyślij produkt** the application also posts
 
 ### Inventory CSV format
 The auction queue reads cards from `magazyn.csv`. Preferred headers are
-`nazwa_karty`, `numer_karty`, `cena_początkowa`, `kwota_przebicia` and
+`nazwa_karty`, `numer_karty`, `cena_początkowa`, `psa10_price`, `kwota_przebicia` and
 `czas_trwania`. When these columns are missing the loader also accepts a Shoper
 export with `name` and `price`. The last token of `name` is interpreted as the
 card number and the remaining text becomes the card name. If no number is

--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -33,6 +33,7 @@ INVENTORY_FIELDNAMES = [
     "rank_votes",
     "images 1",
     "warehouse_code",
+    "psa10_price",
 ]
 
 
@@ -55,6 +56,7 @@ def format_inventory_row(row):
         "category": row["category"],
         "producer": row["producer"],
         "other_price": row.get("other_price", ""),
+        "psa10_price": row.get("psa10_price", ""),
         "pkwiu": row.get("pkwiu", ""),
         "weight": row.get("weight", 0.01),
         "priority": row.get("priority", 0),

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -26,6 +26,7 @@ def test_export_includes_warehouse(tmp_path):
             "description": "d",
             "warehouse_code": "K1R1P1",
             "image1": "img.jpg",
+            "psa10_price": "99",
         }]
     )
     dummy.back_to_welcome = lambda: None
@@ -39,10 +40,12 @@ def test_export_includes_warehouse(tmp_path):
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
         assert "warehouse_code" in reader.fieldnames
+        assert "psa10_price" in reader.fieldnames
         row = rows[0]
         assert row["warehouse_code"] == "K1R1P1"
         assert row["vat"] == "23%"
         assert row["unit"] == "szt."
+        assert row["psa10_price"] == "99"
 
 
 def test_export_appends_inventory(tmp_path, monkeypatch):
@@ -69,6 +72,7 @@ def test_export_appends_inventory(tmp_path, monkeypatch):
             "description": "d",
             "warehouse_code": "K1R1P1",
             "image1": "img.jpg",
+            "psa10_price": "99",
         }]
     )
     dummy.back_to_welcome = lambda: None
@@ -82,5 +86,6 @@ def test_export_appends_inventory(tmp_path, monkeypatch):
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
         assert rows[0]["warehouse_code"] == "K1R1P1"
+        assert rows[0]["psa10_price"] == "99"
 
 


### PR DESCRIPTION
## Summary
- include psa10_price in inventory CSV exports
- document psa10_price in preferred headers
- test csv export for psa10_price

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e72fe000c832fb8c6116e20bfc167