### PR TITLE
Reject unknown OCR codes

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -985,7 +985,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
             ocr_codes = extract_set_code_ocr(local_path, rect)
             for code in ocr_codes:
                 name_lookup = get_set_name(code)
-                if name_lookup:
+                if name_lookup and name_lookup != code:
                     set_code = code
                     set_name = name_lookup
                     print(f"[SUCCESS] OCR recognized set code: {name_lookup}")
@@ -1000,6 +1000,8 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                     if debug and rect:
                         result["rect"] = rect
                     return result
+                else:
+                    print(f"[WARN] OCR produced unknown set code: {code}")
 
             print("[INFO] OCR analysis did not find a valid set code.")
         except Exception as e:

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -203,6 +203,33 @@ def test_analyze_card_image_ocr(monkeypatch):
     mock_lookup.assert_not_called()
 
 
+def test_analyze_card_image_ocr_unknown_code(monkeypatch, capsys):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
+
+    with patch.object(ui, "identify_set_by_hash", return_value=[]) as mock_hash, \
+        patch.object(ui, "extract_set_code_ocr", return_value=["XYZ"]) as mock_ocr, \
+        patch.object(ui, "extract_card_info_openai") as mock_extract, \
+        patch.object(ui, "lookup_sets_from_api") as mock_lookup:
+        result = ui.analyze_card_image(str(logo_path))
+
+    assert result == {
+        "name": "",
+        "number": "",
+        "total": "",
+        "set": "",
+        "set_code": "",
+        "orientation": 0,
+    }
+    mock_hash.assert_called_once()
+    mock_ocr.assert_called_once()
+    mock_extract.assert_not_called()
+    mock_lookup.assert_not_called()
+    out, err = capsys.readouterr()
+    assert "OCR produced unknown set code: XYZ" in out
+
+
 def test_analyze_card_image_hash_short_circuits_ocr(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 


### PR DESCRIPTION
## Summary
- ignore OCR set codes that don't map to known sets
- log warnings for rejected OCR codes
- add regression test for unknown OCR codes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895dcda4e84832f9394bc65e27c4c0d