### PR TITLE
Return raw OCR set codes

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -630,7 +630,7 @@ def identify_set_by_hash(
 
 def extract_set_code_ocr(
     scan_path: str, rect: tuple[int, int, int, int]
-) -> list[tuple[str, str]]:
+) -> list[str]:
     """Extract potential set codes from the scan using OCR.
 
     Parameters
@@ -643,9 +643,9 @@ def extract_set_code_ocr(
 
     Returns
     -------
-    list[tuple[str, str]]
-        List of tuples ``(code, set_name)`` recognized from the image. When no
-        codes are recognized the list is empty.
+    list[str]
+        List of unique set code strings recognized from the image. When no codes
+        are recognized the list is empty.
     """
 
     try:
@@ -658,15 +658,10 @@ def extract_set_code_ocr(
     candidates: set[str] = set()
     for token in re.split(r"\s+", raw.upper()):
         token = re.sub(r"[^A-Z0-9]", "", token).strip()
-        if len(token) > 1:
+        if len(token) > 1 and not token.isdigit():
             candidates.add(token.lower())
 
-    results: list[tuple[str, str]] = []
-    for code in candidates:
-        name = tcg_sets_eng_code_map.get(code)
-        if name:
-            results.append((code, name))
-    return results
+    return list(candidates)
 
 
 class CardData(BaseModel):
@@ -681,7 +676,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
     local_path = path if parsed.scheme not in ("http", "https") else None
 
     w = h = None
-    ocr_matches: list[tuple[str, str]] = []
+    ocr_matches: list[str] = []
     if local_path:
         try:
             with Image.open(local_path) as im:
@@ -689,7 +684,7 @@ def analyze_card_image(path: str, translate_name: bool = False):
             rect = get_symbol_rect(w, h)
             ocr_matches = extract_set_code_ocr(local_path, rect)
             if len(ocr_matches) == 1:
-                return {"name": "", "number": "", "total": "", "set": ocr_matches[0][1]}
+                return {"name": "", "number": "", "total": "", "set": ocr_matches[0]}
         except Exception:
             ocr_matches = []
     if not OPENAI_API_KEY:

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -60,14 +60,14 @@ def test_show_card_uses_analyzer(tmp_path):
     with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
          patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
          patch.object(
-            ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": SV01_NAME}
+            ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": SV01_CODE}
          ) as mock_analyze:
         ui.CardEditorApp.show_card(dummy)
 
     mock_analyze.assert_called_once_with(str(img))
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "1")
-    set_var.set.assert_called_with(SV01_NAME)
+    set_var.set.assert_called_with(SV01_CODE)
 
 
 def test_analyze_card_image_api_single_set(monkeypatch):
@@ -142,13 +142,13 @@ def test_analyze_card_image_ocr(monkeypatch):
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
 
-    with patch.object(ui, "extract_set_code_ocr", return_value=[(SV01_CODE, SV01_NAME)]) as mock_ocr, \
+    with patch.object(ui, "extract_set_code_ocr", return_value=[SV01_CODE]) as mock_ocr, \
         patch.object(ui, "identify_set_by_hash") as mock_hash, \
         patch("openai.OpenAI") as mock_openai, \
         patch.object(ui, "lookup_sets_from_api") as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
-    assert result == {"name": "", "number": "", "total": "", "set": SV01_NAME}
+    assert result == {"name": "", "number": "", "total": "", "set": SV01_CODE}
     mock_ocr.assert_called_once()
     mock_hash.assert_not_called()
     mock_openai.assert_not_called()
@@ -160,10 +160,10 @@ def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
     path = tmp_path / "img.png"
     img.save(path)
 
-    with patch("pytesseract.image_to_string", return_value="E\nSV01\n"):
+    with patch("pytesseract.image_to_string", return_value="E\n123\nSV01\n"):
         result = ui.extract_set_code_ocr(str(path), (0, 0, 10, 10))
 
-    assert result == [(SV01_CODE, SV01_NAME)]
+    assert result == [SV01_CODE]
 
 
 def test_analyze_card_image_bad_json(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- Remove set code validation against `tcg_sets.json`
- Return raw OCR set codes and filter digits and single letters
- Update tests for unvalidated set code output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891f5393298832fa92d5ac43a45e317