### PR TITLE
warn when set code not recognized

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -178,6 +178,7 @@ def get_set_name(code: str) -> str:
         for key, name in mapping.items():
             if key.lower() == search:
                 return name
+    print(f"Nie znaleziono nazwy dla setu '{code}'. Weryfikacja ręczna wymagana.")
     return code
 
 
@@ -527,8 +528,6 @@ def identify_set_by_hash(
     mapped: list[tuple[str, str, int]] = []
     for code, diff in results[:3]:
         name = get_set_name(code)
-        if name == code:
-            print(f"Nie znaleziono nazwy dla setu '{code}'. Weryfikacja ręczna wymagana.")
         mapped.append((code, name, diff))
     return mapped
 

--- a/tests/test_get_set_name.py
+++ b/tests/test_get_set_name.py
@@ -1,0 +1,17 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui  # noqa: E402
+importlib.reload(ui)  # ensure globals use stubbed modules
+
+
+def test_get_set_name_unknown_triggers_warning(capsys):
+    code = "not_in_map"
+    result = ui.get_set_name(code)
+    captured = capsys.readouterr()
+    assert result == code
+    assert "Weryfikacja ręczna wymagana" in captured.out


### PR DESCRIPTION
## Summary
- alert when get_set_name fails to map code to a known set, prompting manual selection
- streamline identify_set_by_hash to rely on get_set_name mapping
- cover missing-set warning with a unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891da6995f8832fa1002754c9bea1a2