### PR TITLE
Implement API-driven set selection with card number parsing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -594,7 +594,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
             rect = get_symbol_rect(w, h)
             ocr_matches = extract_set_code_ocr(local_path, rect)
             if len(ocr_matches) == 1:
-                return {"name": "", "number": "", "set": ocr_matches[0][1]}
+                return {"name": "", "number": "", "total": "", "set": ocr_matches[0][1]}
         except Exception:
             ocr_matches = []
 
@@ -608,12 +608,12 @@ def analyze_card_image(path: str, translate_name: bool = False):
             if matches:
                 code, name, diff = matches[0]
                 if diff <= HASH_DIFF_THRESHOLD:
-                    return {"name": "", "number": "", "set": name}
+                    return {"name": "", "number": "", "total": "", "set": name}
         except Exception:
             pass
 
     if not OPENAI_API_KEY:
-        return {"name": "", "number": "", "set": ""}
+        return {"name": "", "number": "", "total": "", "set": ""}
 
     if parsed.scheme in ("http", "https"):
         url = path
@@ -650,14 +650,19 @@ def analyze_card_image(path: str, translate_name: bool = False):
             or not getattr(resp.output[0].content[0], "parsed", None)
         ):
             print(f"[ERROR] analyze_card_image failed to parse response: {resp}")
-            return {"name": "", "number": "", "set": ""}
+            return {"name": "", "number": "", "total": "", "set": ""}
         data: CardData = resp.output[0].content[0].parsed
 
-        number = data.number or ""
-        if isinstance(number, str):
-            m = re.match(r"\D*(\d+)", number)
+        raw_number = data.number or ""
+        number = ""
+        total = ""
+        if isinstance(raw_number, str):
+            m = re.search(r"(\d+)(?:\s*/\s*(\d+))?", raw_number)
             if m:
-                number = str(int(m.group(1)))
+                number = m.group(1)
+                total = m.group(2) or ""
+            else:
+                number = re.sub(r"\D+", "", raw_number)
 
         name = data.name or ""
         set_code = data.set or ""
@@ -668,10 +673,10 @@ def analyze_card_image(path: str, translate_name: bool = False):
         if translate_name and isinstance(name, str) and not name.isascii():
             name = translate_to_english(name)
         set_name = get_set_name(set_code)
-        return {"name": name, "number": number, "set": set_name}
+        return {"name": name, "number": number, "total": total, "set": set_name}
     except Exception as e:
         print(f"[ERROR] analyze_card_image failed: {e}")
-        return {"name": "", "number": "", "set": ""}
+        return {"name": "", "number": "", "total": "", "set": ""}
 
 
 class CardEditorApp:
@@ -2958,6 +2963,11 @@ class CardEditorApp:
         if result:
             name = result.get("name", "")
             number = result.get("number", "")
+            total = result.get("total") or ""
+            if not total and isinstance(number, str):
+                m = re.match(r"(\d+)\s*/\s*(\d+)", number)
+                if m:
+                    number, total = m.group(1), m.group(2)
             set_name = result.get("set", "")
             self.entries["nazwa"].delete(0, tk.END)
             self.entries["nazwa"].insert(0, name)
@@ -2966,9 +2976,80 @@ class CardEditorApp:
             self.entries["set"].set(set_name)
             self.update_set_options()
 
-        # Allow the user to confirm the set using symbol hashes
+            try:
+                api_sets = lookup_sets_from_api(name, number, total or None)
+            except Exception:
+                api_sets = []
+
+            if len(api_sets) == 1:
+                self.entries["set"].set(api_sets[0][1])
+                self.update_set_options()
+                return
+            if len(api_sets) > 1 and hasattr(self, "prompt_set_selection_api"):
+                try:
+                    self.prompt_set_selection_api(api_sets)
+                except Exception:
+                    pass
+                return
+            if api_sets:
+                return
+
+        # Fallback to local hashing/OCR/AI
         if getattr(self, "current_image_path", "") and hasattr(self, "prompt_set_selection"):
