### PR TITLE
Include set labels with logos

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -325,7 +325,8 @@ def analyze_card_image(path: str, translate_name: bool = False):
             },
             {"type": "image_url", "image_url": {"url": url}},
         ]
-        for uri in logos.values():
+        for code, uri in logos.items():
+            content.append({"type": "text", "text": f"Set {code}"})
             content.append({"type": "image_url", "image_url": {"url": uri}})
         resp = openai.chat.completions.create(
             model="gpt-4o",

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -128,6 +128,25 @@ def test_analyze_card_image_with_set(monkeypatch):
     assert result == {"name": "Pikachu", "number": "1", "set": "Base", "suffix": ""}
 
 
+def test_analyze_card_image_includes_logo_labels(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    logos = {"ABC": "http://logo"}
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="{}"))]
+    )
+
+    with patch.object(ui, "load_set_logo_uris", return_value=logos), patch(
+        "openai.chat.completions.create", return_value=resp
+    ) as mock_create:
+        ui.analyze_card_image("http://example.com/img.jpg")
+
+    content = mock_create.call_args.kwargs["messages"][0]["content"]
+    assert content[2] == {"type": "text", "text": "Set ABC"}
+    assert content[3] == {"type": "image_url", "image_url": {"url": "http://logo"}}
+
+
 @pytest.mark.parametrize("letter", ["E", "F"])
 def test_analyze_card_image_sanitizes_single_letter_set(monkeypatch, letter):
     monkeypatch.setenv("OPENAI_API_KEY", "x")


### PR DESCRIPTION
## Summary
- Pass set logos to the analyzer as labeled text+image pairs to help model associate symbols with codes.
- Add regression test ensuring analyze_card_image sends logo labels alongside images.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891081a3cb8832fa53fa70d568921e5