### PR TITLE
Split store and warehouse CSV formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OPENAI_API_KEY=sk-...
 FTP_HOST=example.com
 FTP_USER=username
 FTP_PASSWORD=secret
-INVENTORY_CSV=magazyn.csv
+WAREHOUSE_CSV=magazyn.csv
 BASE_IMAGE_URL=https://your-store.shop/upload/images
 SET_HASH_THRESHOLD=128
 ```
@@ -53,7 +53,7 @@ SET_HASH_THRESHOLD=128
 from version control via `.gitignore` and should never be shared publicly.
 
 The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` supplies the key for OpenAI Vision to recognise card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
-`INVENTORY_CSV` controls where the local inventory CSV is written.
+`WAREHOUSE_CSV` controls where the local warehouse CSV is written.
 
 ## Running the App
 Execute the main script with Python 3:
@@ -116,7 +116,7 @@ empty. Missing bidding step and duration values default to `1` and `60` seconds
 respectively.
 
 ### CSV and image upload
-After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to FTP using the credentials from `.env`. The exported CSV includes `images 1` and `warehouse_code` columns with the remote image path and storage location. A copy of every row is also appended to the file specified in `INVENTORY_CSV` so the full stock list remains in one place. Use the **FTP Obrazy** button on the welcome screen to upload a folder of images to the configured FTP server.
+After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to FTP using the credentials from `.env`. A copy of every row is also appended to the file specified in `WAREHOUSE_CSV` so the full stock list remains in one place. Use the **FTP Obrazy** button on the welcome screen to upload a folder of images to the configured FTP server.
 
 ## License
 This project is licensed under the terms of the [MIT License](LICENSE).

--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -7,10 +7,10 @@ from ftp_client import FTPClient
 FTP_HOST = os.getenv("FTP_HOST")
 FTP_USER = os.getenv("FTP_USER")
 FTP_PASSWORD = os.getenv("FTP_PASSWORD")
-INVENTORY_CSV = os.getenv("INVENTORY_CSV", "magazyn.csv")
+WAREHOUSE_CSV = os.getenv("WAREHOUSE_CSV", "magazyn.csv")
 
