### PR TITLE
Sanitize ambiguous set code in card analyzer

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -329,6 +329,8 @@ def analyze_card_image(path: str, translate_name: bool = False):
         name = data.get("name", "")
         suffix = data.get("suffix", "").upper() if isinstance(data.get("suffix"), str) else ""
         set_code = data.get("set", "") if isinstance(data.get("set"), str) else ""
+        if set_code.strip().upper() == "E":
+            set_code = ""
         if isinstance(name, str) and not suffix:
             parts = name.split()
             if parts and parts[-1].upper() in {"SHINY"}:

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -112,6 +112,21 @@ def test_analyze_card_image_with_set(monkeypatch):
     assert result == {"name": "Pikachu", "number": "1", "set": "Base", "suffix": ""}
 
 
+def test_analyze_card_image_sanitizes_e_set(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    content = '{"name": "Pikachu", "number": "001", "set": "E"}'
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+    with patch("openai.chat.completions.create", return_value=resp):
+        result = ui.analyze_card_image("/tmp/img.jpg")
+
+    assert result == {"name": "Pikachu", "number": "1", "set": "", "suffix": ""}
+
+
 def test_analyze_card_image_translate_name(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     importlib.reload(ui)


### PR DESCRIPTION
## Summary
- sanitize raw set code "E" to an empty string in `analyze_card_image`
- test that a model returning set "E" yields an empty set string

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890e655c7e4832fb1a701aaa4a2949e