### PR TITLE
Remove legacy Pokémon card suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Use the **Porządkuj** button to open a window with actions against your Shoper 
 The welcome screen displays a small dashboard with store statistics fetched from your Shoper account: counts of new orders, pending shipments or payments and recent sales totals. To populate these fields the token must have permissions to read orders and statistics. Active product count is taken from the sales statistics when available, otherwise the application queries the inventory to determine the total number of products. Use the **Pokaż szczegóły** button to open the Shoper window with full functionality.
 
 ### Product attributes
-When a card is sent to Shoper via **Wyślij produkt** the application also posts a `Typ` attribute for the new product. The attribute ID is looked up using `GET /attributes` on first use and cached for later calls. The value is built from all enabled type checkboxes (`Common`, `Holo`, `Reverse`, `Pokeball`, `Masterball`, `Stamp`) combined with the selected suffix (`EX`, `GX`, `V`, `VMAX`, `VSTAR`, `Shiny`, `Promo`).
+When a card is sent to Shoper via **Wyślij produkt** the application also posts a `Typ` attribute for the new product. The attribute ID is looked up using `GET /attributes` on first use and cached for later calls. The value is built from all enabled type checkboxes (`Common`, `Holo`, `Reverse`, `Pokeball`, `Masterball`, `Stamp`) combined with the selected suffix (`Shiny`, `Promo`).
 
 ### Inventory CSV format
 The auction queue reads cards from `magazyn.csv`. Preferred headers are

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -68,11 +68,6 @@ def normalize(text: str, keep_spaces: bool = False) -> str:
     text = unicodedata.normalize("NFKD", text)
     text = text.lower()
     for suffix in [
-        " ex",
-        " gx",
-        " v",
-        " vmax",
-        " vstar",
         " shiny",
         " promo",
     ]:
@@ -268,7 +263,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
                         {
                             "type": "text",
                             "text": (
-                                "Extract Pokemon card name, number and suffix (EX, GX, V, VMAX, VSTAR, Shiny, Promo) as JSON {\"name\":\"\",\"number\":\"\",\"suffix\":\"\"}. Return empty suffix when not applicable."
+                                "Extract Pokemon card name, number and suffix (Shiny, Promo) as JSON {\"name\":\"\",\"number\":\"\",\"suffix\":\"\"}. Return empty suffix when not applicable."
                             ),
                         },
                         {"type": "image_url", "image_url": {"url": url}},
@@ -306,7 +301,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
         suffix = data.get("suffix", "").upper() if isinstance(data.get("suffix"), str) else ""
         if isinstance(name, str) and not suffix:
             parts = name.split()
-            if parts and parts[-1].upper() in {"EX", "GX", "V", "VMAX", "VSTAR", "SHINY", "PROMO"}:
+            if parts and parts[-1].upper() in {"SHINY", "PROMO"}:
                 suffix = parts[-1].upper()
                 name = " ".join(parts[:-1])
         if translate_name and isinstance(name, str) and not name.isascii():
@@ -2422,7 +2417,7 @@ class CardEditorApp:
         suffix_dropdown = ctk.CTkComboBox(
             self.info_frame,
             variable=self.suffix_var,
-            values=["", "EX", "GX", "V", "VMAX", "VSTAR", "Shiny", "Promo"],
+            values=["", "Shiny", "Promo"],
             width=20,
         )
         suffix_dropdown.grid(row=start_row + 6, column=1, sticky="ew", **grid_opts)

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -49,7 +49,7 @@ def test_show_card_uses_analyzer(tmp_path):
 
     with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
          patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
-        patch.object(ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "suffix": "V"}) as mock_analyze:
+        patch.object(ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "suffix": "Promo"}) as mock_analyze:
         ui.CardEditorApp.show_card(dummy)
 
     folder = os.path.basename(img.parent)
@@ -58,7 +58,7 @@ def test_show_card_uses_analyzer(tmp_path):
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "001")
     set_var.set.assert_called_with("")
-    suffix_var.set.assert_called_with("V")
+    suffix_var.set.assert_called_with("Promo")
 
 
 def test_analyze_card_image_bad_json(monkeypatch, capsys):
@@ -170,7 +170,7 @@ def test_analyze_and_fill_translates_for_jp(monkeypatch):
 def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;numer;set;suffix\nPikachu;001;Base;EX\n",
+        "name;numer;set;suffix\nPikachu;001;Base;Promo\n",
         encoding="utf-8",
     )
     monkeypatch.setenv("INVENTORY_CSV", str(csv_path))
@@ -224,5 +224,5 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     name_entry.insert.assert_called_with(0, "Pikachu")
     num_entry.insert.assert_called_with(0, "001")
     set_var.set.assert_called_with("Base")
-    suffix_var.set.assert_called_with("EX")
+    suffix_var.set.assert_called_with("Promo")
 

--- a/tests/test_push_product_attribute.py
+++ b/tests/test_push_product_attribute.py
@@ -36,7 +36,7 @@ def test_push_product_posts_attribute(monkeypatch):
         _build_shoper_payload=lambda card: {"name": "x"},
         shoper_client=fake_client,
         type_vars={"Reverse": DummyVar(True)},
-        entries={"suffix": DummyVar("V")},
+        entries={"suffix": DummyVar("Promo")},
     )
 
     monkeypatch.setattr(ui.messagebox, "showerror", lambda *a, **k: None)
@@ -47,4 +47,4 @@ def test_push_product_posts_attribute(monkeypatch):
     widget = DummyText()
     ui.CardEditorApp.push_product(dummy, widget)
 
-    fake_client.add_product_attribute.assert_called_once_with(3, 2, ["Reverse", "V"])
+    fake_client.add_product_attribute.assert_called_once_with(3, 2, ["Reverse", "Promo"])


### PR DESCRIPTION
## Summary
- Drop EX/GX/V/VMAX/VSTAR suffix support from normalization and card analysis, leaving only Shiny and Promo.
- Limit the suffix dropdown and docs to the remaining options.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3d103790832f9a6f77247e43fdf2