### PR TITLE
Sanitize card number before API lookup

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -217,6 +217,9 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
         number_str = str(number)
         if "/" in number_str:
             number, total = number_str.split("/", 1)
+    number = sanitize_number(str(number))
+    if total is not None:
+        total = sanitize_number(str(total))
 
     name_api = normalize(name, keep_spaces=True)
     params = {"name": name_api, "number": number}
@@ -254,8 +257,8 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
         cards = data
 
     name_norm = normalize(name)
-    number_norm = str(number).strip().lower()
-    total_norm = str(total).strip().lower() if total else None
+    number_norm = sanitize_number(str(number).strip().lower())
+    total_norm = sanitize_number(str(total).strip().lower()) if total else None
 
     scores = {}
     for card in cards:

--- a/tests/test_lookup_sets_from_api.py
+++ b/tests/test_lookup_sets_from_api.py
@@ -74,6 +74,19 @@ def test_lookup_sets_from_api_splits_number(monkeypatch):
     assert captured["params"]["total"] == "102"
 
 
+def test_lookup_sets_from_api_sanitizes_number(monkeypatch):
+    data = {"cards": []}
+    captured = {}
+
+    def fake_get(url, params=None, timeout=None):
+        captured["params"] = params
+        return DummyResp(data)
+
+    monkeypatch.setattr(ui.requests, "get", fake_get)
+    ui.lookup_sets_from_api("Pikachu", "037")
+    assert captured["params"]["number"] == "37"
+
+
 def test_lookup_sets_from_api_filters_results(monkeypatch):
     data = {
         "cards": [


### PR DESCRIPTION
## Summary
- Clean card `number` and `total` using `sanitize_number` before sending API requests and when scoring results
- Add regression test ensuring numbers like `037` are transmitted as `37`

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932fcc2164832f95d7d2ec41b31fbd