### PR TITLE
Use number param and fallback for set lookup

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -222,9 +222,7 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
         total = sanitize_number(str(total))
 
     name_api = normalize(name, keep_spaces=True)
-    params = {"name": name_api, "card_number": number}
-    if total:
-        params["total"] = total
+    params = {"name": name_api, "number": number}
 
     # log input data
     print(
@@ -238,28 +236,35 @@ def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):
         headers["X-RapidAPI-Key"] = RAPIDAPI_KEY
         headers["X-RapidAPI-Host"] = RAPIDAPI_HOST
 
-    try:
-        response = requests.get(url, params=params, headers=headers, timeout=10)
-        if response.status_code != 200:
-            print(f"[ERROR] API error: {response.status_code}")
+    def _request(params):
+        try:
+            response = requests.get(url, params=params, headers=headers, timeout=10)
+            if response.status_code != 200:
+                print(f"[ERROR] API error: {response.status_code}")
+                return []
+            data = response.json()
+        except requests.Timeout:
+            print("[ERROR] Request timed out")
             return []
-        data = response.json()
-    except requests.Timeout:
-        print("[ERROR] Request timed out")
-        return []
-    except Exception as e:  # pragma: no cover - network/JSON errors
-        print(f"[ERROR] Fetching sets from TCGGO failed: {e}")
-        return []
+        except Exception as e:  # pragma: no cover - network/JSON errors
+            print(f"[ERROR] Fetching sets from TCGGO failed: {e}")
+            return []
 
-    if isinstance(data, dict):
-        if "cards" in data:
-            cards = data["cards"]
-        elif "data" in data:
-            cards = data["data"]
-        else:
-            cards = []
+        if isinstance(data, dict):
+            if "cards" in data:
+                return data["cards"]
+            if "data" in data:
+                return data["data"]
+            return []
+        return data
+
+    cards = []
+    if total:
+        cards = _request({**params, "total": total})
+        if not cards:
+            cards = _request(params)
     else:
-        cards = data
+        cards = _request(params)
 
     name_norm = normalize(name)
     number_norm = sanitize_number(str(number).strip().lower())

--- a/tests/test_lookup_sets_from_api.py
+++ b/tests/test_lookup_sets_from_api.py
@@ -38,7 +38,7 @@ def test_lookup_sets_from_api_sorts_results(monkeypatch):
     def fake_get(url, params=None, timeout=None, headers=None):
         assert url == "https://www.tcggo.com/api/cards/"
         assert params["name"] == ui.normalize("Pikachu", keep_spaces=True)
-        assert params["card_number"] == "25"
+        assert params["number"] == "25"
         assert params["total"] == "102"
         assert headers == {"User-Agent": "kartoteka/1.0"}
         return DummyResp(data)
@@ -59,25 +59,28 @@ def test_lookup_sets_from_api_omits_total(monkeypatch):
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "25", None)
-    assert captured["params"]["card_number"] == "25"
+    assert captured["params"]["number"] == "25"
     assert "total" not in captured["params"]
     assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
 
 
 def test_lookup_sets_from_api_splits_number(monkeypatch):
     data = {"cards": []}
-    captured = {}
+    calls = []
 
     def fake_get(url, params=None, timeout=None, headers=None):
-        captured["params"] = params
-        captured["headers"] = headers
+        calls.append({"params": params, "headers": headers})
         return DummyResp(data)
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "25/102")
-    assert captured["params"]["card_number"] == "25"
-    assert captured["params"]["total"] == "102"
-    assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
+    assert len(calls) == 2
+    assert calls[0]["params"]["number"] == "25"
+    assert calls[0]["params"]["total"] == "102"
+    assert calls[0]["headers"] == {"User-Agent": "kartoteka/1.0"}
+    assert calls[1]["params"]["number"] == "25"
+    assert "total" not in calls[1]["params"]
+    assert calls[1]["headers"] == {"User-Agent": "kartoteka/1.0"}
 
 
 def test_lookup_sets_from_api_sanitizes_number(monkeypatch):
@@ -91,7 +94,7 @@ def test_lookup_sets_from_api_sanitizes_number(monkeypatch):
 
     monkeypatch.setattr(ui.requests, "get", fake_get)
     ui.lookup_sets_from_api("Pikachu", "037")
-    assert captured["params"]["card_number"] == "37"
+    assert captured["params"]["number"] == "37"
     assert captured["headers"] == {"User-Agent": "kartoteka/1.0"}
 
 


### PR DESCRIPTION
## Summary
- query card API using `number` instead of `card_number`
- retry set lookup without `total` when initial request returns no cards
- update tests for new parameter name and fallback logic

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6893c209b9d8832fbba64eb6d7c8d3dc