### PR TITLE
Handle multiple OCR set codes without OpenAI by hashing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -781,17 +781,36 @@ def analyze_card_image(path: str, translate_name: bool = False):
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         # Without the API key we can't recognize name/number, so fall back to
-        # local hashing if possible.
-        if local_path and not ocr_matches:
+        # local hashing if possible and use OCR hints when available.
+        if local_path:
             try:
                 if w is None or h is None:
                     with Image.open(local_path) as im:
                         w, h = im.size
-                matches = identify_set_by_hash(local_path, get_symbol_rect(w, h))
-                if matches:
-                    code, name, diff = matches[0]
-                    if diff <= HASH_DIFF_THRESHOLD:
-                        return {"name": "", "number": "", "total": "", "set": name}
+                rect = get_symbol_rect(w, h)
+                if len(ocr_matches) > 1:
+                    matches = identify_set_by_hash(local_path, rect)
+                    if matches:
+                        code, name, diff = matches[0]
+                        if diff <= HASH_DIFF_THRESHOLD and code in ocr_matches:
+                            return {"name": "", "number": "", "total": "", "set": name}
+                    return {
+                        "name": "",
+                        "number": "",
+                        "total": "",
+                        "set": get_set_name(ocr_matches[0]),
+                    }
+                if not ocr_matches:
+                    matches = identify_set_by_hash(local_path, rect)
+                    if matches:
+                        code, name, diff = matches[0]
+                        if diff <= HASH_DIFF_THRESHOLD:
+                            return {
+                                "name": "",
+                                "number": "",
+                                "total": "",
+                                "set": name,
+                            }
             except Exception:
                 pass
         return {"name": "", "number": "", "total": "", "set": ""}

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -137,6 +137,48 @@ def test_analyze_card_image_ocr(monkeypatch):
     mock_lookup.assert_not_called()
 
 
+def test_analyze_card_image_ocr_multiple(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
+
+    with patch.object(
+        ui, "extract_set_code_ocr", return_value=[SV01_CODE, "other"]
+    ) as mock_ocr, patch.object(
+        ui, "identify_set_by_hash", return_value=[(SV01_CODE, SV01_NAME, 0)]
+    ) as mock_hash, patch.object(ui, "extract_card_text_openai") as mock_extract, patch.object(
+        ui, "lookup_sets_from_api"
+    ) as mock_lookup:
+        result = ui.analyze_card_image(str(logo_path))
+
+    assert result == {"name": "", "number": "", "total": "", "set": SV01_NAME}
+    mock_ocr.assert_called_once()
+    mock_hash.assert_called_once()
+    mock_extract.assert_not_called()
+    mock_lookup.assert_not_called()
+
+
+def test_analyze_card_image_ocr_multiple_ambiguous(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
+
+    with patch.object(
+        ui, "extract_set_code_ocr", return_value=[SV01_CODE, "other"]
+    ) as mock_ocr, patch.object(
+        ui, "identify_set_by_hash", return_value=[("x", "Set X", 0)]
+    ) as mock_hash, patch.object(ui, "extract_card_text_openai") as mock_extract, patch.object(
+        ui, "lookup_sets_from_api"
+    ) as mock_lookup:
+        result = ui.analyze_card_image(str(logo_path))
+
+    assert result == {"name": "", "number": "", "total": "", "set": SV01_NAME}
+    mock_ocr.assert_called_once()
+    mock_hash.assert_called_once()
+    mock_extract.assert_not_called()
+    mock_lookup.assert_not_called()
+
+
 def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
     img = Image.new("RGB", (10, 10), color="white")
     path = tmp_path / "img.png"


### PR DESCRIPTION
## Summary
- Improve analyze_card_image to resolve multiple OCR set codes by comparing hash matches when OpenAI is unavailable
- Add tests covering hash-based disambiguation and ambiguous cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689302570620832fa310fb6ace684ab4