### PR TITLE
Disable TkinterWeb debug messages in Cardmarket search

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3370,7 +3370,7 @@ class CardEditorApp:
         top.title("Cardmarket Search")
         top.geometry("800x600")
 
-        browser = HtmlFrame(top)
+        browser = HtmlFrame(top, messages_enabled=False)
         browser.pack(fill="both", expand=True)
         try:
             utilities.HEADERS["User-Agent"] = (


### PR DESCRIPTION
## Summary
- silence TkinterWeb debug output by disabling messages when creating the HtmlFrame in Cardmarket search dialog

## Testing
- `pytest`
- `xvfb-run -a python - <<'PY' ...` (open_cardmarket_search without debug output)

------
https://chatgpt.com/codex/tasks/task_e_68912ccc9f24832f97679db406a68f52