### PR TITLE
Adjust analyze_card_image tests for nested OpenAI response

### DIFF
--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -63,7 +63,7 @@ def test_analyze_card_image_bad_json(monkeypatch, capsys):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     importlib.reload(ui)
 
-    resp = SimpleNamespace(output=[])
+    resp = SimpleNamespace(output=[SimpleNamespace(content=[])])
     client = SimpleNamespace(responses=SimpleNamespace(parse=MagicMock(return_value=resp)))
 
     with patch("openai.OpenAI", return_value=client):


### PR DESCRIPTION
## Summary
- Refactor `test_analyze_card_image_bad_json` to use nested `content` structure matching updated OpenAI response schema.
- Ensures analyze_card_image test cases use the new nested schema.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689192256060832fac8e4d76457136aa