### PR TITLE
Remove leading zeros from card numbers

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -98,6 +98,19 @@ def norm_header(name: str) -> str:
     return name.strip().lower()
 
 
+def sanitize_number(value: str) -> str:
+    """Remove leading zeros from a number string.
+
+    Returns
+    -------
+    str
+        ``value`` without leading zeros or ``"0"`` if the result is
+        empty.
+    """
+
+    return value.lstrip("0") or "0"
+
+
 
 
 # Wczytanie danych setów
@@ -2853,6 +2866,8 @@ class CardEditorApp:
             for field, value in cached.get("entries", {}).items():
                 entry = self.entries.get(field)
                 if isinstance(entry, (tk.Entry, ctk.CTkEntry)):
+                    if field == "numer":
+                        value = sanitize_number(str(value))
                     entry.insert(0, value)
                 elif isinstance(entry, tk.StringVar):
                     entry.set(value)
@@ -2863,7 +2878,9 @@ class CardEditorApp:
 
         elif inv_entry:
             self.entries["nazwa"].insert(0, inv_entry.get("nazwa", ""))
-            self.entries["numer"].insert(0, inv_entry.get("numer", ""))
+            self.entries["numer"].insert(
+                0, sanitize_number(str(inv_entry.get("numer", "")))
+            )
             self.entries["set"].set(inv_entry.get("set", ""))
             self.update_set_options()
             skip_analysis = True
@@ -2983,6 +3000,7 @@ class CardEditorApp:
                 if m:
                     number, total = m.group(1), m.group(2)
             set_name = result.get("set", "")
+            number = sanitize_number(str(number))
             self.entries["nazwa"].delete(0, tk.END)
             self.entries["nazwa"].insert(0, name)
             self.entries["numer"].delete(0, tk.END)
@@ -3744,7 +3762,7 @@ class CardEditorApp:
 
     def fetch_card_data(self):
         name = self.entries["nazwa"].get()
-        number = self.entries["numer"].get()
+        number = sanitize_number(self.entries["numer"].get())
         set_name = self.entries["set"].get()
 
         is_reverse = self.type_vars["Reverse"].get()
@@ -3785,7 +3803,7 @@ class CardEditorApp:
     def show_variants(self):
         """Display a list of matching cards from the API."""
         name = self.entries["nazwa"].get()
-        number = self.entries["numer"].get()
+        number = sanitize_number(self.entries["numer"].get())
         set_name = self.entries["set"].get()
 
         is_reverse = self.type_vars["Reverse"].get()
@@ -3840,7 +3858,7 @@ class CardEditorApp:
     def open_cardmarket_search(self):
         """Open a Cardmarket search for the current card inside the app."""
         name = self.entries["nazwa"].get()
-        number = self.entries["numer"].get()
+        number = sanitize_number(self.entries["numer"].get())
         search_terms = " ".join(t for t in [name, number] if t)
         params = urlencode({"searchString": search_terms})
         url = f"https://www.cardmarket.com/en/Pokemon/Products/Search?{params}"

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -67,7 +67,7 @@ def test_show_card_uses_analyzer(tmp_path):
     expected_url = f"{ui.BASE_IMAGE_URL}/{folder}/{img.name}"
     mock_analyze.assert_called_once_with(expected_url)
     name_entry.insert.assert_called_with(0, "Pika")
-    num_entry.insert.assert_called_with(0, "001")
+    num_entry.insert.assert_called_with(0, "1")
     set_var.set.assert_called_with(SV01_NAME)
     dummy.prompt_set_selection_api.assert_not_called()
 
@@ -339,6 +339,6 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
 
     mock_analyze.assert_not_called()
     name_entry.insert.assert_called_with(0, "Pikachu")
-    num_entry.insert.assert_called_with(0, "001")
+    num_entry.insert.assert_called_with(0, "1")
     set_var.set.assert_called_with(SV01_NAME)
 

--- a/tests/test_apply_analysis_result.py
+++ b/tests/test_apply_analysis_result.py
@@ -37,7 +37,7 @@ def test_apply_analysis_result_single_set(monkeypatch):
     monkeypatch.setattr(ui, "lookup_sets_from_api", fake_lookup)
 
     dummy._apply_analysis_result({"name": "Pikachu", "number": "037/159", "set": ""}, 0)
-    assert captured["args"] == ("Pikachu", "037", "159")
+    assert captured["args"] == ("Pikachu", "37", "159")
     set_var.set.assert_called_with("Scarlet & Violet")
     dummy.prompt_set_selection_api.assert_not_called()
     dummy.prompt_set_selection.assert_not_called()


### PR DESCRIPTION
## Summary
- add `sanitize_number` helper for trimming leading zeros
- sanitize card numbers when inserting into or reading from GUI fields
- adjust tests for normalized card numbers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e3658a18832f8a4808096a30f6c7