### PR TITLE
Normalize set codes by stripping language suffixes

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -252,7 +252,10 @@ def get_set_code(name: str) -> str:
     """Return the API code for a set name or abbreviation if available."""
     if not name:
         return ""
-    search = name.strip().lower()
+    search = name.strip()
+    # remove trailing language or other short alphabetic suffixes like "EN", "JP"
+    search = re.sub(r"[-_\s]+[a-z]{1,3}$", "", search, flags=re.IGNORECASE)
+    search = search.strip().lower()
     for mapping in (
         tcg_sets_eng_map,
         tcg_sets_jp_map,
@@ -3740,6 +3743,12 @@ class CardEditorApp:
             set_code = "xpre"
         else:
             set_code = get_set_code(set_name)
+        full_name = get_set_name(set_code)
+        if hasattr(self, "set_var"):
+            try:
+                self.set_var.set(full_name)
+            except Exception:
+                pass
 
         try:
             headers = {}
@@ -3830,6 +3839,12 @@ class CardEditorApp:
             set_code = "xpre"
         else:
             set_code = get_set_code(set_name)
+        full_name = get_set_name(set_code)
+        if hasattr(self, "set_var"):
+            try:
+                self.set_var.set(full_name)
+            except Exception:
+                pass
 
         try:
             headers = {}
@@ -3907,6 +3922,12 @@ class CardEditorApp:
             set_code = "xpre"
         else:
             set_code = get_set_code(set_name)
+        full_name = get_set_name(set_code)
+        if hasattr(self, "set_var"):
+            try:
+                self.set_var.set(full_name)
+            except Exception:
+                pass
 
         try:
             headers = {}
@@ -3982,6 +4003,12 @@ class CardEditorApp:
             set_code = "xpre"
         else:
             set_code = get_set_code(set_name)
+        full_name = get_set_name(set_code)
+        if hasattr(self, "set_var"):
+            try:
+                self.set_var.set(full_name)
+            except Exception:
+                pass
 
         try:
             headers = {}

--- a/tests/test_get_set_code_from_abbr.py
+++ b/tests/test_get_set_code_from_abbr.py
@@ -11,3 +11,10 @@ importlib.reload(ui)
 
 def test_get_set_code_from_abbreviation():
     assert ui.get_set_code("DRI") == "sv10"
+
+
+def test_get_set_code_strips_suffixes_to_full_name():
+    for suffix in ("", " EN", " JP"):
+        code = ui.get_set_code(f"DRI{suffix}")
+        assert code == "sv10"
+        assert ui.get_set_name(code) == "Destined Rivals"


### PR DESCRIPTION
## Summary
- ignore language suffixes when resolving set codes
- after mapping code, update UI to show full set name
- cover language-suffixed abbreviations in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689724983784832fa20e47084006de3a