### PR TITLE
Parse embedded total in card number

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -213,6 +213,10 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
     list[tuple[str, str]]
         A list of ``(set_code, set_name)`` tuples sorted by relevance.
     """
+    if not total:
+        number_str = str(number)
+        if "/" in number_str:
+            number, total = number_str.split("/", 1)
 
     name_api = normalize(name, keep_spaces=True)
     params = {"name": name_api, "number": number}

--- a/tests/test_lookup_sets_from_api.py
+++ b/tests/test_lookup_sets_from_api.py
@@ -60,6 +60,20 @@ def test_lookup_sets_from_api_omits_total(monkeypatch):
     assert "total" not in captured["params"]
 
 
+def test_lookup_sets_from_api_splits_number(monkeypatch):
+    data = {"cards": []}
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["params"] = params
+        return DummyResp(data)
+
+    monkeypatch.setattr(ui.requests, "get", fake_get)
+    ui.lookup_sets_from_api("Pikachu", "25/102")
+    assert captured["params"]["number"] == "25"
+    assert captured["params"]["total"] == "102"
+
+
 def test_lookup_sets_from_api_filters_results(monkeypatch):
     data = {
         "cards": [


### PR DESCRIPTION
## Summary
- handle card numbers containing total value (e.g. `25/102`) when total parameter is absent
- test that API params are built from split values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689329ebcc28832fb61c5bced3eeddeb