### PR TITLE
Use inventory CSV for warehouse operations

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -7,7 +7,10 @@ from ftp_client import FTPClient
 FTP_HOST = os.getenv("FTP_HOST")
 FTP_USER = os.getenv("FTP_USER")
 FTP_PASSWORD = os.getenv("FTP_PASSWORD")
-WAREHOUSE_CSV = os.getenv("WAREHOUSE_CSV", "magazyn.csv")
+INVENTORY_CSV = os.getenv(
+    "INVENTORY_CSV", os.getenv("WAREHOUSE_CSV", "magazyn.csv")
+)
+WAREHOUSE_CSV = os.getenv("WAREHOUSE_CSV", INVENTORY_CSV)
 
 # column order for exported CSV files
 STORE_FIELDNAMES = [

--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -1,4 +1,6 @@
+import csv
 import re
+from . import csv_utils
 
 
 def location_from_code(code: str) -> str:
@@ -38,31 +40,47 @@ def next_free_location(app):
     return generate_location(idx)
 
 
-def compute_column_occupancy(app):
+def compute_column_occupancy():
     occ = {b: {c: 0 for c in range(1, 5)} for b in range(1, 9)}
-    for row in getattr(app, "output_data", []):
-        codes = str(row.get("warehouse_code") or "").split(";")
-        for code in codes:
-            code = code.strip()
-            if not code:
-                continue
-            m = re.match(r"K(\d+)R(\d)P(\d+)", code)
-            if not m:
-                continue
-            box = int(m.group(1))
-            c = int(m.group(2))
-            if box in occ and c in occ[box]:
-                occ[box][c] += 1
+    try:
+        with open(csv_utils.INVENTORY_CSV, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter=";")
+            for row in reader:
+                codes = str(row.get("warehouse_code") or "").split(";")
+                for code in codes:
+                    code = code.strip()
+                    if not code:
+                        continue
+                    m = re.match(r"K(\d+)R(\d)P(\d+)", code)
+                    if not m:
+                        continue
+                    box = int(m.group(1))
+                    c = int(m.group(2))
+                    if box in occ and c in occ[box]:
+                        occ[box][c] += 1
+    except FileNotFoundError:
+        pass
     return occ
 
 
-def repack_column(app, box: int, column: int):
+def repack_column(box: int, column: int):
+    path = csv_utils.INVENTORY_CSV
+    try:
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter=";")
+            fieldnames = reader.fieldnames or []
+            rows = list(reader)
+    except FileNotFoundError:
+        return
+
     pattern = re.compile(r"K(\d+)R(\d)P(\d+)")
     entries = []
-    for row in getattr(app, "output_data", []):
-        if not row:
-            continue
-        codes = [c.strip() for c in str(row.get("warehouse_code") or "").split(";") if c.strip()]
+    for row in rows:
+        codes = [
+            c.strip()
+            for c in str(row.get("warehouse_code") or "").split(";")
+            if c.strip()
+        ]
         for idx, code in enumerate(codes):
             m = pattern.fullmatch(code)
             if m and int(m.group(1)) == box and int(m.group(2)) == column:
@@ -74,6 +92,9 @@ def repack_column(app, box: int, column: int):
         codes[idx] = f"K{box:02d}R{column}P{new_pos:04d}"
         row["warehouse_code"] = ";".join(codes)
 
-    if entries and hasattr(app, "refresh_magazyn"):
-        app.refresh_magazyn()
+    if entries:
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+            writer.writeheader()
+            writer.writerows(rows)
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2296,11 +2296,12 @@ class CardEditorApp:
 
     def compute_column_occupancy(self):
         """Return dictionary of used slots per box column."""
-        return storage.compute_column_occupancy(self)
+        return storage.compute_column_occupancy()
 
     def repack_column(self, box: int, column: int):
         """Renumber codes in the given column so there are no gaps."""