-            self.prompt_set_selection(self.current_image_path)
+            try:
+                self.prompt_set_selection(self.current_image_path)
+            except Exception:
+                pass
+
+    def prompt_set_selection_api(self, options):
+        """Display a simple selection dialog for API-provided sets."""
+        if not options:
+            return
+
+        def apply(name: str):
+            try:
+                self.entries["set"].set(name)
+            except Exception:
+                entry = self.entries.get("set")
+                if entry:
+                    try:
+                        entry.delete(0, tk.END)
+                        entry.insert(0, name)
+                    except Exception:
+                        pass
+            try:
+                self.update_set_options()
+            except Exception:
+                pass
+
+        try:
+            top = ctk.CTkToplevel(self.root, fg_color=BG_COLOR)
+        except Exception:
+            apply(options[0][1])
+            return
+
+        top.title("Wybierz set")
+        for code, name in options:
+            btn = ctk.CTkButton(
+                top,
+                text=name,
+                fg_color=ACCENT_COLOR,
+                hover_color=HOVER_COLOR,
+                command=lambda n=name: (apply(n), top.destroy()),
+            )
+            btn.pack(padx=10, pady=5, fill="x")
+
+        try:
+            top.update_idletasks()
+            w = top.winfo_width()
+            h = top.winfo_height()
+            x = int(top.winfo_screenwidth() / 2 - w / 2)
+            y = int(top.winfo_screenheight() / 2 - h / 2)
+            top.geometry(f"{w}x{h}+{x}+{y}")
+            top.focus_force()
+            top.grab_set()
+        except Exception:
+            pass
 
     def prompt_set_selection(self, scan_path: str):
         """Display a dialog with candidate set logos for manual selection."""

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -75,7 +75,7 @@ def test_analyze_card_image_ocr(monkeypatch):
         patch("openai.OpenAI") as mock_openai:
         result = ui.analyze_card_image(str(logo_path))
 
-    assert result == {"name": "", "number": "", "set": SV01_NAME}
+    assert result == {"name": "", "number": "", "total": "", "set": SV01_NAME}
     mock_ocr.assert_called_once()
     mock_hash.assert_not_called()
     mock_openai.assert_not_called()
@@ -103,7 +103,7 @@ def test_analyze_card_image_bad_json(monkeypatch, capsys):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
     output = capsys.readouterr().out
-    assert result == {"name": "", "number": "", "set": ""}
+    assert result == {"name": "", "number": "", "total": "", "set": ""}
     assert "analyze_card_image failed to parse response" in output
 
 
@@ -118,7 +118,7 @@ def test_analyze_card_image_truncated_code_block(monkeypatch):
     with patch("openai.OpenAI", return_value=client):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
-    assert result == {"name": "Pikachu", "number": "37", "set": ""}
+    assert result == {"name": "Pikachu", "number": "037", "total": "159", "set": ""}
 
 
 def test_analyze_card_image_leading_text(monkeypatch):
@@ -132,7 +132,7 @@ def test_analyze_card_image_leading_text(monkeypatch):
     with patch("openai.OpenAI", return_value=client):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
-    assert result == {"name": "Pikachu", "number": "37", "set": ""}
+    assert result == {"name": "Pikachu", "number": "037", "total": "159", "set": ""}
 
 
 def test_analyze_card_image_with_set(monkeypatch):
@@ -147,7 +147,7 @@ def test_analyze_card_image_with_set(monkeypatch):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
     expected_name = ui.get_set_name("swsh11")
-    assert result == {"name": "Pikachu", "number": "1", "set": expected_name}
+    assert result == {"name": "Pikachu", "number": "001", "total": "", "set": expected_name}
 
 
 def test_analyze_card_image_includes_logo_labels(monkeypatch):
@@ -182,7 +182,7 @@ def test_analyze_card_image_sanitizes_single_letter_set(monkeypatch, letter):
     with patch("openai.OpenAI", return_value=client):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
-    assert result == {"name": "Pikachu", "number": "1", "set": ""}
+    assert result == {"name": "Pikachu", "number": "001", "total": "", "set": ""}
 
 
 def test_analyze_card_image_unknown_set(monkeypatch):
@@ -196,7 +196,7 @@ def test_analyze_card_image_unknown_set(monkeypatch):
     with patch("openai.OpenAI", return_value=client):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
-    assert result == {"name": "Pikachu", "number": "1", "set": ""}
+    assert result == {"name": "Pikachu", "number": "001", "total": "", "set": ""}
 
 
 def test_analyze_card_image_local_hash(monkeypatch):
@@ -207,7 +207,7 @@ def test_analyze_card_image_local_hash(monkeypatch):
     with patch("openai.OpenAI") as mock_openai:
         result = ui.analyze_card_image(str(logo_path))
 
