### PR TITLE
Increase set code match cutoff and validate weak match rejection

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -63,6 +63,15 @@ SET_LOGO_DIR = "set_logos"
 HASH_DIFF_THRESHOLD = 20  # hash difference threshold for accepting matches
 HASH_SIZE = (32, 32)
 
+# minimum similarity ratio for fuzzy set code matching
+SET_CODE_MATCH_CUTOFF = 0.8
+try:
+    SET_CODE_MATCH_CUTOFF = float(
+        os.getenv("SET_CODE_MATCH_CUTOFF", SET_CODE_MATCH_CUTOFF)
+    )
+except ValueError:
+    pass
+
 _LOGO_HASHES: dict[str, tuple[imagehash.ImageHash, imagehash.ImageHash, imagehash.ImageHash]] = {}
 
 
@@ -660,7 +669,9 @@ def match_set_code(value: str) -> str:
     if value in codes:
         return value
 
-    match = difflib.get_close_matches(value, list(codes), n=1, cutoff=0.6)
+    match = difflib.get_close_matches(
+        value, list(codes), n=1, cutoff=SET_CODE_MATCH_CUTOFF
+    )
     if match:
         return match[0]
     return ""

--- a/tests/test_match_set_code.py
+++ b/tests/test_match_set_code.py
@@ -19,6 +19,10 @@ def test_match_set_code_fuzzy():
     assert ui.match_set_code("swsh-11") == "swsh11"
 
 
+def test_match_set_code_weak_match_rejected():
+    assert ui.match_set_code("sws-111") == ""
+
+
 def test_match_set_code_unknown():
     assert ui.match_set_code("unknown") == ""
 


### PR DESCRIPTION
## Summary
- raise fuzzy set code match cutoff to configurable constant (default 0.8)
- test weak set code matches are rejected

## Testing
- `pytest tests/test_match_set_code.py`


------
https://chatgpt.com/codex/tasks/task_e_6895e00b6cb0832f90945cd5a807dd58