-        storage.repack_column(self, box, column)
+        storage.repack_column(box, column)
+        self.refresh_magazyn()
 
     def refresh_magazyn(self):
         """Refresh storage view and color code capacity usage.

--- a/tests/test_column_occupancy.py
+++ b/tests/test_column_occupancy.py
@@ -6,11 +6,18 @@ from unittest.mock import MagicMock
 
 sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-import kartoteka.ui as ui
 
 
-def test_split_codes_counted():
+def test_split_codes_counted(tmp_path, monkeypatch):
+    from kartoteka import csv_utils
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        'name;warehouse_code\nA;"K1R1P1;K1R1P2"\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(csv_utils, "INVENTORY_CSV", str(csv_path))
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(csv_path))
+    import kartoteka.ui as ui
     importlib.reload(ui)
-    dummy = SimpleNamespace(output_data=[{"warehouse_code": "K1R1P1;K1R1P2"}])
+    dummy = SimpleNamespace()
     occ = ui.CardEditorApp.compute_column_occupancy(dummy)
     assert occ[1][1] == 2

--- a/tests/test_repack_column.py
+++ b/tests/test_repack_column.py
@@ -1,3 +1,4 @@
+import csv
 import importlib
 import sys
 from pathlib import Path
@@ -6,30 +7,37 @@ from unittest.mock import MagicMock
 
 sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-import kartoteka.ui as ui
-importlib.reload(ui)
 
 
-def test_repack_after_removal():
-    dummy = SimpleNamespace(
-        output_data=[
-            {"warehouse_code": "K01R1P0001"},
-            {"warehouse_code": "K01R1P0003"},
-        ],
-        mag_canvases=[],
-        mag_box_photo=SimpleNamespace(width=lambda: 0, height=lambda: 0),
-        refresh_magazyn=lambda: None,
+def _prepare_csv(tmp_path, content):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(content, encoding="utf-8")
+    from kartoteka import csv_utils
+    csv_utils.INVENTORY_CSV = csv_utils.WAREHOUSE_CSV = str(csv_path)
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+    return csv_path, ui
+
+
+def test_repack_after_removal(tmp_path):
+    csv_path, ui = _prepare_csv(
+        tmp_path,
+        "name;warehouse_code\nA;K01R1P0001\nB;K01R1P0003\n",
     )
+    dummy = SimpleNamespace(refresh_magazyn=lambda: None)
     ui.CardEditorApp.repack_column(dummy, 1, 1)
-    assert dummy.output_data[1]["warehouse_code"] == "K01R1P0002"
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f, delimiter=";"))
+    assert rows[1]["warehouse_code"] == "K01R1P0002"
 
 
-def test_repack_within_row():
-    dummy = SimpleNamespace(
-        output_data=[{"warehouse_code": "K01R1P0001;K01R1P0003"}],
-        mag_canvases=[],
-        mag_box_photo=SimpleNamespace(width=lambda: 0, height=lambda: 0),
-        refresh_magazyn=lambda: None,
+def test_repack_within_row(tmp_path):
+    csv_path, ui = _prepare_csv(
+        tmp_path,
+        'name;warehouse_code\nA;"K01R1P0001;K01R1P0003"\n',
     )
+    dummy = SimpleNamespace(refresh_magazyn=lambda: None)
     ui.CardEditorApp.repack_column(dummy, 1, 1)
-    assert dummy.output_data[0]["warehouse_code"] == "K01R1P0001;K01R1P0002"
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f, delimiter=";"))
+    assert rows[0]["warehouse_code"] == "K01R1P0001;K01R1P0002"


### PR DESCRIPTION
## Summary
- Count column usage from `INVENTORY_CSV` rather than in-memory data and repack columns by rewriting the CSV
- Expose `INVENTORY_CSV` in `csv_utils` and update the UI to refresh from file-based storage functions
- Adjust tests to work with temporary inventory files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894cde5ca14832f94b4a773406c49c8