-    assert result == {"name": "", "number": "", "set": SV01_NAME}
+    assert result == {"name": "", "number": "", "total": "", "set": SV01_NAME}
     mock_openai.assert_not_called()
 
 
@@ -227,7 +227,7 @@ def test_analyze_card_image_translate_name(monkeypatch):
     ) as mock_create:
         result = ui.analyze_card_image("/tmp/img.jpg", translate_name=True)
 
-    assert result == {"name": "Pikachu", "number": "37", "set": ""}
+    assert result == {"name": "Pikachu", "number": "037", "total": "159", "set": ""}
     mock_create.assert_called_once()
 
 
@@ -269,7 +269,7 @@ def test_analyze_and_fill_translates_for_jp(monkeypatch):
 
     with patch("openai.OpenAI", return_value=client), patch(
         "openai.chat.completions.create", return_value=resp_translate
-    ):
+    ), patch.object(ui, "lookup_sets_from_api", return_value=[]):
         ui.CardEditorApp._analyze_and_fill(dummy, "http://x", 0)
 
     name_entry.insert.assert_called_with(0, "Pikachu")

--- a/tests/test_apply_analysis_result.py
+++ b/tests/test_apply_analysis_result.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import kartoteka.ui as ui
+
+
+def make_dummy():
+    name_entry = MagicMock()
+    num_entry = MagicMock()
+    set_var = MagicMock()
+    name_entry.delete = MagicMock()
+    name_entry.insert = MagicMock()
+    num_entry.delete = MagicMock()
+    num_entry.insert = MagicMock()
+    set_var.set = MagicMock()
+    dummy = SimpleNamespace(
+        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var},
+        root=SimpleNamespace(),
+        index=0,
+        stop_scan_animation=lambda: None,
+        update_set_options=lambda: None,
+        current_image_path="/tmp/img.jpg",
+    )
+    dummy._apply_analysis_result = ui.CardEditorApp._apply_analysis_result.__get__(dummy, ui.CardEditorApp)
+    dummy.prompt_set_selection_api = MagicMock()
+    dummy.prompt_set_selection = MagicMock()
+    return dummy, name_entry, num_entry, set_var
+
+
+def test_apply_analysis_result_single_set(monkeypatch):
+    dummy, _n, _num, set_var = make_dummy()
+    captured = {}
+
+    def fake_lookup(name, number, total):
+        captured["args"] = (name, number, total)
+        return [("sv01", "Scarlet & Violet")]
+
+    monkeypatch.setattr(ui, "lookup_sets_from_api", fake_lookup)
+
+    dummy._apply_analysis_result({"name": "Pikachu", "number": "037/159", "set": ""}, 0)
+    assert captured["args"] == ("Pikachu", "037", "159")
+    set_var.set.assert_called_with("Scarlet & Violet")
+    dummy.prompt_set_selection_api.assert_not_called()
+    dummy.prompt_set_selection.assert_not_called()
+
+
+def test_apply_analysis_result_multiple_sets(monkeypatch):
+    dummy, _n, _num, _set = make_dummy()
+    options = [("a", "Set A"), ("b", "Set B")]
+    monkeypatch.setattr(ui, "lookup_sets_from_api", lambda n, num, total: options)
+
+    dummy._apply_analysis_result({"name": "Pikachu", "number": "037", "total": "159", "set": ""}, 0)
+    dummy.prompt_set_selection_api.assert_called_once_with(options)
+    dummy.prompt_set_selection.assert_not_called()
+
+
+def test_apply_analysis_result_fallback(monkeypatch):
+    dummy, _n, _num, _set = make_dummy()
+    monkeypatch.setattr(ui, "lookup_sets_from_api", lambda n, num, total: [])
+
+    dummy._apply_analysis_result({"name": "Pikachu", "number": "037", "total": "159", "set": ""}, 0)
+    dummy.prompt_set_selection.assert_called_once_with("/tmp/img.jpg")


### PR DESCRIPTION
## Summary
- Split card numbers like `037/159` into separate `number` and `total` fields when analyzing images.
- Query `lookup_sets_from_api` during result application and branch to auto-select, prompt selection, or local fallback based on API results.
- Provide a `prompt_set_selection_api` helper to display choices and new tests covering API-driven set selection scenarios.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891d3b34d88832fb09cdf15e9b17cc0