### PR TITLE
Handle missing tkinterweb dependency in Cardmarket search

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -23,7 +23,6 @@ from shoper_client import ShoperClient
 from ftp_client import FTPClient
 from . import csv_utils, storage
 import threading
-import webbrowser
 from urllib.parse import urlencode, urlparse
 import io
 
@@ -3530,8 +3529,13 @@ class CardEditorApp:
 
         try:
             from tkinterweb import HtmlFrame
-        except Exception:
-            webbrowser.open(url)
+        except ModuleNotFoundError:
+            messagebox.showwarning(
+                "Brak modułu",
+                "Moduł 'tkinterweb' nie jest zainstalowany.\n"
+                "Aby korzystać z wbudowanej przeglądarki, zainstaluj go poleceniem:\n"
+                "pip install tkinterweb",
+            )
             return
 
         top = ctk.CTkToplevel(self.root)


### PR DESCRIPTION
## Summary
- Display a warning if the `tkinterweb` module is missing instead of launching the system browser.
- Load Cardmarket search results inside the app using `HtmlFrame` when the module is available.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689055d26ba4832f97a26ab53cec76bf