### PR TITLE
Add Promo card type and drop suffix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Use the **Porządkuj** button to open a window with actions against your Shoper 
 The welcome screen displays a small dashboard with store statistics fetched from your Shoper account: counts of new orders, pending shipments or payments and recent sales totals. To populate these fields the token must have permissions to read orders and statistics. Active product count is taken from the sales statistics when available, otherwise the application queries the inventory to determine the total number of products. Use the **Pokaż szczegóły** button to open the Shoper window with full functionality.
 
 ### Product attributes
-When a card is sent to Shoper via **Wyślij produkt** the application also posts a `Typ` attribute for the new product. The attribute ID is looked up using `GET /attributes` on first use and cached for later calls. The value is built from all enabled type checkboxes (`Common`, `Holo`, `Reverse`, `Pokeball`, `Masterball`, `Stamp`) combined with the selected suffix (`Shiny`, `Promo`).
+When a card is sent to Shoper via **Wyślij produkt** the application also posts a `Typ` attribute for the new product. The attribute ID is looked up using `GET /attributes` on first use and cached for later calls. The value is built from all enabled type checkboxes (`Common`, `Holo`, `Reverse`, `Pokeball`, `Masterball`, `Promo`, `Stamp`) combined with the selected suffix (`Shiny`).
 
 ### Inventory CSV format
 The auction queue reads cards from `magazyn.csv`. Preferred headers are

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -263,7 +263,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
                         {
                             "type": "text",
                             "text": (
-                                "Extract Pokemon card name, number and suffix (Shiny, Promo) as JSON {\"name\":\"\",\"number\":\"\",\"suffix\":\"\"}. Return empty suffix when not applicable."
+                                "Extract Pokemon card name, number and suffix (Shiny) as JSON {\"name\":\"\",\"number\":\"\",\"suffix\":\"\"}. Return empty suffix when not applicable."
                             ),
                         },
                         {"type": "image_url", "image_url": {"url": url}},
@@ -301,7 +301,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
         suffix = data.get("suffix", "").upper() if isinstance(data.get("suffix"), str) else ""
         if isinstance(name, str) and not suffix:
             parts = name.split()
-            if parts and parts[-1].upper() in {"SHINY", "PROMO"}:
+            if parts and parts[-1].upper() in {"SHINY"}:
                 suffix = parts[-1].upper()
                 name = " ".join(parts[:-1])
         if translate_name and isinstance(name, str) and not name.isascii():
@@ -2379,7 +2379,7 @@ class CardEditorApp:
         self.type_vars = {}
         self.type_frame = ctk.CTkFrame(self.info_frame)
         self.type_frame.grid(row=start_row + 4, column=1, columnspan=7, sticky="w", **grid_opts)
-        types = ["Common", "Holo", "Reverse", "Pokeball", "Masterball", "Stamp"]
+        types = ["Common", "Holo", "Reverse", "Pokeball", "Masterball", "Promo", "Stamp"]
         for t in types:
             var = tk.BooleanVar()
             self.type_vars[t] = var
@@ -2417,7 +2417,7 @@ class CardEditorApp:
         suffix_dropdown = ctk.CTkComboBox(
             self.info_frame,
             variable=self.suffix_var,
-            values=["", "Shiny", "Promo"],
+            values=["", "Shiny"],
             width=20,
         )
         suffix_dropdown.grid(row=start_row + 6, column=1, sticky="ew", **grid_opts)
@@ -2761,7 +2761,12 @@ class CardEditorApp:
             self.entries["numer"].insert(0, inv_entry.get("numer", ""))
             self.entries["set"].set(inv_entry.get("set", ""))
             if "suffix" in inv_entry:
-                self.entries.get("suffix").set(inv_entry.get("suffix", ""))
+                suffix_val = inv_entry.get("suffix", "")
+                if suffix_val.upper() == "PROMO" and "Promo" in self.type_vars:
+                    self.type_vars["Promo"].set(True)
+                    self.entries.get("suffix").set("")
+                else:
+                    self.entries.get("suffix").set(suffix_val)
             self.update_set_options()
             skip_analysis = True
 
