### PR TITLE
Add OCR fallback to analyze_card_image

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -904,65 +904,6 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
             if rect is None:
                 rect = (0, 0, 0, 0)
 
-            # Try OCR first
-            ocr_codes = extract_set_code_ocr(local_path, rect)
-            if ocr_codes:
-                if len(ocr_codes) == 1:
-                    code = ocr_codes[0]
-                    name_lookup = get_set_name(code)
-                    if name_lookup:
-                        set_code = code
-                        set_name = name_lookup
-                        print(f"[SUCCESS] OCR recognized set code: {name_lookup}")
-                        result = {
-                            "name": name,
-                            "number": number,
-                            "total": total,
-                            "set": set_name,
-                            "set_code": set_code,
-                            "orientation": orientation,
-                        }
-                        if debug and rect:
-                            result["rect"] = rect
-                        return result
-                else:
-                    matches = identify_set_by_hash(local_path, rect)
-                    if matches:
-                        code, name_match, diff = matches[0]
-                        if code in ocr_codes and diff <= HASH_DIFF_THRESHOLD:
-                            set_code = code
-                            set_name = name_match
-                            print(
-                                f"[SUCCESS] Local hash analysis disambiguated OCR: {name_match}"
-                            )
-                            result = {
-                                "name": name,
-                                "number": number,
-                                "total": total,
-                                "set": set_name,
-                                "set_code": set_code,
-                                "orientation": orientation,
-                            }
-                            if debug and rect:
-                                result["rect"] = rect
-                            return result
-                    name_lookup = get_set_name(ocr_codes[0])
-                    if name_lookup:
-                        set_code = ocr_codes[0]
-                        set_name = name_lookup
-                        print(f"[SUCCESS] OCR recognized set code: {name_lookup}")
-                        result = {
-                            "name": name,
-                            "number": number,
-                            "total": total,
-                            "set": set_name,
-                            "set_code": set_code,
-                            "orientation": orientation,
-                        }
-                        if debug and rect:
-                            result["rect"] = rect
-                        return result
-
             matches = identify_set_by_hash(local_path, rect)
             if matches:
                 code, name_match, diff = matches[0]
@@ -982,7 +923,28 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                         result["rect"] = rect
                     return result
 
-            print("[INFO] Hash analysis did not yield a confident result.")
+            print("[INFO] Hash analysis did not yield a confident result. Trying OCR...")
+
+            ocr_codes = extract_set_code_ocr(local_path, rect)
+            for code in ocr_codes:
+                name_lookup = get_set_name(code)
+                if name_lookup:
+                    set_code = code
+                    set_name = name_lookup
+                    print(f"[SUCCESS] OCR recognized set code: {name_lookup}")
+                    result = {
+                        "name": name,
+                        "number": number,
+                        "total": total,
+                        "set": set_name,
+                        "set_code": set_code,
+                        "orientation": orientation,
+                    }
+                    if debug and rect:
+                        result["rect"] = rect
+                    return result
+
+            print("[INFO] OCR analysis did not find a valid set code.")
         except Exception as e:
             print(f"[ERROR] Local analysis failed: {e}")
 

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -183,8 +183,8 @@ def test_analyze_card_image_ocr(monkeypatch):
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
 
-    with patch.object(ui, "extract_set_code_ocr", return_value=[SV01_CODE]) as mock_ocr, \
-        patch.object(ui, "identify_set_by_hash") as mock_hash, \
+    with patch.object(ui, "identify_set_by_hash", return_value=[]) as mock_hash, \
+        patch.object(ui, "extract_set_code_ocr", return_value=[SV01_CODE]) as mock_ocr, \
         patch.object(ui, "extract_card_info_openai") as mock_extract, \
         patch.object(ui, "lookup_sets_from_api") as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
@@ -197,24 +197,22 @@ def test_analyze_card_image_ocr(monkeypatch):
         "set_code": SV01_CODE,
         "orientation": 0,
     }
+    mock_hash.assert_called_once()
     mock_ocr.assert_called_once()
-    mock_hash.assert_not_called()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
 
 
-def test_analyze_card_image_ocr_multiple(monkeypatch):
+def test_analyze_card_image_hash_short_circuits_ocr(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
 
     with patch.object(
-        ui, "extract_set_code_ocr", return_value=[SV01_CODE, "other"]
-    ) as mock_ocr, patch.object(
         ui, "identify_set_by_hash", return_value=[(SV01_CODE, SV01_NAME, 0)]
-    ) as mock_hash, patch.object(ui, "extract_card_info_openai") as mock_extract, patch.object(
-        ui, "lookup_sets_from_api"
-    ) as mock_lookup:
+    ) as mock_hash, patch.object(ui, "extract_set_code_ocr") as mock_ocr, patch.object(
+        ui, "extract_card_info_openai"
+    ) as mock_extract, patch.object(ui, "lookup_sets_from_api") as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
     assert result == {
@@ -225,22 +223,22 @@ def test_analyze_card_image_ocr_multiple(monkeypatch):
         "set_code": SV01_CODE,
         "orientation": 0,
     }
-    mock_ocr.assert_called_once()
     mock_hash.assert_called_once()
+    mock_ocr.assert_not_called()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
 
 
-def test_analyze_card_image_ocr_multiple_ambiguous(monkeypatch):
+def test_analyze_card_image_hash_falls_back_to_ocr(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
 
     with patch.object(
+        ui, "identify_set_by_hash", return_value=[("x", "Set X", ui.HASH_DIFF_THRESHOLD + 1)]
+    ) as mock_hash, patch.object(
         ui, "extract_set_code_ocr", return_value=[SV01_CODE, "other"]
-    ) as mock_ocr, patch.object(
-        ui, "identify_set_by_hash", return_value=[("x", "Set X", 0)]
-    ) as mock_hash, patch.object(ui, "extract_card_info_openai") as mock_extract, patch.object(
+    ) as mock_ocr, patch.object(ui, "extract_card_info_openai") as mock_extract, patch.object(
         ui, "lookup_sets_from_api"
     ) as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
@@ -253,8 +251,8 @@ def test_analyze_card_image_ocr_multiple_ambiguous(monkeypatch):
         "set_code": SV01_CODE,
         "orientation": 0,
     }
-    mock_ocr.assert_called_once()
     mock_hash.assert_called_once()
+    mock_ocr.assert_called_once()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
 


### PR DESCRIPTION
## Summary
- Call `extract_set_code_ocr` after hash lookup fails in `analyze_card_image`
- Map OCR codes to set names via `get_set_name`
- Add tests for OCR fallback and hash short-circuit behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894650f637c832fabd0d5475c49359f