### PR TITLE
Limit set logo operations to selected eras

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -145,7 +145,14 @@ def reload_sets():
 
 reload_sets()
 
-
+# Allowed eras and set codes used for logo operations
+ALLOWED_ERAS = {"Scarlet & Violet", "Sword & Shield", "Sun & Moon"}
+ALLOWED_SET_CODES = {
+    item["code"]
+    for era, sets in tcg_sets_eng_by_era.items()
+    if era in ALLOWED_ERAS
+    for item in sets
+}
 
 
 def get_set_code(name: str) -> str:
@@ -374,12 +381,15 @@ def identify_set_by_hash(
         for file in os.listdir(SET_LOGO_DIR):
             if not file.lower().endswith(".png"):
                 continue
+            code = os.path.splitext(file)[0]
+            if ALLOWED_SET_CODES and code not in ALLOWED_SET_CODES:
+                continue
             path = os.path.join(SET_LOGO_DIR, file)
             if not os.path.isfile(path):
                 continue
             try:
                 with Image.open(path) as im:
-                    logos[os.path.splitext(file)[0]] = (
+                    logos[code] = (
                         imagehash.phash(im),
                         imagehash.dhash(im),
                         imagehash.average_hash(im),
@@ -452,7 +462,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
         url = f"{BASE_IMAGE_URL}/{folder}/{filename}"
 
     try:
-        logos = load_set_logo_uris()
+        logos = load_set_logo_uris(available_sets=ALLOWED_SET_CODES)
         content = [
             {
                 "type": "input_text",
@@ -2913,6 +2923,8 @@ class CardEditorApp:
             if not file.lower().endswith((".png", ".jpg", ".jpeg", ".gif")):
                 continue
             code = os.path.splitext(file)[0]
+            if ALLOWED_SET_CODES and code not in ALLOWED_SET_CODES:
+                continue
             try:
                 img = Image.open(path)
                 img.thumbnail((40, 40))

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -169,11 +169,11 @@ def test_analyze_card_image_local_hash(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     importlib.reload(ui)
 
-    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "base1.png"
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "sv01.png"
     with patch("openai.OpenAI") as mock_openai:
         result = ui.analyze_card_image(str(logo_path))
 
-    assert result == {"name": "", "number": "", "set": "Base Set"}
+    assert result == {"name": "", "number": "", "set": "Scarlet & Violet"}
     mock_openai.assert_not_called()
 
 

--- a/tests/test_identify_set_by_hash.py
+++ b/tests/test_identify_set_by_hash.py
@@ -11,18 +11,18 @@ importlib.reload(ui)  # ensure globals use stubbed modules
 
 
 def test_identify_set_by_hash_match():
-    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "base1.png"
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "sv01.png"
     with Image.open(logo_path) as im:
         w, h = im.size
     matches = ui.identify_set_by_hash(str(logo_path), (0, 0, w, h))
     code, _name, diff = matches[0]
-    assert code == "base1"
+    assert code == "sv01"
     assert diff == 0
 
 
 def test_identify_set_by_hash_maps_code_to_name():
-    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "base1.png"
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "sv01.png"
     with Image.open(logo_path) as im:
         w, h = im.size
     matches = ui.identify_set_by_hash(str(logo_path), (0, 0, w, h))
-    assert matches[0][1] == "Base Set"
+    assert matches[0][1] == "Scarlet & Violet"


### PR DESCRIPTION
## Summary
- define allowed set eras and codes
- restrict identify_set_by_hash and load_set_logos to allowed sets
- only send OpenAI logos from allowed sets

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891b25d6b14832f9bfe89debe2c9471