### PR TITLE
Add OCR-based set code recognition

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -24,6 +24,7 @@ import difflib
 import sys
 from typing import Iterable, Optional
 from pydantic import BaseModel
+import pytesseract
 
 from shoper_client import ShoperClient
 from ftp_client import FTPClient
@@ -428,6 +429,47 @@ def identify_set_by_hash(
     return mapped
 
 
+def extract_set_code_ocr(
+    scan_path: str, rect: tuple[int, int, int, int]
+) -> list[tuple[str, str]]:
+    """Extract potential set codes from the scan using OCR.
+
+    Parameters
+    ----------
+    scan_path:
+        Path to the card scan image.
+    rect:
+        Bounding box ``(left, upper, right, lower)`` containing the expected
+        location of the set code.
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        List of tuples ``(code, set_name)`` recognized from the image. When no
+        codes are recognized the list is empty.
+    """
+
+    try:
+        with Image.open(scan_path) as im:
+            crop = im.crop(rect)
+        raw = pytesseract.image_to_string(crop)
+    except Exception:
+        return []
+
+    candidates: set[str] = set()
+    for token in re.split(r"\s+", raw.upper()):
+        token = re.sub(r"[^A-Z0-9]", "", token).strip()
+        if len(token) > 1:
+            candidates.add(token.lower())
+
+    results: list[tuple[str, str]] = []
+    for code in candidates:
+        name = tcg_sets_eng_code_map.get(code)
+        if name:
+            results.append((code, name))
+    return results
+
+
 class CardData(BaseModel):
     """Structured card information returned by the model."""
     name: str = ""
@@ -439,11 +481,25 @@ def analyze_card_image(path: str, translate_name: bool = False):
     parsed = urlparse(path)
     local_path = path if parsed.scheme not in ("http", "https") else None
 
-    # Try to identify the set using local logo hashes first
+    w = h = None
+    ocr_matches: list[tuple[str, str]] = []
     if local_path:
         try:
             with Image.open(local_path) as im:
                 w, h = im.size
+            rect = (0, int(h * 0.8), int(w * 0.3), h)
+            ocr_matches = extract_set_code_ocr(local_path, rect)
+            if len(ocr_matches) == 1:
+                return {"name": "", "number": "", "set": ocr_matches[0][1]}
+        except Exception:
+            ocr_matches = []
+
+    # Try to identify the set using local logo hashes if OCR failed
+    if local_path and not ocr_matches:
+        try:
+            if w is None or h is None:
+                with Image.open(local_path) as im:
+                    w, h = im.size
             matches = identify_set_by_hash(local_path, (0, 0, w, h))
             if matches:
                 code, name, diff = matches[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ customtkinter
 openai
 tkinterweb
 imagehash
+pytesseract

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -6,8 +6,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 import tkinter as tk
 import pytest
+from PIL import Image
 
 sys.modules["customtkinter"] = SimpleNamespace(CTkEntry=tk.Entry, CTkImage=MagicMock())
+sys.modules["pytesseract"] = SimpleNamespace(image_to_string=MagicMock(return_value=""))
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import kartoteka.ui as ui
 importlib.reload(ui)
@@ -60,6 +62,34 @@ def test_show_card_uses_analyzer(tmp_path):
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "001")
     set_var.set.assert_called_with(SV01_NAME)
+
+
+def test_analyze_card_image_ocr(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    importlib.reload(ui)
+
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
+
+    with patch.object(ui, "extract_set_code_ocr", return_value=[(SV01_CODE, SV01_NAME)]) as mock_ocr, \
+        patch.object(ui, "identify_set_by_hash") as mock_hash, \
+        patch("openai.OpenAI") as mock_openai:
+        result = ui.analyze_card_image(str(logo_path))
+
+    assert result == {"name": "", "number": "", "set": SV01_NAME}
+    mock_ocr.assert_called_once()
+    mock_hash.assert_not_called()
+    mock_openai.assert_not_called()
+
+
+def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
+    img = Image.new("RGB", (10, 10), color="white")
+    path = tmp_path / "img.png"
+    img.save(path)
+
+    with patch("pytesseract.image_to_string", return_value="E\nSV01\n"):
+        result = ui.extract_set_code_ocr(str(path), (0, 0, 10, 10))
+
+    assert result == [(SV01_CODE, SV01_NAME)]
 
 
 def test_analyze_card_image_bad_json(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- add `extract_set_code_ocr` to detect set codes via pytesseract
- integrate OCR into `analyze_card_image` before hash-based lookup
- extend tests for OCR path and single-letter filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891be84f2a4832fa24fbde5c3319e2d