### PR TITLE
Handle new inventory CSV format

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1862,12 +1862,22 @@ class CardEditorApp:
         return refresh_tree
 
     def _load_auction_queue(self):
-        """Load auction queue from ``magazyn.csv`` into ``self.auction_queue``."""
-        path = csv_utils.WAREHOUSE_CSV
+        """Load auction queue from inventory CSV into ``self.auction_queue``."""
+        path = getattr(
+            csv_utils,
+            "WAREHOUSE_CSV",
+            getattr(csv_utils, "INVENTORY_CSV", "magazyn.csv"),
+        )
         self.auction_queue = self.read_inventory_rows([], path)
 
-    def read_inventory_rows(self, codes, path=csv_utils.WAREHOUSE_CSV):
+    def read_inventory_rows(self, codes, path=None):
         """Return rows from ``path`` filtered by ``codes``."""
+        if path is None:
+            path = getattr(
+                csv_utils,
+                "WAREHOUSE_CSV",
+                getattr(csv_utils, "INVENTORY_CSV", "magazyn.csv"),
+            )
         with open(path, newline="", encoding="utf-8") as f:
             sample = f.read(2048)
             f.seek(0)
@@ -1898,6 +1908,11 @@ class CardEditorApp:
                     row.setdefault("czas_trwania", "60")
             else:
                 raise ValueError("Nie rozpoznano formatu pliku CSV")
+        for row in rows:
+            row.setdefault("price", "0")
+            row.setdefault("product_code", "")
+            if "image" in row and "images 1" not in row:
+                row["images 1"] = row.pop("image")
         if codes:
             wanted = {str(c) for c in codes}
             rows = [r for r in rows if str(r.get("product_code")) in wanted]

--- a/tests/test_read_inventory_rows.py
+++ b/tests/test_read_inventory_rows.py
@@ -67,5 +67,16 @@ def test_read_inventory_rows_extra_values_ignored(tmp_path):
     )
     dummy = SimpleNamespace()
     rows = ui.CardEditorApp.read_inventory_rows(dummy, [], str(csv_path))
-    assert rows == [{"product_code": "1", "nazwa_karty": "A"}]
+    assert rows == [{"product_code": "1", "nazwa_karty": "A", "price": "0"}]
+
+
+def test_read_inventory_rows_image_and_defaults(tmp_path):
+    csv_path = tmp_path / "inv.csv"
+    csv_path.write_text("name;image\nTest 1;img.png\n", encoding="utf-8")
+    dummy = SimpleNamespace()
+    rows = ui.CardEditorApp.read_inventory_rows(dummy, [], str(csv_path))
+    assert rows[0]["images 1"] == "img.png"
+    assert rows[0]["price"] == "0"
+    assert rows[0]["product_code"] == ""
+    assert rows[0]["cena_początkowa"] == "0"
 


### PR DESCRIPTION
## Summary
- Map `image` header to `images 1` and default missing `price` and `product_code` values when reading inventory CSVs
- Load auction queues using the updated inventory CSV constants
- Test reading of the new inventory CSV format

## Testing
- `pytest tests/test_read_inventory_rows.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894d97a7a50832fb8656fe6cdc20fa7