### PR TITLE
Crop set symbol from bottom left

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -480,7 +480,7 @@ def match_set_code(value: str) -> str:
 def get_symbol_rect(w: int, h: int) -> tuple[int, int, int, int]:
     """Return a rectangle around the expected set symbol location.
 
-    The symbol is typically located near the bottom-right corner of a card.
+    The symbol is typically located near the bottom-left corner of a card.
     For very small images (e.g. stand-alone set logos) the entire image is
     returned to ensure matching still works in tests and for direct logo
     comparisons.
@@ -490,9 +490,9 @@ def get_symbol_rect(w: int, h: int) -> tuple[int, int, int, int]:
     if w <= 100 and h <= 100:
         return (0, 0, w, h)
 
-    left = int(w * 0.7)
     upper = int(h * 0.8)
-    return (left, upper, w, h)
+    right = int(w * 0.3)
+    return (0, upper, right, h)
 
 
 def identify_set_by_hash(

--- a/tests/test_get_symbol_rect.py
+++ b/tests/test_get_symbol_rect.py
@@ -1,0 +1,14 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+
+def test_get_symbol_rect_bottom_left():
+    w, h = 1000, 1400
+    assert ui.get_symbol_rect(w, h) == (0, int(h * 0.8), int(w * 0.3), h)


### PR DESCRIPTION
## Summary
- adjust get_symbol_rect to crop bottom-left corner of full card images
- document new crop location and add test for typical card dimensions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891ec9ac830832f881a318475e981d1