### PR TITLE
feat: prefer local set hash before OpenAI

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -55,6 +55,7 @@ PRICE_DB_PATH = "card_prices.csv"
 PRICE_MULTIPLIER = 1.23
 HOLO_REVERSE_MULTIPLIER = 3.5
 SET_LOGO_DIR = "set_logos"
+HASH_DIFF_THRESHOLD = 7
 
 DEFAULT_LOGO_LIMIT = 20
 try:
@@ -421,12 +422,28 @@ class CardData(BaseModel):
     name: str = ""
     number: str = ""
     set: str = ""
+
 def analyze_card_image(path: str, translate_name: bool = False):
     """Return card details recognized from the image using OpenAI."""
+    parsed = urlparse(path)
+    local_path = path if parsed.scheme not in ("http", "https") else None
+
+    # Try to identify the set using local logo hashes first
+    if local_path:
+        try:
+            with Image.open(local_path) as im:
+                w, h = im.size
+            matches = identify_set_by_hash(local_path, (0, 0, w, h))
+            if matches:
+                code, name, diff = matches[0]
+                if diff <= HASH_DIFF_THRESHOLD:
+                    return {"name": "", "number": "", "set": name}
+        except Exception:
+            pass
+
     if not OPENAI_API_KEY:
         return {"name": "", "number": "", "set": ""}
 
-    parsed = urlparse(path)
     if parsed.scheme in ("http", "https"):
         url = path
     else:

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -165,6 +165,18 @@ def test_analyze_card_image_unknown_set(monkeypatch):
     assert result == {"name": "Pikachu", "number": "1", "set": ""}
 
 
+def test_analyze_card_image_local_hash(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    importlib.reload(ui)
+
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "base1.png"
+    with patch("openai.OpenAI") as mock_openai:
+        result = ui.analyze_card_image(str(logo_path))
+
+    assert result == {"name": "", "number": "", "set": "Base Set"}
+    mock_openai.assert_not_called()
+
+
 def test_analyze_card_image_translate_name(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     importlib.reload(ui)


### PR DESCRIPTION
## Summary
- attempt local set detection via `identify_set_by_hash` before calling OpenAI
- use hash matches with low difference to set card set without OpenAI
- add unit test for local set detection path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a62417e8832f9cda66aa3390230c