### PR TITLE
Load set logos on main thread

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2789,8 +2789,8 @@ class CardEditorApp:
     def startup_tasks(self):
         """Run initial setup tasks in the background."""
         self.update_sets()
-        self.load_set_logos()
-        self.root.after(0, self.finish_startup)
+        self.root.after(0, self.load_set_logos)
+        self.root.after(1, self.finish_startup)
 
     def finish_startup(self):
         """Finalize initialization after background tasks complete."""


### PR DESCRIPTION
## Summary
- Schedule set logo loading on the Tk main thread instead of from a worker thread

## Testing
- `pytest`
- `python - <<'PY'
import tkinter as tk
from kartoteka.ui import CardEditorApp
root = tk.Tk()
app = CardEditorApp(root)
app.startup_tasks()
root.update()
app.create_cheat_frame()
print('set logos loaded:', bool(app.set_logos))
root.destroy()
PY` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6890fbaf9374832f8fef7948eb25d88b