### PR TITLE
Load OpenAI key from environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
 SHOPER_API_URL=https://your-store.shop/webapi/rest
 SHOPER_API_TOKEN=your-token
 SHOPER_DELIVERY_ID=1
-# API key for OpenAI (required for card text recognition)
+# API key for OpenAI (required for card text recognition via Vision)
 OPENAI_API_KEY=
 FTP_HOST=example.com
 FTP_USER=username

--- a/README.md
+++ b/README.md
@@ -45,10 +45,12 @@ INVENTORY_CSV=magazyn.csv
 BASE_IMAGE_URL=https://your-store.shop/upload/images
 ```
 
+- `OPENAI_API_KEY` – API key used by OpenAI Vision to extract card details from scans.
+
 **Warning:** This file may contain private API keys and tokens. It is excluded
 from version control via `.gitignore` and should never be shared publicly.
 
-The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` enables automatic recognition of card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
+The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` supplies the key for OpenAI Vision to recognise card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
 `INVENTORY_CSV` controls where the local inventory CSV is written.
 
 ## Running the App

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -681,7 +681,8 @@ def extract_card_text_openai(path: str) -> tuple[str, str, str]:
         url = f"{BASE_IMAGE_URL}/{folder}/{filename}"
 
     try:
-        client = openai.OpenAI()
+        api_key = os.getenv("OPENAI_API_KEY")
+        client = openai.OpenAI(api_key=api_key) if api_key else openai.OpenAI()
         resp = client.responses.parse(
             model="gpt-4o",
             input=[


### PR DESCRIPTION
## Summary
- add OPENAI_API_KEY placeholder in example env file
- document OPENAI_API_KEY in README
- read OPENAI_API_KEY from environment when using OpenAI Vision

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892e6a92128832f99f17ccab095bfed