### PR TITLE
Handle single-letter set codes

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -329,7 +329,8 @@ def analyze_card_image(path: str, translate_name: bool = False):
         name = data.get("name", "")
         suffix = data.get("suffix", "").upper() if isinstance(data.get("suffix"), str) else ""
         set_code = data.get("set", "") if isinstance(data.get("set"), str) else ""
-        if set_code.strip().upper() == "E":
+        stripped = set_code.strip()
+        if len(stripped) == 1 and stripped.isalpha():
             set_code = ""
         if isinstance(name, str) and not suffix:
             parts = name.split()

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -5,6 +5,7 @@ import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 import tkinter as tk
+import pytest
 
 sys.modules["customtkinter"] = SimpleNamespace(CTkEntry=tk.Entry, CTkImage=MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -112,11 +113,12 @@ def test_analyze_card_image_with_set(monkeypatch):
     assert result == {"name": "Pikachu", "number": "1", "set": "Base", "suffix": ""}
 
 
-def test_analyze_card_image_sanitizes_e_set(monkeypatch):
+@pytest.mark.parametrize("letter", ["E", "F"])
+def test_analyze_card_image_sanitizes_single_letter_set(monkeypatch, letter):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     importlib.reload(ui)
 
-    content = '{"name": "Pikachu", "number": "001", "set": "E"}'
+    content = f'{{"name": "Pikachu", "number": "001", "set": "{letter}"}}'
     resp = SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
     )


### PR DESCRIPTION
## Summary
- Sanitize `analyze_card_image` set codes: clear when only a single alphabetic character
- Parameterize tests to confirm single-letter set codes (E, F) are removed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890eb2f83a0832f97461fe3f10a5371