### PR TITLE
Rotate horizontal scans before hashing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -864,8 +864,12 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
         try:
             with Image.open(local_path) as im:
                 w, h = im.size
-            orientation = 90 if w > h else 0
-            rect = get_symbol_rect(w, h)
+                orientation = 90 if w > h else 0
+                if orientation == 90:
+                    im = im.rotate(90, expand=True)
+                    im.save(local_path)
+                    w, h = im.size
+                rect = get_symbol_rect(w, h)
         except Exception:
             rect = None
 

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -396,6 +396,30 @@ def test_analyze_card_image_orientation(tmp_path, monkeypatch):
     assert result["orientation"] == 90
 
 
+def test_analyze_card_image_horizontal_scan(tmp_path, monkeypatch):
+    """Ensure horizontal scans are rotated and hashed correctly."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    img_path = tmp_path / "horizontal.png"
+    Image.new("RGB", (400, 200), color="white").save(img_path)
+
+    expected_rect = ui.get_symbol_rect(200, 400)
+
+    def fake_hash(path, rect):
+        assert rect == expected_rect
+        return [(SV01_CODE, SV01_NAME, 0)]
+
+    monkeypatch.setattr(ui, "identify_set_by_hash", fake_hash)
+    monkeypatch.setattr(ui, "extract_card_info_openai", lambda *a, **k: ("", "", "", "", ""))
+    monkeypatch.setattr(ui, "lookup_sets_from_api", lambda *a, **k: [])
+    monkeypatch.setattr(ui, "extract_set_code_ocr", lambda *a, **k: [])
+
+    result = ui.analyze_card_image(str(img_path))
+
+    assert result["set"] == SV01_NAME
+    assert result["set_code"] == SV01_CODE
+    assert result["orientation"] == 90
+
+
 def test_analyze_and_fill_translates_for_jp(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
 


### PR DESCRIPTION
## Summary
- rotate locally loaded card scans by 90° when width exceeds height
- recompute set symbol region after rotation and use it for hashing
- test horizontal scans to ensure rotated region is hashed for set identification

## Testing
- `pytest tests/test_analyze_card_image.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895d5177620832f8c73795e8b9484f7