### PR TITLE
Enhance set code OCR preprocessing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -691,8 +691,14 @@ def extract_set_code_ocr(
 
     try:
         with Image.open(scan_path) as im:
-            crop = im.crop(rect)
-        raw = pytesseract.image_to_string(crop)
+            crop = im.crop(rect).convert("L")
+            w, h = crop.size
+            crop = crop.resize((w * 3, h * 3), Image.LANCZOS)
+            crop = crop.point(lambda x: 0 if x < 128 else 255, "1").convert("L")
+        raw = pytesseract.image_to_string(
+            crop,
+            config="--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        )
     except Exception:
         return []
 

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -184,10 +184,18 @@ def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
     path = tmp_path / "img.png"
     img.save(path)
 
-    with patch("pytesseract.image_to_string", return_value="E\n123\nSV01\n"):
+    with patch("pytesseract.image_to_string", return_value="E\n123\nSV01\n") as ocr:
         result = ui.extract_set_code_ocr(str(path), (0, 0, 10, 10))
 
     assert result == [SV01_CODE]
+    ocr.assert_called_once()
+    processed = ocr.call_args.args[0]
+    assert processed.mode == "L"
+    assert processed.size == (30, 30)
+    assert (
+        ocr.call_args.kwargs.get("config")
+        == "--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    )
 
 
 def test_analyze_card_image_bad_json(monkeypatch):


### PR DESCRIPTION
## Summary
- Improve `extract_set_code_ocr` preprocessing by converting to grayscale, scaling, binarizing, and restricting OCR character set
- Adjust OCR call to use `--psm 7` and a whitelist of alphanumerics
- Extend tests to validate new OCR preprocessing and configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893b0a00f30832f9cc107e764881bb5