### PR TITLE
Embed Cardmarket search in app

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3521,13 +3521,28 @@ class CardEditorApp:
         tree.bind("<Double-1>", set_selected_price)
 
     def open_cardmarket_search(self):
-        """Open a Cardmarket search for the current card in the default browser."""
+        """Open a Cardmarket search for the current card inside the app."""
         name = self.entries["nazwa"].get()
         number = self.entries["numer"].get()
         search_terms = " ".join(t for t in [name, number] if t)
         params = urlencode({"searchString": search_terms})
         url = f"https://www.cardmarket.com/en/Pokemon/Products/Search?{params}"
-        webbrowser.open(url)
+
+        try:
+            from tkinterweb import HtmlFrame
+        except Exception:
+            webbrowser.open(url)
+            return
+
+        top = ctk.CTkToplevel(self.root)
+        top.title("Cardmarket Search")
+        top.geometry("800x600")
+
+        browser = HtmlFrame(top)
+        browser.pack(fill="both", expand=True)
+        browser.load_website(url)
+
+        self.create_button(top, text="Close", command=top.destroy).pack(pady=5)
 
     def get_exchange_rate(self):
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 python-dotenv
 customtkinter
 openai
+tkinterweb


### PR DESCRIPTION
## Summary
- embed Cardmarket search results in a CTkToplevel window using `tkinterweb`
- add `tkinterweb` to project dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f40d7c944832fa2255408497b3fb2