-# column order for inventory CSV files
-INVENTORY_FIELDNAMES = [
+# column order for exported CSV files
+STORE_FIELDNAMES = [
     "product_code",
     "name",
     "producer_code",
@@ -19,20 +19,19 @@ INVENTORY_FIELDNAMES = [
     "short_description",
     "description",
     "price",
-    "psa10_price",
     "currency",
     "availability",
     "unit",
     "delivery",
-    "images 1",
+    "stock",
     "seo_title",
-    "seo_description",
-    "seo_keywords",
 ]
 
+WAREHOUSE_FIELDNAMES = ["name", "warehouse_code", "image"]
 
-def format_inventory_row(row):
-    """Return a row formatted for the inventory CSV."""
+
+def format_store_row(row):
+    """Return a row formatted for the store CSV."""
     name_parts = [row["nazwa"], row["numer"]]
     formatted_name = " ".join(part for part in name_parts if part)
 
@@ -45,15 +44,24 @@ def format_inventory_row(row):
         "short_description": row["short_description"],
         "description": row["description"],
         "price": row["cena"],
-        "psa10_price": row.get("psa10_price", ""),
         "currency": row.get("currency", "PLN"),
         "availability": row.get("availability", 1),
         "unit": row.get("unit", "szt."),
         "delivery": row.get("delivery", ""),
-        "images 1": row.get("image1", row.get("images", "")),
+        "stock": row.get("stock", 1),
         "seo_title": row.get("seo_title", ""),
-        "seo_description": row.get("seo_description", ""),
-        "seo_keywords": row.get("seo_keywords", ""),
+    }
+
+
+def format_warehouse_row(row):
+    """Return a row formatted for the warehouse CSV."""
+    name_parts = [row.get("nazwa"), row.get("numer")]
+    formatted_name = " ".join(part for part in name_parts if part)
+
+    return {
+        "name": formatted_name,
+        "warehouse_code": row.get("warehouse_code", ""),
+        "image": row.get("image1", row.get("images", "")),
     }
 
 
@@ -181,23 +189,23 @@ def export_csv(app):
             combined[key] = row.copy()
             combined[key]["stock"] = 1
 
-    fieldnames = INVENTORY_FIELDNAMES
+    fieldnames = STORE_FIELDNAMES
 
     with open(file_path, mode="w", encoding="utf-8", newline="") as file:
         writer = csv.DictWriter(file, fieldnames=fieldnames, delimiter=";")
         writer.writeheader()
         for row in combined.values():
-            writer.writerow(format_inventory_row(row))
-    append_inventory_csv(app)
+            writer.writerow(format_store_row(row))
+    append_warehouse_csv(app)
     messagebox.showinfo("Sukces", "Plik CSV został zapisany.")
     if messagebox.askyesno("Wysyłka", "Czy wysłać plik do Shoper?"):
         send_csv_to_shoper(app, file_path)
     app.back_to_welcome()
 
 
-def append_inventory_csv(app, path: str = INVENTORY_CSV):
-    """Append all collected rows to the inventory CSV."""
-    fieldnames = INVENTORY_FIELDNAMES
+def append_warehouse_csv(app, path: str = WAREHOUSE_CSV):
+    """Append all collected rows to the warehouse CSV."""
+    fieldnames = WAREHOUSE_FIELDNAMES
 
     file_exists = os.path.exists(path)
     with open(path, "a", encoding="utf-8", newline="") as f:
@@ -207,7 +215,7 @@ def append_inventory_csv(app, path: str = INVENTORY_CSV):
         for row in app.output_data:
             if row is None:
                 continue
-            writer.writerow(format_inventory_row(row))
+            writer.writerow(format_warehouse_row(row))
 
 
 def send_csv_to_shoper(app, file_path: str):

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1498,7 +1498,7 @@ class CardEditorApp:
             self._load_auction_queue()
         except FileNotFoundError:
             messagebox.showerror(
-                "Błąd", f"Nie znaleziono pliku {csv_utils.INVENTORY_CSV}"
+                "Błąd", f"Nie znaleziono pliku {csv_utils.WAREHOUSE_CSV}"
             )
             self.auction_queue = []
         except ValueError as exc:
@@ -1746,7 +1746,7 @@ class CardEditorApp:
                 codes = [treeview.item(i, "values")[0] for i in treeview.selection()]
                 if codes:
                     try:
-                        rows = self.read_inventory_rows(codes, csv_utils.INVENTORY_CSV)
+                        rows = self.read_inventory_rows(codes, csv_utils.WAREHOUSE_CSV)
                     except Exception as exc:
                         messagebox.showerror("Błąd", str(exc))
                         return
@@ -1863,10 +1863,10 @@ class CardEditorApp:
 
     def _load_auction_queue(self):
         """Load auction queue from ``magazyn.csv`` into ``self.auction_queue``."""
-        path = csv_utils.INVENTORY_CSV
+        path = csv_utils.WAREHOUSE_CSV
         self.auction_queue = self.read_inventory_rows([], path)
 
-    def read_inventory_rows(self, codes, path=csv_utils.INVENTORY_CSV):
+    def read_inventory_rows(self, codes, path=csv_utils.WAREHOUSE_CSV):
         """Return rows from ``path`` filtered by ``codes``."""
         with open(path, newline="", encoding="utf-8") as f:
             sample = f.read(2048)
@@ -1904,14 +1904,14 @@ class CardEditorApp:
         return rows
 
     def lookup_inventory_entry(self, key):
-        """Return first row from ``INVENTORY_CSV`` matching ``key``."""
+        """Return first row from ``WAREHOUSE_CSV`` matching ``key``."""
         try:
             name, number, set_name = key.split("|", 2)
         except ValueError:
             return None
 
         try:
-            with open(csv_utils.INVENTORY_CSV, newline="", encoding="utf-8") as f:
+            with open(csv_utils.WAREHOUSE_CSV, newline="", encoding="utf-8") as f:
                 reader = csv.DictReader(f, delimiter=";")
                 for raw in reader:
                     row = {norm_header(k): v for k, v in raw.items() if k is not None}
@@ -2110,7 +2110,7 @@ class CardEditorApp:
     def load_inventory_csv(self, widget):
         """Load local inventory data from the CSV file."""
         try:
-            path = csv_utils.INVENTORY_CSV
+            path = csv_utils.WAREHOUSE_CSV
             if isinstance(widget, ttk.Treeview):
                 style = ttk.Style(widget)
                 style.configure(
@@ -3054,7 +3054,7 @@ class CardEditorApp:
             self.session_csv_path = csv_path
             with open(csv_path, "w", encoding="utf-8", newline="") as f:
                 writer = csv.DictWriter(
-                    f, fieldnames=csv_utils.INVENTORY_FIELDNAMES, delimiter=";"
+                    f, fieldnames=csv_utils.STORE_FIELDNAMES, delimiter=";"
                 )
                 writer.writeheader()
         self.in_scan = True
@@ -4274,10 +4274,10 @@ class CardEditorApp:
             with open(self.session_csv_path, "a", encoding="utf-8", newline="") as f:
                 writer = csv.DictWriter(
                     f,
-                    fieldnames=csv_utils.INVENTORY_FIELDNAMES,
+                    fieldnames=csv_utils.STORE_FIELDNAMES,
                     delimiter=";",
                 )
-                writer.writerow(csv_utils.format_inventory_row(data))
+                writer.writerow(csv_utils.format_store_row(data))
 
     def save_and_next(self):
         """Save the current card data and display the next scan."""

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -447,7 +447,7 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
         f"name;numer;set\nPikachu;001;{SV01_NAME}\n",
         encoding="utf-8",
     )
-    monkeypatch.setenv("INVENTORY_CSV", str(csv_path))
+    monkeypatch.setenv("WAREHOUSE_CSV", str(csv_path))
     import importlib
     import kartoteka.csv_utils as csv_utils
     importlib.reload(csv_utils)

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -1,4 +1,5 @@
 import csv
+import csv
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -37,18 +38,19 @@ def test_export_includes_new_fields(tmp_path):
     with open(out_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
-        assert reader.fieldnames == csv_utils.INVENTORY_FIELDNAMES
+        assert reader.fieldnames == csv_utils.STORE_FIELDNAMES
         row = rows[0]
         assert row["currency"] == "PLN"
         assert row["producer_code"] == "1"
-        assert row["psa10_price"] == ""
+        assert row["stock"] == "1"
+        assert "psa10_price" not in reader.fieldnames
         assert "vat" not in reader.fieldnames
 
 
-def test_export_appends_inventory(tmp_path, monkeypatch):
+def test_export_appends_warehouse(tmp_path, monkeypatch):
     out_path = tmp_path / "out.csv"
     inv_path = tmp_path / "inv.csv"
-    monkeypatch.setenv("INVENTORY_CSV", str(inv_path))
+    monkeypatch.setenv("WAREHOUSE_CSV", str(inv_path))
     import importlib
     importlib.reload(csv_utils)
     importlib.reload(ui)
@@ -77,8 +79,8 @@ def test_export_appends_inventory(tmp_path, monkeypatch):
     with open(inv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
-        assert rows[0]["producer_code"] == "1"
-        assert rows[0]["currency"] == "PLN"
-        assert rows[0]["psa10_price"] == ""
+        assert reader.fieldnames == csv_utils.WAREHOUSE_FIELDNAMES
+        assert rows[0]["name"] == "Pikachu 1"
+        assert rows[0]["image"] == "img.jpg"
 
 

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -62,8 +62,8 @@ def test_session_csv_created(tmp_path):
     assert dummy.session_csv_path == str(session_path)
     with open(session_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
-        assert reader.fieldnames == csv_utils.INVENTORY_FIELDNAMES
-        assert "psa10_price" in reader.fieldnames
+        assert reader.fieldnames == csv_utils.STORE_FIELDNAMES
+        assert "stock" in reader.fieldnames
 
 
 def test_save_current_appends_session(tmp_path):
@@ -71,7 +71,7 @@ def test_save_current_appends_session(tmp_path):
     dummy = make_dummy()
     dummy.session_csv_path = str(session_path)
     with open(session_path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.DictWriter(f, fieldnames=csv_utils.INVENTORY_FIELDNAMES, delimiter=";")
+        writer = csv.DictWriter(f, fieldnames=csv_utils.STORE_FIELDNAMES, delimiter=";")
         writer.writeheader()
 
     ui.CardEditorApp.save_current_data(dummy)
@@ -83,5 +83,5 @@ def test_save_current_appends_session(tmp_path):
         assert rows[0]["name"]
         assert rows[0]["currency"] == "PLN"
         assert rows[0]["producer_code"] == "4"
-        assert rows[0]["psa10_price"] == ""
+        assert rows[0]["stock"] == "1"
 


### PR DESCRIPTION
## Summary
- separate store export and warehouse archival field lists
- add helpers to format store and warehouse rows
- export store CSV while appending warehouse data to `magazyn.csv`
- update UI and tests for new constants and functions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68948ac60fa4832f9ef4a38d245097a5