### PR TITLE
Handle corrupt images gracefully

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2533,12 +2533,20 @@ class CardEditorApp:
         self.index = 0
         self.output_data = [None] * len(self.cards)
         self.card_counts = defaultdict(int)
+        self.failed_cards = []
         self.progress_var.set(f"0/{len(self.cards)}")
         self.log(f"Loaded {len(self.cards)} cards")
         self.show_card()
 
     def show_card(self):
         if self.index >= len(self.cards):
+            if getattr(self, "failed_cards", None):
+                msg = "Failed to load images:\n" + "\n".join(self.failed_cards)
+                print(msg, file=sys.stderr)
+                try:
+                    messagebox.showerror("Errors", msg)
+                except tk.TclError:
+                    pass
             messagebox.showinfo("Koniec", "Wszystkie karty zostały zapisane.")
             self.export_csv()
             return
@@ -2550,7 +2558,15 @@ class CardEditorApp:
         if not cache_key:
             cache_key = self._guess_key_from_filename(image_path)
         inv_entry = self.lookup_inventory_entry(cache_key) if cache_key else None
-        image = Image.open(image_path)
+        try:
+            image = Image.open(image_path)
+        except Exception as e:
+            print(f"Failed to load image {image_path}: {e}", file=sys.stderr)
+            if getattr(self, "failed_cards", None) is not None:
+                self.failed_cards.append(image_path)
+            self.index += 1
+            self.show_card()
+            return
         image.thumbnail((400, 560))
         self.current_card_image = image.copy()
         if hasattr(ctk, "CTkImage"):

--- a/tests/test_corrupt_image_handling.py
+++ b/tests/test_corrupt_image_handling.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import tkinter as tk
+
+sys.modules["customtkinter"] = SimpleNamespace(CTkEntry=tk.Entry, CTkImage=MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+
+def test_show_card_logs_corrupt_image(tmp_path, capsys):
+    img = tmp_path / "bad.jpg"
+    img.write_bytes(b"not an image")
+
+    dummy = SimpleNamespace(
+        cards=[str(img)],
+        index=0,
+        image_objects=[],
+        image_label=MagicMock(),
+        progress_var=SimpleNamespace(set=lambda *a, **k: None),
+        entries={},
+        rarity_vars={},
+        type_vars={},
+        card_cache={},
+        file_to_key={},
+        failed_cards=[],
+        _guess_key_from_filename=lambda *a, **k: None,
+        lookup_inventory_entry=lambda *a, **k: None,
+        export_csv=lambda *a, **k: None,
+    )
+    dummy.show_card = lambda: ui.CardEditorApp.show_card(dummy)
+
+    with patch.object(ui.Image, "open", side_effect=OSError("bad image")), \
+         patch.object(ui.messagebox, "showinfo"), \
+         patch.object(ui.messagebox, "showerror") as mock_error:
+        ui.CardEditorApp.show_card(dummy)
+
+    err = capsys.readouterr().err
+    assert "Failed to load image" in err
+    assert str(img) in err
+    assert dummy.failed_cards == [str(img)]
+    mock_error.assert_called_once()


### PR DESCRIPTION
## Summary
- handle failures in `CardEditorApp.show_card` by catching image loading errors, logging filenames to STDERR and summarizing failures on completion
- add regression test ensuring corrupt images are reported and skipped

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68910cde7c90832f8084a47884620fe2