### PR TITLE
Resolve card set from API set code

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3906,24 +3906,28 @@ class CardEditorApp:
         else:
             number = sanitize_number(number_raw)
 
-        if not set_name:
-            api_sets = lookup_sets_from_api(name, number, total)
-            if len(api_sets) == 1:
-                self.entries["set"].set(api_sets[0][1])
-                set_name = api_sets[0][1]
+        api_sets = lookup_sets_from_api(name, number, total)
+        if api_sets:
+            first_code = api_sets[0][0]
+            resolved = get_set_name(first_code) or api_sets[0][1]
+            current = self.entries["set"].get()
+            if not current or current != resolved:
+                self.entries["set"].set(resolved)
+                set_name = resolved
                 if hasattr(self, "update_set_options"):
                     self.update_set_options()
-            elif len(api_sets) > 1 and hasattr(self, "prompt_set_selection"):
+            if len(api_sets) > 1 and hasattr(self, "prompt_set_selection"):
                 try:
                     selected_code = self.prompt_set_selection(api_sets)
                 except Exception:
-                    selected_code = api_sets[0][0]
+                    selected_code = first_code
                 set_name = get_set_name(selected_code) or next(
-                    (n for c, n in api_sets if c == selected_code), ""
+                    (n for c, n in api_sets if c == selected_code), "",
                 )
-                self.entries["set"].set(set_name)
-                if hasattr(self, "update_set_options"):
-                    self.update_set_options()
+                if self.entries["set"].get() != set_name:
+                    self.entries["set"].set(set_name)
+                    if hasattr(self, "update_set_options"):
+                        self.update_set_options()
 
         is_reverse = self.type_vars["Reverse"].get()
         is_holo = self.type_vars["Holo"].get()

--- a/tests/test_lookup_sets_from_api.py
+++ b/tests/test_lookup_sets_from_api.py
@@ -140,3 +140,24 @@ def test_lookup_sets_from_api_uses_rapidapi(monkeypatch):
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "25", "102")
+
+
+def test_get_set_name_swsh11(monkeypatch):
+    data = {
+        "cards": [
+            {
+                "name": "Pikachu",
+                "card_number": "25",
+                "total_prints": "102",
+                "episode": {"name": "Lost Origin", "code": "swsh11"},
+            }
+        ]
+    }
+
+    def fake_get(url, params=None, timeout=None, headers=None):
+        return DummyResp(data)
+
+    monkeypatch.setattr(ui.requests, "get", fake_get)
+    result = ui.lookup_sets_from_api("Pikachu", "25", "102")
+    code = result[0][0]
+    assert ui.get_set_name(code) == "Lost Origin"


### PR DESCRIPTION
## Summary
- Derive the card set name from the first API result's set code in `fetch_card_data`
- Add regression test ensuring `get_set_name` maps `swsh11` to `Lost Origin`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68934dfd2b6c832fa578c664ca9546d2