### PR TITLE
feat: make set logo hash threshold configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ FTP_USER=username
 FTP_PASSWORD=secret
 INVENTORY_CSV=magazyn.csv
 BASE_IMAGE_URL=https://your-store.shop/upload/images
+SET_HASH_THRESHOLD=128
 ```
 
 - `OPENAI_API_KEY` – API key used by OpenAI Vision to extract card details from scans.
+- `SET_HASH_THRESHOLD` – grayscale threshold for binarising set logos prior to hashing (default `128`).
 
 **Warning:** This file may contain private API keys and tokens. It is excluded
 from version control via `.gitignore` and should never be shared publicly.

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -62,6 +62,12 @@ HOLO_REVERSE_MULTIPLIER = 3.5
 SET_LOGO_DIR = "set_logos"
 HASH_DIFF_THRESHOLD = 10 # ZMIANA: Lekko zwiększony próg dla większej elastyczności
 
+SET_HASH_THRESHOLD = 128
+try:
+    SET_HASH_THRESHOLD = int(os.getenv("SET_HASH_THRESHOLD", SET_HASH_THRESHOLD))
+except ValueError:
+    pass
+
 DEFAULT_LOGO_LIMIT = 20
 try:
     DEFAULT_LOGO_LIMIT = int(os.getenv("SET_LOGO_LIMIT", DEFAULT_LOGO_LIMIT))
@@ -640,7 +646,10 @@ def identify_set_by_hash(
                 continue
             try:
                 with Image.open(path) as im:
-                    im = im.convert("L").point(lambda x: 0 if x < 128 else 255, "1")
+                    im = im.convert("L").point(
+                        lambda x, t=SET_HASH_THRESHOLD: 0 if x < t else 255,
+                        "1",
+                    )
                     logos[code] = (
                         imagehash.phash(im),
                         imagehash.dhash(im),
@@ -656,7 +665,10 @@ def identify_set_by_hash(
         with Image.open(scan_path) as im:
             crop = im.crop(rect)
             # ZMIANA: Przetwarzanie obrazu w celu usunięcia szumu tła przed haszowaniem
-            crop = crop.convert("L").point(lambda x: 0 if x < 128 else 255, '1')
+            crop = crop.convert("L").point(
+                lambda x, t=SET_HASH_THRESHOLD: 0 if x < t else 255,
+                "1",
+            )
             crop_hashes = (
                 imagehash.phash(crop),
                 imagehash.dhash(crop),

--- a/tests/test_identify_set_by_hash.py
+++ b/tests/test_identify_set_by_hash.py
@@ -33,3 +33,27 @@ def test_identify_set_by_hash_maps_code_to_name():
     code, name, _ = matches[0]
     assert ui.get_set_name(code) == name
     assert name == expected_name
+
+
+def test_set_hash_threshold_default(monkeypatch):
+    monkeypatch.delenv("SET_HASH_THRESHOLD", raising=False)
+    importlib.reload(ui)
+    assert ui.SET_HASH_THRESHOLD == 128
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "sv01.png"
+    with Image.open(logo_path) as im:
+        w, h = im.size
+    matches = ui.identify_set_by_hash(str(logo_path), (0, 0, w, h))
+    assert any(diff != 0 for _, _, diff in matches[1:4])
+
+
+def test_set_hash_threshold_custom(monkeypatch):
+    monkeypatch.setenv("SET_HASH_THRESHOLD", "0")
+    importlib.reload(ui)
+    assert ui.SET_HASH_THRESHOLD == 0
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / "sv01.png"
+    with Image.open(logo_path) as im:
+        w, h = im.size
+    matches = ui.identify_set_by_hash(str(logo_path), (0, 0, w, h))
+    assert matches and all(diff == 0 for _, _, diff in matches[:4])
+    monkeypatch.delenv("SET_HASH_THRESHOLD", raising=False)
+    importlib.reload(ui)


### PR DESCRIPTION
## Summary
- add `SET_HASH_THRESHOLD` env option to control logo binarisation for hashing
- replace hardcoded threshold in `identify_set_by_hash`
- document configurable threshold and test default and custom behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68947fc031ac832fba912119ad674309