### PR TITLE
Adapt Cardmarket search to TkinterWeb v4

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3356,7 +3356,7 @@ class CardEditorApp:
         url = f"https://www.cardmarket.com/en/Pokemon/Products/Search?{params}"
 
         try:
-            from tkinterweb import HtmlFrame
+            from tkinterweb import HtmlFrame, utilities
         except ModuleNotFoundError:
             messagebox.showwarning(
                 "Brak modułu",
@@ -3373,14 +3373,12 @@ class CardEditorApp:
         browser = HtmlFrame(top)
         browser.pack(fill="both", expand=True)
         try:
-            browser.load_website(
-                url,
-                useragent=(
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/115.0.0.0 Safari/537.36"
-                ),
+            utilities.HEADERS["User-Agent"] = (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/115.0.0.0 Safari/537.36"
             )
+            browser.load_website(url)
         except HTTPError as e:
             messagebox.showerror(
                 "Błąd", f"Nie udało się wczytać Cardmarket ({e.code})."


### PR DESCRIPTION
## Summary
- adjust `open_cardmarket_search` to use TkinterWeb v4 API
- set custom user agent via `tkinterweb.utilities.HEADERS` before loading Cardmarket

## Testing
- `pytest -q`
- `xvfb-run -a python - <<'PY'
import customtkinter as ctk
from kartoteka.ui import CardEditorApp
root = ctk.CTk(); app = object.__new__(CardEditorApp); app.root = root
app.create_button = lambda *a, **k: ctk.CTkButton(*a, **k)
app.entries={'nazwa': ctk.CTkEntry(root), 'numer': ctk.CTkEntry(root)}
app.open_cardmarket_search(); print('open_cardmarket_search executed')
root.after(1000, root.destroy); root.mainloop()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68912a32f0bc832f9252810092ee3289