### PR TITLE
Add RapidAPI header and URL handling for set lookup

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -231,10 +231,15 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
         f"[lookup_sets_from_api] name={name!r}, number={number!r}, total={total!r}"
     )
 
+    headers = {"User-Agent": "kartoteka/1.0"}
+    url = "https://www.tcggo.com/api/cards/"
+    if RAPIDAPI_KEY and RAPIDAPI_HOST:
+        url = f"https://{RAPIDAPI_HOST}/cards/search"
+        headers["X-RapidAPI-Key"] = RAPIDAPI_KEY
+        headers["X-RapidAPI-Host"] = RAPIDAPI_HOST
+
     try:
-        response = requests.get(
-            "https://www.tcggo.com/api/cards/", params=params, timeout=10
-        )
+        response = requests.get(url, params=params, headers=headers, timeout=10)
         if response.status_code != 200:
             print(f"[ERROR] API error: {response.status_code}")
             return []

--- a/tests/test_lookup_sets_from_api.py
+++ b/tests/test_lookup_sets_from_api.py
@@ -35,11 +35,12 @@ def test_lookup_sets_from_api_sorts_results(monkeypatch):
         ]
     }
 
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, timeout=None, headers=None):
         assert url == "https://www.tcggo.com/api/cards/"
         assert params["name"] == ui.normalize("Pikachu", keep_spaces=True)
         assert params["number"] == "25"
         assert params["total"] == "102"
+        assert headers == {"User-Agent": "kartoteka/1.0"}
         return DummyResp(data)
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
@@ -51,40 +52,46 @@ def test_lookup_sets_from_api_omits_total(monkeypatch):
     data = {"cards": []}
     captured = {}
 
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, timeout=None, headers=None):
         captured["params"] = params
+        captured["headers"] = headers
         return DummyResp(data)
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "25", None)
     assert "total" not in captured["params"]
+    assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
 
 
 def test_lookup_sets_from_api_splits_number(monkeypatch):
     data = {"cards": []}
     captured = {}
 
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, timeout=None, headers=None):
         captured["params"] = params
+        captured["headers"] = headers
         return DummyResp(data)
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "25/102")
     assert captured["params"]["number"] == "25"
     assert captured["params"]["total"] == "102"
+    assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
 
 
 def test_lookup_sets_from_api_sanitizes_number(monkeypatch):
     data = {"cards": []}
     captured = {}
 
-    def fake_get(url, params=None, timeout=None):
+    def fake_get(url, params=None, timeout=None, headers=None):
         captured["params"] = params
+        captured["headers"] = headers
         return DummyResp(data)
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "037")
     assert captured["params"]["number"] == "37"
+    assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
 
 
 def test_lookup_sets_from_api_filters_results(monkeypatch):
@@ -105,8 +112,31 @@ def test_lookup_sets_from_api_filters_results(monkeypatch):
         ]
     }
 
-    monkeypatch.setattr(
-        ui.requests, "get", lambda url, params=None, timeout=None: DummyResp(data)
-    )
+    def fake_get(url, params=None, timeout=None, headers=None):
+        assert headers == {"User-Agent": "kartoteka/1.0"}
+        return DummyResp(data)
+
+    monkeypatch.setattr(ui.requests, "get", fake_get)
     result = ui.lookup_sets_from_api("Pikachu", "25", "102")
     assert result == [("BS", "Base Set")]
+
+
+def test_lookup_sets_from_api_uses_rapidapi(monkeypatch):
+    data = {"cards": []}
+    host = "example.p.rapidapi.com"
+    key = "secret"
+
+    monkeypatch.setattr(ui, "RAPIDAPI_HOST", host)
+    monkeypatch.setattr(ui, "RAPIDAPI_KEY", key)
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        assert url == f"https://{host}/cards/search"
+        assert headers == {
+            "User-Agent": "kartoteka/1.0",
+            "X-RapidAPI-Key": key,
+            "X-RapidAPI-Host": host,
+        }
+        return DummyResp(data)
+
+    monkeypatch.setattr(ui.requests, "get", fake_get)
+    ui.lookup_sets_from_api("Pikachu", "25", "102")


### PR DESCRIPTION
## Summary
- Add support for custom headers and RapidAPI endpoints in `lookup_sets_from_api`
- Always send a User-Agent and include RapidAPI key/host when configured
- Extend tests to verify headers and URL selection

## Testing
- `PYTHONPATH=. pytest tests/test_lookup_sets_from_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68933e02d944832fbae8938a217f2c7a