@@ -2861,7 +2866,10 @@ class CardEditorApp:
             name = result.get("name", "")
             number = result.get("number", "")
             set_name = result.get("set", "")
-            suffix_val = result.get("suffix", "")
+            suffix_val = result.get("suffix", "").strip()
+            if suffix_val.upper() == "PROMO" and "Promo" in self.type_vars:
+                self.type_vars["Promo"].set(True)
+                suffix_val = ""
             self.entries["nazwa"].delete(0, tk.END)
             self.entries["nazwa"].insert(0, name)
             self.entries["numer"].delete(0, tk.END)

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -20,6 +20,9 @@ def test_show_card_uses_analyzer(tmp_path):
     num_entry = MagicMock()
     set_var = MagicMock()
     suffix_var = MagicMock()
+    promo_var = MagicMock()
+    promo_var.get = MagicMock(return_value=False)
+    promo_var.set = MagicMock()
     name_entry.delete = MagicMock()
     name_entry.insert = MagicMock()
     name_entry.focus_set = MagicMock()
@@ -35,7 +38,7 @@ def test_show_card_uses_analyzer(tmp_path):
         progress_var=SimpleNamespace(set=lambda *a, **k: None),
         entries={"nazwa": name_entry, "numer": num_entry, "set": set_var, "suffix": suffix_var},
         rarity_vars={},
-        type_vars={},
+        type_vars={"Promo": promo_var},
         card_cache={},
         file_to_key={},
         _guess_key_from_filename=lambda *a, **k: None,
@@ -58,7 +61,8 @@ def test_show_card_uses_analyzer(tmp_path):
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "001")
     set_var.set.assert_called_with("")
-    suffix_var.set.assert_called_with("Promo")
+    suffix_var.set.assert_called_with("")
+    promo_var.set.assert_called_with(True)
 
 
 def test_analyze_card_image_bad_json(monkeypatch, capsys):
@@ -187,6 +191,9 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     num_entry = MagicMock()
     set_var = MagicMock()
     suffix_var = MagicMock()
+    promo_var = MagicMock()
+    promo_var.get = MagicMock(return_value=False)
+    promo_var.set = MagicMock()
     name_entry.delete = MagicMock()
     name_entry.insert = MagicMock()
     name_entry.focus_set = MagicMock()
@@ -203,7 +210,7 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
         progress_var=SimpleNamespace(set=lambda *a, **k: None),
         entries={"nazwa": name_entry, "numer": num_entry, "set": set_var, "suffix": suffix_var},
         rarity_vars={},
-        type_vars={},
+        type_vars={"Promo": promo_var},
         card_cache={},
         file_to_key={img.name: "Pikachu|001|Base"},
         _guess_key_from_filename=lambda *a, **k: None,
@@ -224,5 +231,6 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     name_entry.insert.assert_called_with(0, "Pikachu")
     num_entry.insert.assert_called_with(0, "001")
     set_var.set.assert_called_with("Base")
-    suffix_var.set.assert_called_with("Promo")
+    suffix_var.set.assert_called_with("")
+    promo_var.set.assert_called_with(True)
 

--- a/tests/test_push_product_attribute.py
+++ b/tests/test_push_product_attribute.py
@@ -35,8 +35,8 @@ def test_push_product_posts_attribute(monkeypatch):
         save_current_data=lambda: None,
         _build_shoper_payload=lambda card: {"name": "x"},
         shoper_client=fake_client,
-        type_vars={"Reverse": DummyVar(True)},
-        entries={"suffix": DummyVar("Promo")},
+        type_vars={"Reverse": DummyVar(True), "Promo": DummyVar(True)},
+        entries={"suffix": DummyVar("")},
     )
 
     monkeypatch.setattr(ui.messagebox, "showerror", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- add Promo to card type checkboxes and remove Promo from suffix dropdown
- treat existing Promo suffix values as type flags
- document updated type and suffix usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f3eb02010832f9253a7fc5da65381