### PR TITLE
Support set abbreviations in lookups

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -127,6 +127,8 @@ def reload_sets():
     """Load set definitions from the JSON files."""
     global tcg_sets_eng_by_era, tcg_sets_eng_map, tcg_sets_eng, tcg_sets_eng_code_map
     global tcg_sets_jp_by_era, tcg_sets_jp_map, tcg_sets_jp, tcg_sets_jp_code_map
+    global tcg_sets_eng_abbr_map, tcg_sets_eng_abbr_name_map
+    global tcg_sets_jp_abbr_map, tcg_sets_jp_abbr_name_map
 
     try:
         with open("tcg_sets.json", encoding="utf-8") as f:
@@ -142,6 +144,18 @@ def reload_sets():
         item["code"]: item["name"]
         for sets in tcg_sets_eng_by_era.values()
         for item in sets
+    }
+    tcg_sets_eng_abbr_map = {
+        item["abbr"]: item["code"]
+        for sets in tcg_sets_eng_by_era.values()
+        for item in sets
+        if "abbr" in item
+    }
+    tcg_sets_eng_abbr_name_map = {
+        item["abbr"]: item["name"]
+        for sets in tcg_sets_eng_by_era.values()
+        for item in sets
+        if "abbr" in item
     }
     tcg_sets_eng = [
         item["name"] for sets in tcg_sets_eng_by_era.values() for item in sets
@@ -162,6 +176,18 @@ def reload_sets():
         for sets in tcg_sets_jp_by_era.values()
         for item in sets
     }
+    tcg_sets_jp_abbr_map = {
+        item["abbr"]: item["code"]
+        for sets in tcg_sets_jp_by_era.values()
+        for item in sets
+        if "abbr" in item
+    }
+    tcg_sets_jp_abbr_name_map = {
+        item["abbr"]: item["name"]
+        for sets in tcg_sets_jp_by_era.values()
+        for item in sets
+        if "abbr" in item
+    }
     tcg_sets_jp = [
         item["name"] for sets in tcg_sets_jp_by_era.values() for item in sets
     ]
@@ -180,11 +206,16 @@ ALLOWED_SET_CODES = {
 
 
 def get_set_code(name: str) -> str:
-    """Return the API code for a set name if available."""
+    """Return the API code for a set name or abbreviation if available."""
     if not name:
         return ""
     search = name.strip().lower()
-    for mapping in (tcg_sets_eng_map, tcg_sets_jp_map):
+    for mapping in (
+        tcg_sets_eng_map,
+        tcg_sets_jp_map,
+        tcg_sets_eng_abbr_map,
+        tcg_sets_jp_abbr_map,
+    ):
         for key, code in mapping.items():
             if key.lower() == search:
                 return code
@@ -192,15 +223,22 @@ def get_set_code(name: str) -> str:
 
 
 def get_set_name(code: str) -> str:
-    """Return the display name for a set code if available."""
+    """Return the display name for a set code or abbreviation if available."""
     if not code:
         return ""
     search = code.strip().lower()
-    for mapping in (tcg_sets_eng_code_map, tcg_sets_jp_code_map):
+    for mapping in (
+        tcg_sets_eng_code_map,
+        tcg_sets_jp_code_map,
+        tcg_sets_eng_abbr_name_map,
+        tcg_sets_jp_abbr_name_map,
+    ):
         for key, name in mapping.items():
             if key.lower() == search:
                 return name
-    print(f"Nie znaleziono nazwy dla setu '{code}'. Weryfikacja ręczna wymagana.")
+    print(
+        f"Nie znaleziono nazwy dla setu '{code}'. Weryfikacja ręczna wymagana."
+    )
     return code
 
 

--- a/tests/test_get_set_code_from_abbr.py
+++ b/tests/test_get_set_code_from_abbr.py
@@ -1,0 +1,13 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui  # noqa: E402
+importlib.reload(ui)
+
+
+def test_get_set_code_from_abbreviation():
+    assert ui.get_set_code("DRI") == "sv10"

--- a/tests/test_get_set_name.py
+++ b/tests/test_get_set_name.py
@@ -15,3 +15,7 @@ def test_get_set_name_unknown_triggers_warning(capsys):
     captured = capsys.readouterr()
     assert result == code
     assert "Weryfikacja ręczna wymagana" in captured.out
+
+
+def test_get_set_name_from_abbr():
+    assert ui.get_set_name("DRI") == "Destined Rivals"


### PR DESCRIPTION
## Summary
- map set abbreviations to codes and names
- resolve set codes and names from abbreviations
- test abbreviation lookups for Destined Rivals

## Testing
- `pytest tests/test_get_set_name.py tests/test_get_set_code_from_abbr.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68959fdfd36c832f9adab51b9d05db94