### PR TITLE
Use API to resolve card sets before local fallback

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -301,6 +301,65 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
     return result
 
 
+def prompt_set_selection_api(options):
+    """Prompt the user to choose a set from API results.
+
+    Parameters
+    ----------
+    options:
+        List of ``(set_code, set_name)`` tuples.
+
+    Returns
+    -------
+    str
+        The selected set name or the first option if no selection is made.
+    """
+
+    if not options:
+        return ""
+
+    selected = {"name": options[0][1]}
+    try:
+        root = tk._default_root or tk.Tk()
+        top = ctk.CTkToplevel(root, fg_color=BG_COLOR)
+    except Exception:
+        return selected["name"]
+
+    top.title("Wybierz set")
+
+    def choose(name: str):
+        selected["name"] = name
+        try:
+            top.destroy()
+        except Exception:
+            pass
+
+    for _code, name in options:
+        btn = ctk.CTkButton(
+            top,
+            text=name,
+            fg_color=ACCENT_COLOR,
+            hover_color=HOVER_COLOR,
+            command=lambda n=name: choose(n),
+        )
+        btn.pack(padx=10, pady=5, fill="x")
+
+    try:
+        top.update_idletasks()
+        w = top.winfo_width()
+        h = top.winfo_height()
+        x = int(top.winfo_screenwidth() / 2 - w / 2)
+        y = int(top.winfo_screenheight() / 2 - h / 2)
+        top.geometry(f"{w}x{h}+{x}+{y}")
+        top.focus_force()
+        top.grab_set()
+        top.wait_window()
+    except Exception:
+        pass
+
+    return selected["name"]
+
+
 def choose_nearest_locations(order_list, output_data):
     """Assign the nearest warehouse codes to order items.
 
@@ -633,22 +692,21 @@ def analyze_card_image(path: str, translate_name: bool = False):
                 return {"name": "", "number": "", "total": "", "set": ocr_matches[0][1]}
         except Exception:
             ocr_matches = []
-
-    # Try to identify the set using local logo hashes if OCR failed
-    if local_path and not ocr_matches:
-        try:
-            if w is None or h is None:
-                with Image.open(local_path) as im:
-                    w, h = im.size
-            matches = identify_set_by_hash(local_path, get_symbol_rect(w, h))
-            if matches:
-                code, name, diff = matches[0]
-                if diff <= HASH_DIFF_THRESHOLD:
-                    return {"name": "", "number": "", "total": "", "set": name}
-        except Exception:
-            pass
-
     if not OPENAI_API_KEY:
+        # Without the API key we can't recognize name/number, so fall back to
+        # local hashing if possible.
+        if local_path and not ocr_matches:
+            try:
+                if w is None or h is None:
+                    with Image.open(local_path) as im:
+                        w, h = im.size
+                matches = identify_set_by_hash(local_path, get_symbol_rect(w, h))
+                if matches:
+                    code, name, diff = matches[0]
+                    if diff <= HASH_DIFF_THRESHOLD:
+                        return {"name": "", "number": "", "total": "", "set": name}
+            except Exception:
+                pass
         return {"name": "", "number": "", "total": "", "set": ""}
 
     if parsed.scheme in ("http", "https"):
@@ -708,6 +766,44 @@ def analyze_card_image(path: str, translate_name: bool = False):
         set_code = match_set_code(set_code)
         if translate_name and isinstance(name, str) and not name.isascii():
             name = translate_to_english(name)
+
+        # Look up possible sets from external API
+        api_sets: list[tuple[str, str]] = []
+        if name and number:
+            try:
+                api_sets = lookup_sets_from_api(name, number, total or None)
+            except Exception:
+                api_sets = []
+
+        if len(api_sets) == 1:
+            set_name = api_sets[0][1]
+            return {"name": name, "number": number, "total": total, "set": set_name}
+        if len(api_sets) > 1:
+            try:
+                set_name = prompt_set_selection_api(api_sets)
+            except Exception:
+                set_name = api_sets[0][1]
+            return {"name": name, "number": number, "total": total, "set": set_name}
+
+        # Fallback to local hashing if API did not provide answers
+        if local_path and not ocr_matches:
+            try:
+                if w is None or h is None:
+                    with Image.open(local_path) as im:
+                        w, h = im.size
+                matches = identify_set_by_hash(local_path, get_symbol_rect(w, h))
+                if matches:
+                    code, name_match, diff = matches[0]
+                    if diff <= HASH_DIFF_THRESHOLD:
+                        return {
+                            "name": name,
+                            "number": number,
+                            "total": total,
+                            "set": name_match,
+                        }
+            except Exception:
+                pass
+
         set_name = get_set_name(set_code)
         return {"name": name, "number": number, "total": total, "set": set_name}
     except Exception as e:
@@ -2906,12 +3002,11 @@ class CardEditorApp:
             skip_analysis = True
 
         folder = os.path.basename(os.path.dirname(image_path))
-        remote_url = f"{BASE_IMAGE_URL}/{folder}/{os.path.basename(image_path)}"
         if not skip_analysis:
             self.start_scan_animation()
             threading.Thread(
                 target=self._analyze_and_fill,
-                args=(remote_url, self.index),
+                args=(image_path, self.index),
                 daemon=True,
             ).start()
         else:
@@ -2996,7 +3091,7 @@ class CardEditorApp:
         if hasattr(self, "current_card_photo"):
             self.image_label.configure(image=self.current_card_photo)
 
-    def _analyze_and_fill(self, url, idx):
+    def _analyze_and_fill(self, path, idx):
         lang_var = getattr(self, "lang_var", None)
         translate = False
         if lang_var is not None:
@@ -3004,7 +3099,7 @@ class CardEditorApp:
                 translate = lang_var.get() == "JP"
             except Exception:
                 translate = False
-        result = analyze_card_image(url, translate_name=translate)
+        result = analyze_card_image(path, translate_name=translate)
         self.root.after(0, lambda: self._apply_analysis_result(result, idx))
 
     def _apply_analysis_result(self, result, idx):
@@ -3027,39 +3122,7 @@ class CardEditorApp:
             self.entries["numer"].insert(0, number)
             self.entries["set"].set(set_name)
             self.update_set_options()
-
-            try:
-                api_sets = lookup_sets_from_api(name, number, total or None)
-            except Exception:
-                api_sets = []
-
-            if len(api_sets) == 1:
-                self.entries["set"].set(api_sets[0][1])
-                self.update_set_options()
-                return
-            if len(api_sets) > 1 and hasattr(self, "prompt_set_selection_api"):
-                try:
-                    self.prompt_set_selection_api(api_sets)
-                except Exception:
-                    pass
-                return
-            if api_sets:
-                return
-
-        # Fallback to local hashing/OCR/AI
-        if getattr(self, "current_image_path", "") and hasattr(self, "prompt_set_selection"):
-            try:
-                with Image.open(self.current_image_path) as im:
-                    rect = get_symbol_rect(*im.size)
-                matches = identify_set_by_hash(self.current_image_path, rect)
-            except Exception:
-                matches = []
-            options = [(c, n) for c, n, _ in matches]
-            if options:
-                try:
-                    self.prompt_set_selection(options)
-                except Exception:
-                    pass
+        return
 
     def prompt_set_selection_api(self, options):
         """Display a simple selection dialog for API-provided sets."""

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock, patch
 import tkinter as tk
 from PIL import Image
 
-sys.modules["customtkinter"] = SimpleNamespace(CTkEntry=tk.Entry, CTkImage=MagicMock())
+sys.modules["customtkinter"] = SimpleNamespace(
+    CTkEntry=tk.Entry,
+    CTkImage=MagicMock(),
+    CTkButton=MagicMock,
+    CTkToplevel=MagicMock,
+)
 sys.modules["pytesseract"] = SimpleNamespace(image_to_string=MagicMock(return_value=""))
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import kartoteka.ui as ui
@@ -48,7 +53,6 @@ def test_show_card_uses_analyzer(tmp_path):
 
     dummy.start_scan_animation = lambda *a, **k: None
     dummy.stop_scan_animation = lambda *a, **k: None
-    dummy.prompt_set_selection_api = MagicMock()
     dummy._analyze_and_fill = lambda url, idx: ui.CardEditorApp._apply_analysis_result(
         dummy, ui.analyze_card_image(url), idx
     )
@@ -56,68 +60,80 @@ def test_show_card_uses_analyzer(tmp_path):
     with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
          patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
          patch.object(
-            ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": ""}
-         ) as mock_analyze, \
-         patch.object(
-            ui, "lookup_sets_from_api", return_value=[("sv01", SV01_NAME)]
-         ):
+            ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": SV01_NAME}
+         ) as mock_analyze:
         ui.CardEditorApp.show_card(dummy)
 
-    folder = os.path.basename(img.parent)
-    expected_url = f"{ui.BASE_IMAGE_URL}/{folder}/{img.name}"
-    mock_analyze.assert_called_once_with(expected_url)
+    mock_analyze.assert_called_once_with(str(img))
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "1")
     set_var.set.assert_called_with(SV01_NAME)
-    dummy.prompt_set_selection_api.assert_not_called()
 
 
-def test_show_card_prompts_for_set_selection(tmp_path):
-    img = tmp_path / "card.jpg"
-    img.write_bytes(b"data")
+def test_analyze_card_image_api_single_set(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
 
-    name_entry = MagicMock()
-    num_entry = MagicMock()
-    set_var = MagicMock()
-    name_entry.delete = MagicMock()
-    name_entry.insert = MagicMock()
-    name_entry.focus_set = MagicMock()
-    num_entry.delete = MagicMock()
-    num_entry.insert = MagicMock()
-    set_var.set = MagicMock()
+    parsed = ui.CardData(name="Pikachu", number="037", set="")
+    resp = SimpleNamespace(output=[SimpleNamespace(content=[SimpleNamespace(parsed=parsed)])])
+    client = SimpleNamespace(responses=SimpleNamespace(parse=MagicMock(return_value=resp)))
 
-    dummy = SimpleNamespace(
-        cards=[str(img)],
-        index=0,
-        image_objects=[],
-        image_label=MagicMock(),
-        progress_var=SimpleNamespace(set=lambda *a, **k: None),
-        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var},
-        type_vars={},
-        card_cache={},
-        file_to_key={},
-        _guess_key_from_filename=lambda *a, **k: None,
-        lookup_inventory_entry=lambda *a, **k: None,
-        update_set_options=lambda *a, **k: None,
-    )
+    with patch("openai.OpenAI", return_value=client), \
+         patch.object(ui, "lookup_sets_from_api", return_value=[("sv01", SV01_NAME)]), \
+         patch.object(ui, "prompt_set_selection_api") as mock_prompt, \
+         patch.object(ui, "identify_set_by_hash") as mock_hash:
+        result = ui.analyze_card_image("/tmp/img.jpg")
 
-    dummy.start_scan_animation = lambda *a, **k: None
-    dummy.stop_scan_animation = lambda *a, **k: None
-    dummy.prompt_set_selection_api = MagicMock()
-    dummy._analyze_and_fill = lambda url, idx: ui.CardEditorApp._apply_analysis_result(
-        dummy, ui.analyze_card_image(url), idx
-    )
+    assert result == {"name": "Pikachu", "number": "037", "total": "", "set": SV01_NAME}
+    mock_prompt.assert_not_called()
+    mock_hash.assert_not_called()
 
+
+def test_analyze_card_image_api_multiple_sets(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    parsed = ui.CardData(name="Pikachu", number="037", set="")
+    resp = SimpleNamespace(output=[SimpleNamespace(content=[SimpleNamespace(parsed=parsed)])])
+    client = SimpleNamespace(responses=SimpleNamespace(parse=MagicMock(return_value=resp)))
     options = [("a", "Set A"), ("b", "Set B")]
-    with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
-         patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
-         patch.object(
-            ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": ""}
-         ), \
-         patch.object(ui, "lookup_sets_from_api", return_value=options):
-        ui.CardEditorApp.show_card(dummy)
 
-    dummy.prompt_set_selection_api.assert_called_once_with(options)
+    with patch("openai.OpenAI", return_value=client), \
+         patch.object(ui, "lookup_sets_from_api", return_value=options), \
+         patch.object(ui, "prompt_set_selection_api", return_value="Set B") as mock_prompt, \
+         patch.object(ui, "identify_set_by_hash") as mock_hash:
+        result = ui.analyze_card_image("/tmp/img.jpg")
+
+    assert result == {"name": "Pikachu", "number": "037", "total": "", "set": "Set B"}
+    mock_prompt.assert_called_once_with(options)
+    mock_hash.assert_not_called()
+
+
+def test_analyze_card_image_api_fallback_hash(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    parsed = ui.CardData(name="Pikachu", number="037", set="")
+    resp = SimpleNamespace(output=[SimpleNamespace(content=[SimpleNamespace(parsed=parsed)])])
+    client = SimpleNamespace(responses=SimpleNamespace(parse=MagicMock(return_value=resp)))
+
+    class DummyImage:
+        size = (100, 100)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("openai.OpenAI", return_value=client), \
+         patch.object(ui, "lookup_sets_from_api", return_value=[]), \
+         patch.object(ui, "identify_set_by_hash", return_value=[("x", "Set X", 0)]) as mock_hash, \
+         patch.object(ui.Image, "open", return_value=DummyImage()):
+        result = ui.analyze_card_image("/tmp/img.jpg")
+
+    assert result == {"name": "Pikachu", "number": "037", "total": "", "set": "Set X"}
+    mock_hash.assert_called_once()
 
 
 def test_analyze_card_image_ocr(monkeypatch):
@@ -128,13 +144,15 @@ def test_analyze_card_image_ocr(monkeypatch):
 
     with patch.object(ui, "extract_set_code_ocr", return_value=[(SV01_CODE, SV01_NAME)]) as mock_ocr, \
         patch.object(ui, "identify_set_by_hash") as mock_hash, \
-        patch("openai.OpenAI") as mock_openai:
+        patch("openai.OpenAI") as mock_openai, \
+        patch.object(ui, "lookup_sets_from_api") as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
     assert result == {"name": "", "number": "", "total": "", "set": SV01_NAME}
     mock_ocr.assert_called_once()
     mock_hash.assert_not_called()
     mock_openai.assert_not_called()
+    mock_lookup.assert_not_called()
 
 
 def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
@@ -155,7 +173,9 @@ def test_analyze_card_image_bad_json(monkeypatch, capsys):
     resp = SimpleNamespace(output=[SimpleNamespace(content=[])])
     client = SimpleNamespace(responses=SimpleNamespace(parse=MagicMock(return_value=resp)))
 
-    with patch("openai.OpenAI", return_value=client):
+    with patch("openai.OpenAI", return_value=client), patch.object(
+        ui, "lookup_sets_from_api", return_value=[]
+    ):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
     output = capsys.readouterr().out
@@ -171,7 +191,9 @@ def test_analyze_card_image_truncated_code_block(monkeypatch):
     resp = SimpleNamespace(output=[SimpleNamespace(content=[SimpleNamespace(parsed=parsed)])])
     client = SimpleNamespace(responses=SimpleNamespace(parse=MagicMock(return_value=resp)))
 
-    with patch("openai.OpenAI", return_value=client):
+    with patch("openai.OpenAI", return_value=client), patch.object(
+        ui, "lookup_sets_from_api", return_value=[]
+    ):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
     assert result == {"name": "Pikachu", "number": "037", "total": "159", "set": ""}
@@ -185,7 +207,9 @@ def test_analyze_card_image_leading_text(monkeypatch):
     resp = SimpleNamespace(output=[SimpleNamespace(content=[SimpleNamespace(parsed=parsed)])])
     client = SimpleNamespace(responses=SimpleNamespace(parse=MagicMock(return_value=resp)))
 
-    with patch("openai.OpenAI", return_value=client):
+    with patch("openai.OpenAI", return_value=client), patch.object(
+        ui, "lookup_sets_from_api", return_value=[]
+    ):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
     assert result == {"name": "Pikachu", "number": "037", "total": "159", "set": ""}
@@ -203,7 +227,7 @@ def test_analyze_card_image_includes_logo_labels(monkeypatch):
 
     with patch.object(ui, "load_set_logo_uris", return_value=logos), patch(
         "openai.OpenAI", return_value=client
-    ):
+    ), patch.object(ui, "lookup_sets_from_api", return_value=[]):
         ui.analyze_card_image("http://example.com/img.jpg")
 
     content = mock_parse.call_args.kwargs["input"][0]["content"]
@@ -216,11 +240,14 @@ def test_analyze_card_image_local_hash(monkeypatch):
     importlib.reload(ui)
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
-    with patch("openai.OpenAI") as mock_openai:
+    with patch("openai.OpenAI") as mock_openai, patch.object(
+        ui, "lookup_sets_from_api"
+    ) as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
     assert result == {"name": "", "number": "", "total": "", "set": SV01_NAME}
     mock_openai.assert_not_called()
+    mock_lookup.assert_not_called()
 
 
 def test_analyze_card_image_translate_name(monkeypatch):
@@ -236,7 +263,7 @@ def test_analyze_card_image_translate_name(monkeypatch):
 
     with patch("openai.OpenAI", return_value=client), patch(
         "openai.chat.completions.create", return_value=resp_translate
-    ) as mock_create:
+    ) as mock_create, patch.object(ui, "lookup_sets_from_api", return_value=[]):
         result = ui.analyze_card_image("/tmp/img.jpg", translate_name=True)
 
     assert result == {"name": "Pikachu", "number": "037", "total": "159", "set": ""}
@@ -282,7 +309,7 @@ def test_analyze_and_fill_translates_for_jp(monkeypatch):
     with patch("openai.OpenAI", return_value=client), patch(
         "openai.chat.completions.create", return_value=resp_translate
     ), patch.object(ui, "lookup_sets_from_api", return_value=[]):
-        ui.CardEditorApp._analyze_and_fill(dummy, "http://x", 0)
+        ui.CardEditorApp._analyze_and_fill(dummy, "/tmp/x", 0)
 
     name_entry.insert.assert_called_with(0, "Pikachu")
 

--- a/tests/test_apply_analysis_result.py
+++ b/tests/test_apply_analysis_result.py
@@ -1,6 +1,10 @@
+import importlib
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+import tkinter as tk
+
 import kartoteka.ui as ui
+importlib.reload(ui)
 
 
 def make_dummy():
@@ -18,61 +22,14 @@ def make_dummy():
         index=0,
         stop_scan_animation=lambda: None,
         update_set_options=lambda: None,
-        current_image_path="/tmp/img.jpg",
     )
     dummy._apply_analysis_result = ui.CardEditorApp._apply_analysis_result.__get__(dummy, ui.CardEditorApp)
-    dummy.prompt_set_selection_api = MagicMock()
-    dummy.prompt_set_selection = MagicMock()
     return dummy, name_entry, num_entry, set_var
 
 
-def test_apply_analysis_result_single_set(monkeypatch):
-    dummy, _n, _num, set_var = make_dummy()
-    captured = {}
-
-    def fake_lookup(name, number, total):
-        captured["args"] = (name, number, total)
-        return [("sv01", "Scarlet & Violet")]
-
-    monkeypatch.setattr(ui, "lookup_sets_from_api", fake_lookup)
-
-    dummy._apply_analysis_result({"name": "Pikachu", "number": "037/159", "set": ""}, 0)
-    assert captured["args"] == ("Pikachu", "37", "159")
-    set_var.set.assert_called_with("Scarlet & Violet")
-    dummy.prompt_set_selection_api.assert_not_called()
-    dummy.prompt_set_selection.assert_not_called()
-
-
-def test_apply_analysis_result_multiple_sets(monkeypatch):
-    dummy, _n, _num, _set = make_dummy()
-    options = [("a", "Set A"), ("b", "Set B")]
-    monkeypatch.setattr(ui, "lookup_sets_from_api", lambda n, num, total: options)
-
-    dummy._apply_analysis_result({"name": "Pikachu", "number": "037", "total": "159", "set": ""}, 0)
-    dummy.prompt_set_selection_api.assert_called_once_with(options)
-    dummy.prompt_set_selection.assert_not_called()
-
-
-def test_apply_analysis_result_fallback(monkeypatch):
-    dummy, _n, _num, _set = make_dummy()
-    monkeypatch.setattr(ui, "lookup_sets_from_api", lambda n, num, total: [])
-    class DummyImage:
-        size = (100, 100)
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            return False
-
-    monkeypatch.setattr(ui.Image, "open", lambda path: DummyImage())
-    monkeypatch.setattr(
-        ui,
-        "identify_set_by_hash",
-        lambda path, rect: [("x", "Set X", 0)],
-    )
-
-    dummy._apply_analysis_result(
-        {"name": "Pikachu", "number": "037", "total": "159", "set": ""}, 0
-    )
-    dummy.prompt_set_selection.assert_called_once_with([("x", "Set X")])
+def test_apply_analysis_result_updates_fields():
+    dummy, name_entry, num_entry, set_var = make_dummy()
+    dummy._apply_analysis_result({"name": "Pikachu", "number": "037/159", "set": "Set X"}, 0)
+    name_entry.insert.assert_called_with(0, "Pikachu")
+    num_entry.insert.assert_called_with(0, "37")
+    set_var.set.assert_called_with("Set X")


### PR DESCRIPTION
## Summary
- add `prompt_set_selection_api` for interactive set choice
- query TCGGO for card sets in `analyze_card_image` before falling back to hash/AI
- analyze local image paths so hashing is available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891eea54098832f9987c51e154f7ee2