### PR TITLE
Improve JSON extraction from AI responses

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -270,6 +270,37 @@ def load_set_logo_uris(limit: int = 20) -> dict:
     return logos
 
 
+def extract_json_block(text: str) -> Optional[dict]:
+    """Return the first JSON object found in ``text``.
+
+    The function looks for a fenced `````json`` code block first, falling
+    back to scanning for the first ``{...}`` object.  ``None`` is returned
+    when no valid JSON can be decoded.
+    """
+
+    if not text:
+        return None
+
+    # Try fenced code block
+    fence = re.search(r"```json\s*([\s\S]*?)(```|$)", text)
+    if fence:
+        snippet = fence.group(1).strip()
+        try:
+            return json.loads(snippet)
+        except json.JSONDecodeError:
+            pass
+
+    # Fallback: search for first JSON object
+    decoder = json.JSONDecoder()
+    for match in re.finditer(r"\{", text):
+        try:
+            obj, _ = decoder.raw_decode(text[match.start():])
+            return obj
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
 def analyze_card_image(path: str, translate_name: bool = False):
     """Return card details recognized from the image using OpenAI."""
     if not OPENAI_API_KEY:
@@ -289,7 +320,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
             {
                 "type": "text",
                 "text": (
-                    "Extract Pokemon card name, number, suffix and set code as JSON {\"name\":\"\",\"number\":\"\",\"set\":\"\",\"suffix\":\"\"} by comparing the set symbol on the card with the provided set logos."
+                    "Extract Pokemon card name, number, suffix and set code as JSON {\"name\":\"\",\"number\":\"\",\"set\":\"\",\"suffix\":\"\"} by comparing the set symbol on the card with the provided set logos. Respond in JSON only."
                 ),
             },
             {"type": "image_url", "image_url": {"url": url}},
@@ -299,26 +330,13 @@ def analyze_card_image(path: str, translate_name: bool = False):
         resp = openai.chat.completions.create(
             model="gpt-4o",
             messages=[{"role": "user", "content": content}],
-            max_tokens=80,
+            max_tokens=150,
         )
         content = resp.choices[0].message.content
-        try:
-            data = json.loads(content)
-        except json.JSONDecodeError:
-            data = None
-
+        data = extract_json_block(content)
         if data is None:
-            # Remove Markdown code fences if present
-            text = content.strip()
-            if text.startswith("```"):
-                lines = text.splitlines()
-                if len(lines) >= 2 and lines[0].startswith("```") and lines[-1].startswith("```"):
-                    text = "\n".join(lines[1:-1]).strip()
-            try:
-                data = json.loads(text)
-            except json.JSONDecodeError as e:
-                print(f"[ERROR] analyze_card_image failed to decode JSON: {content!r} - {e}")
-                return {"name": "", "number": "", "set": "", "suffix": ""}
+            print(f"[ERROR] analyze_card_image failed to decode JSON: {content!r}")
+            return {"name": "", "number": "", "set": "", "suffix": ""}
 
         number = data.get("number", "")
         if isinstance(number, str):

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -83,11 +83,26 @@ def test_analyze_card_image_bad_json(monkeypatch, capsys):
     assert "not json" in output
 
 
-def test_analyze_card_image_code_block(monkeypatch):
+def test_analyze_card_image_truncated_code_block(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     importlib.reload(ui)
 
-    content = "```json\n{\"name\": \"Pikachu\", \"number\": \"037/159\"}\n```"
+    content = "```json\n{\"name\": \"Pikachu\", \"number\": \"037/159\"}"
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+    with patch("openai.chat.completions.create", return_value=resp):
+        result = ui.analyze_card_image("/tmp/img.jpg")
+
+    assert result == {"name": "Pikachu", "number": "37", "set": "", "suffix": ""}
+
+
+def test_analyze_card_image_leading_text(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    content = "Sure!\n{\"name\": \"Pikachu\", \"number\": \"037/159\"}\nThanks!"
     resp = SimpleNamespace(
         choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
     )


### PR DESCRIPTION
## Summary
- add `extract_json_block` helper to robustly parse JSON from AI output
- expand analyze_card_image prompt and increase token limit
- cover leading text and truncated code block scenarios in tests

## Testing
- `pytest tests/test_analyze_card_image.py::test_analyze_card_image_truncated_code_block -q`
- `pytest tests/test_analyze_card_image.py::test_analyze_card_image_leading_text -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890ebe21f00832fa407825e17092ec9