### PR TITLE
Assign unique product codes sequentially

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -130,20 +130,8 @@ def load_csv_data(app):
             combined[key] = new_row
 
     for row in combined.values():
-        map_key = (
-            f"{row.get('nazwa', '').strip()}|{row.get('numer', '').strip()}|{row.get('set', '').strip()}"
-        )
-        code_str = str(row.get("product_code", "")).strip()
-        if map_key not in app.product_code_map:
-            if code_str.isdigit():
-                code_int = int(code_str)
-                app.product_code_map[map_key] = code_int
-                if code_int >= app.next_product_code:
-                    app.next_product_code = code_int + 1
-            else:
-                app.product_code_map[map_key] = app.next_product_code
-                app.next_product_code += 1
-        row["product_code"] = app.product_code_map[map_key]
+        row["product_code"] = app.next_product_code
+        app.next_product_code += 1
 
     if qty_field is None:
         qty_field = "ilość"

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3602,10 +3602,8 @@ class CardEditorApp:
         self.file_to_key[front_file] = key
 
         data["image1"] = f"{BASE_IMAGE_URL}/{self.folder_name}/{front_file}"
-        if key not in self.product_code_map:
-            self.product_code_map[key] = self.next_product_code
-            self.next_product_code += 1
-        data["product_code"] = self.product_code_map[key]
+        data["product_code"] = self.next_product_code
+        self.next_product_code += 1
         data["unit"] = "szt."
         data["category"] = f"Karty Pokémon > {data['set']}"
         data["producer"] = "Pokémon"

--- a/tests/test_csv_import.py
+++ b/tests/test_csv_import.py
@@ -39,7 +39,7 @@ def test_old_csv_location_pattern(tmp_path):
     row = rows[0]
     assert row["warehouse_code"] == "K1R1P1"
     assert row["product_code"] == "1"
-    assert dummy.product_code_map == {"Pikachu|1|Base": 1}
+    assert dummy.product_code_map == {}
     assert dummy.next_product_code == 2
 
 

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -52,3 +52,5 @@ def test_html_generated():
     assert data["short_description"].startswith("<p><strong>")
     assert "<li>" in data["short_description"]
     assert data["description"].count("<p>") >= 2
+    assert dummy.product_code_map == {}
+    assert dummy.next_product_code == 2


### PR DESCRIPTION
## Summary
- Remove product_code_map reuse: always assign the next available product code when saving data and increment the counter.
- Simplify CSV import to give each row a fresh product code independent of any map key.
- Update tests to reflect sequential product code generation.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890573dd470832fa71a6e4c191c381e