### PR TITLE
Simplify PSA10 price retrieval

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3263,7 +3263,6 @@ class CardEditorApp:
                         card.get("prices", {})
                         .get("cardmarket", {})
                         .get("graded", {})
-                        .get("psa", {})
                         .get("psa10")
                     )
                     try:


### PR DESCRIPTION
## Summary
- Simplify PSA10 price extraction from card data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689060ea8ea8832f9ca1c137abd5611b