### PR TITLE
Include ptcgo abbreviations in set files

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3664,13 +3664,17 @@ class CardEditorApp:
             series = item.get("series") or "Other"
             code = item.get("id")
             name = item.get("name")
+            abbr = item.get("ptcgoCode")
             if not code or not name:
                 continue
             code_key = code.strip().lower()
             if code_key in existing_codes:
                 continue
             group = current_sets.setdefault(series, [])
-            group.append({"name": name, "code": code})
+            entry = {"name": name, "code": code}
+            if abbr:
+                entry["abbr"] = abbr
+            group.append(entry)
             existing_codes.add(code_key)
             added += 1
             new_items.append({"name": name, "code": code})

--- a/tests/test_sets_file.py
+++ b/tests/test_sets_file.py
@@ -51,7 +51,16 @@ def run_update_sets(tmp_path, filename):
 
     resp = SimpleNamespace(
         status_code=200,
-        json=lambda: {"data": [{"series": "X", "id": "CODE", "name": "Name"}]},
+        json=lambda: {
+            "data": [
+                {
+                    "series": "X",
+                    "id": "CODE",
+                    "name": "Name",
+                    "ptcgoCode": "PTCGO",
+                }
+            ]
+        },
         raise_for_status=lambda: None,
     )
     with patch("requests.get", return_value=resp), patch.object(ui, "reload_sets") as reload_mock:
@@ -59,9 +68,9 @@ def run_update_sets(tmp_path, filename):
         reload_mock.assert_called_once()
 
     data = json.loads(sets_file.read_text(encoding="utf-8"))
-    # expect inserted under "X" with code and name
+    # expect inserted under "X" with code, name and abbr
     assert "X" in data
-    assert {"name": "Name", "code": "CODE"} in data["X"]
+    assert {"name": "Name", "code": "CODE", "abbr": "PTCGO"} in data["X"]
     dummy.download_set_symbols.assert_called_once_with([{"name": "Name", "code": "CODE"}])
 
 


### PR DESCRIPTION
## Summary
- store PTCGO `ptcgoCode` as `abbr` when updating set JSONs
- test that update_sets writes the `abbr` field to set files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a225c898832f84d9ebc932ee35ba