### PR TITLE
Add set code matching helper

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -18,6 +18,7 @@ from dotenv import load_dotenv
 import unicodedata
 from itertools import combinations
 import html
+import difflib
 import sys
 from typing import Iterable, Optional
 
@@ -314,6 +315,36 @@ def load_set_logo_uris(
     return logos
 
 
+def match_set_code(value: str) -> str:
+    """Return a set code that matches available logo filenames.
+
+    The function performs an exact match against filenames in ``SET_LOGO_DIR``.
+    When no exact match is found, a fuzzy match is attempted.  An empty string
+    is returned if no suitable match is identified or when the logo directory
+    is missing.
+    """
+
+    if not value:
+        return ""
+    value = value.strip().lower()
+    if not value or not os.path.isdir(SET_LOGO_DIR):
+        return ""
+
+    codes = {
+        os.path.splitext(f)[0].lower()
+        for f in os.listdir(SET_LOGO_DIR)
+        if os.path.isfile(os.path.join(SET_LOGO_DIR, f))
+    }
+
+    if value in codes:
+        return value
+
+    match = difflib.get_close_matches(value, list(codes), n=1, cutoff=0.6)
+    if match:
+        return match[0]
+    return ""
+
+
 def extract_json_block(text: str) -> Optional[dict]:
     """Return the first JSON object found in ``text``.
 
@@ -394,6 +425,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
         stripped = set_code.strip()
         if len(stripped) == 1 and stripped.isalpha():
             set_code = ""
+        set_code = match_set_code(set_code)
         if translate_name and isinstance(name, str) and not name.isascii():
             name = translate_to_english(name)
         set_name = get_set_name(set_code)

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -156,6 +156,21 @@ def test_analyze_card_image_sanitizes_single_letter_set(monkeypatch, letter):
     assert result == {"name": "Pikachu", "number": "1", "set": ""}
 
 
+def test_analyze_card_image_unknown_set(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    content = '{"name": "Pikachu", "number": "001", "set": "unknown-set"}'
+    resp = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+    with patch("openai.chat.completions.create", return_value=resp):
+        result = ui.analyze_card_image("/tmp/img.jpg")
+
+    assert result == {"name": "Pikachu", "number": "1", "set": ""}
+
+
 def test_analyze_card_image_translate_name(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     importlib.reload(ui)

--- a/tests/test_match_set_code.py
+++ b/tests/test_match_set_code.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui  # noqa: E402
+importlib.reload(ui)  # ensure globals use stubbed modules
+
+
+def test_match_set_code_exact():
+    assert ui.match_set_code("swsh11") == "swsh11"
+    assert ui.match_set_code("SWSH11") == "swsh11"
+
+
+def test_match_set_code_fuzzy():
+    assert ui.match_set_code("swsh-11") == "swsh11"
+
+
+def test_match_set_code_unknown():
+    assert ui.match_set_code("unknown") == ""
+


### PR DESCRIPTION
## Summary
- add `match_set_code` to validate and fuzzy match set codes against available logos
- sanitize unknown set codes via `match_set_code` in `analyze_card_image`
- test helper and unknown set handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68911ec2eec0832fb9ae51b007defd52