### PR TITLE
Map OCR set code to name

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -769,7 +769,12 @@ def analyze_card_image(path: str, translate_name: bool = False):
             rect = get_symbol_rect(w, h)
             ocr_matches = extract_set_code_ocr(local_path, rect)
             if len(ocr_matches) == 1:
-                return {"name": "", "number": "", "total": "", "set": ocr_matches[0]}
+                return {
+                    "name": "",
+                    "number": "",
+                    "total": "",
+                    "set": get_set_name(ocr_matches[0]),
+                }
         except Exception:
             ocr_matches = []
 

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -59,15 +59,15 @@ def test_show_card_uses_analyzer(tmp_path):
 
     with patch.object(ui.Image, "open", return_value=MagicMock(thumbnail=lambda *a, **k: None)), \
          patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
-         patch.object(
-            ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": SV01_CODE}
-         ) as mock_analyze:
+        patch.object(
+            ui, "analyze_card_image", return_value={"name": "Pika", "number": "001", "set": SV01_NAME}
+        ) as mock_analyze:
         ui.CardEditorApp.show_card(dummy)
 
     mock_analyze.assert_called_once_with(str(img))
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "1")
-    set_var.set.assert_called_with(SV01_CODE)
+    set_var.set.assert_called_with(SV01_NAME)
 
 
 def test_analyze_card_image_api_single_set(monkeypatch):
@@ -130,7 +130,7 @@ def test_analyze_card_image_ocr(monkeypatch):
         patch.object(ui, "lookup_sets_from_api") as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
-    assert result == {"name": "", "number": "", "total": "", "set": SV01_CODE}
+    assert result == {"name": "", "number": "", "total": "", "set": SV01_NAME}
     mock_ocr.assert_called_once()
     mock_hash.assert_not_called()
     mock_extract.assert_not_called()


### PR DESCRIPTION
## Summary
- Map single OCR set code matches to user-friendly set names via `get_set_name`.
- Update tests to expect set names instead of raw codes when OCR identifies a set.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892fa0a6044832fa13045f42b9e3756