### PR TITLE
Auto-fill set in fetch_card_data

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3890,8 +3890,35 @@ class CardEditorApp:
 
     def fetch_card_data(self):
         name = self.entries["nazwa"].get()
-        number = sanitize_number(self.entries["numer"].get())
+        number_raw = self.entries["numer"].get()
         set_name = self.entries["set"].get()
+
+        total = None
+        if "/" in str(number_raw):
+            num_part, total_part = str(number_raw).split("/", 1)
+            number = sanitize_number(num_part)
+            total = sanitize_number(total_part)
+        else:
+            number = sanitize_number(number_raw)
+
+        if not set_name:
+            api_sets = lookup_sets_from_api(name, number, total)
+            if len(api_sets) == 1:
+                self.entries["set"].set(api_sets[0][1])
+                set_name = api_sets[0][1]
+                if hasattr(self, "update_set_options"):
+                    self.update_set_options()
+            elif len(api_sets) > 1 and hasattr(self, "prompt_set_selection"):
+                try:
+                    selected_code = self.prompt_set_selection(api_sets)
+                except Exception:
+                    selected_code = api_sets[0][0]
+                set_name = get_set_name(selected_code) or next(
+                    (n for c, n in api_sets if c == selected_code), ""
+                )
+                self.entries["set"].set(set_name)
+                if hasattr(self, "update_set_options"):
+                    self.update_set_options()
 
         is_reverse = self.type_vars["Reverse"].get()
         is_holo = self.type_vars["Holo"].get()

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -345,3 +345,60 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     num_entry.insert.assert_called_with(0, "1")
     set_var.set.assert_called_with(SV01_NAME)
 
+
+def test_fetch_card_data_auto_set(monkeypatch):
+    class DummyEntry:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def delete(self, *args, **kwargs):
+            self.value = ""
+
+        def insert(self, index, val):
+            self.value = str(val)
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+
+        def get(self):
+            return self.value
+
+        def set(self, value):
+            self.value = value
+
+    entries = {
+        "nazwa": DummyEntry("Pikachu"),
+        "numer": DummyEntry("037/102"),
+        "set": DummyVar(""),
+        "cena": DummyEntry(),
+        "psa10_price": DummyEntry(),
+    }
+
+    dummy = SimpleNamespace(
+        entries=entries,
+        type_vars={
+            "Reverse": SimpleNamespace(get=lambda: False),
+            "Holo": SimpleNamespace(get=lambda: False),
+        },
+        get_price_from_db=lambda *a, **k: None,
+        fetch_card_price=lambda *a, **k: None,
+        fetch_psa10_price=lambda *a, **k: None,
+        apply_variant_multiplier=lambda price, **kw: price,
+        log=lambda *a, **k: None,
+        prompt_set_selection=MagicMock(),
+        update_set_options=lambda *a, **k: None,
+    )
+
+    with patch.object(
+        ui, "lookup_sets_from_api", return_value=[("sv01", SV01_NAME)]
+    ) as mock_lookup, patch.object(ui.messagebox, "showinfo"):
+        ui.CardEditorApp.fetch_card_data(dummy)
+
+    assert entries["set"].get() == SV01_NAME
+    mock_lookup.assert_called_once_with("Pikachu", "37", "102")
+    dummy.prompt_set_selection.assert_not_called()
+


### PR DESCRIPTION
## Summary
- extend `fetch_card_data` to query sets API when no set is provided and populate the set field automatically
- test set auto-fill when number includes total and no set is present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893321d967c832fb5cd8c9f5ecea153