### PR TITLE
Use card_number param for set lookup

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -222,7 +222,7 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
         total = sanitize_number(str(total))
 
     name_api = normalize(name, keep_spaces=True)
-    params = {"name": name_api, "number": number}
+    params = {"name": name_api, "card_number": number}
     if total:
         params["total"] = total
 
@@ -269,7 +269,7 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
     for card in cards:
         episode = card.get("episode") or {}
         set_name = episode.get("name")
-        set_code = episode.get("code")
+        set_code = episode.get("code") or episode.get("slug")
         if not (set_name and set_code):
             continue
 

--- a/tests/test_lookup_sets_from_api.py
+++ b/tests/test_lookup_sets_from_api.py
@@ -38,7 +38,7 @@ def test_lookup_sets_from_api_sorts_results(monkeypatch):
     def fake_get(url, params=None, timeout=None, headers=None):
         assert url == "https://www.tcggo.com/api/cards/"
         assert params["name"] == ui.normalize("Pikachu", keep_spaces=True)
-        assert params["number"] == "25"
+        assert params["card_number"] == "25"
         assert params["total"] == "102"
         assert headers == {"User-Agent": "kartoteka/1.0"}
         return DummyResp(data)
@@ -59,6 +59,7 @@ def test_lookup_sets_from_api_omits_total(monkeypatch):
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "25", None)
+    assert captured["params"]["card_number"] == "25"
     assert "total" not in captured["params"]
     assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
 
@@ -74,7 +75,7 @@ def test_lookup_sets_from_api_splits_number(monkeypatch):
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "25/102")
-    assert captured["params"]["number"] == "25"
+    assert captured["params"]["card_number"] == "25"
     assert captured["params"]["total"] == "102"
     assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
 
@@ -90,7 +91,7 @@ def test_lookup_sets_from_api_sanitizes_number(monkeypatch):
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "037")
-    assert captured["params"]["number"] == "37"
+    assert captured["params"]["card_number"] == "37"
     assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
 
 
@@ -101,7 +102,7 @@ def test_lookup_sets_from_api_filters_results(monkeypatch):
                 "name": "Pikachu",
                 "card_number": "25",
                 "total_prints": "102",
-                "episode": {"name": "Base Set", "code": "BS"},
+                "episode": {"name": "Base Set", "slug": "base-set"},
             },
             {
                 "name": "Charmander",
@@ -118,7 +119,7 @@ def test_lookup_sets_from_api_filters_results(monkeypatch):
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     result = ui.lookup_sets_from_api("Pikachu", "25", "102")
-    assert result == [("BS", "Base Set")]
+    assert result == [("base-set", "Base Set")]
 
 
 def test_lookup_sets_from_api_uses_rapidapi(monkeypatch):


### PR DESCRIPTION
## Summary
- Send `card_number` to the API when looking up sets
- Fall back to `episode.slug` when `episode.code` is missing
- Adjust tests for `card_number` and slug-based set codes

## Testing
- `PYTHONPATH=. pytest tests/test_lookup_sets_from_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6893aaa6a0d0832f809bec54dbcdaf9c