### PR TITLE
Handle card image locally for OpenAI analysis

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -803,32 +803,47 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
     ``set_name`` value is normalised to the canonical display name whenever a
     matching ``set_code`` can be resolved.
     """
-    parsed = urlparse(path)
-    if parsed.scheme in ("http", "https"):
-        url = path
-    else:
-        folder = os.path.basename(os.path.dirname(path))
-        filename = os.path.basename(path)
-        url = f"{BASE_IMAGE_URL}/{folder}/{filename}"
-
     try:
+        parsed = urlparse(path)
+        if parsed.scheme in ("http", "https"):
+            try:
+                r = requests.get(path, timeout=10)
+                r.raise_for_status()
+                mime = r.headers.get("Content-Type") or mimetypes.guess_type(path)[0] or "image/jpeg"
+                encoded = base64.b64encode(r.content).decode("utf-8")
+            except Exception as e:
+                print(f"[ERROR] extract_card_info_openai failed to fetch image: {e}")
+                return "", "", "", "", ""
+        else:
+            mime = mimetypes.guess_type(path)[0] or "image/jpeg"
+            try:
+                with open(path, "rb") as f:
+                    encoded = base64.b64encode(f.read()).decode("utf-8")
+            except OSError as e:
+                print(f"[ERROR] extract_card_info_openai failed to read image: {e}")
+                return "", "", "", "", ""
+        data_url = f"data:{mime};base64,{encoded}"
+
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             return "", "", "", "", ""
         client = openai.OpenAI(api_key=api_key)
-        
-        # ZMIANA: Prompt prosi o nazwę, numer i ZESTAW (set_name)
-        prompt_text = "Extract the Pokémon card's name, number, and set name. Return as JSON: {\"name\":\"\", \"number\":\"\", \"set_name\":\"\"}."
+
+        prompt_text = (
+            "You must return a JSON object with the Pokémon card's English name, "
+            "card number in the form NNN/NNN, and English set name. The response "
+            "must strictly match {\"name\":\"\", \"number\":\"\", \"set_name\":\"\"}."
+        )
 
         resp = client.chat.completions.create(
-            model="gpt-4o",
+            model="gpt-5",
             response_format={"type": "json_object"},
             messages=[
                 {
                     "role": "user",
                     "content": [
                         {"type": "text", "text": prompt_text},
-                        {"type": "image_url", "image_url": {"url": url}},
+                        {"type": "image_url", "image_url": {"url": data_url}},
                     ],
                 }
             ],

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -23,8 +23,11 @@ SV01_CODE = "sv01"
 SV01_NAME = ui.get_set_name(SV01_CODE)
 
 
-def test_extract_card_info_openai_maps_set(monkeypatch):
+def test_extract_card_info_openai_maps_set(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
 
     payload = {"name": "Pikachu", "number": "037/198", "set_name": SV01_CODE}
     resp = SimpleNamespace(
@@ -38,7 +41,7 @@ def test_extract_card_info_openai_maps_set(monkeypatch):
             )
 
     monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
-    name, number, total, set_name, set_code = ui.extract_card_info_openai("/tmp/x.jpg")
+    name, number, total, set_name, set_code = ui.extract_card_info_openai(str(img))
     assert (name, number, total) == ("Pikachu", "037", "198")
     assert set_code == SV01_CODE
     assert set_name == SV01_NAME


### PR DESCRIPTION
## Summary
- Encode card images as data URLs before sending to OpenAI
- Prompt GPT-5 to return strict JSON with name, number (NNN/NNN), and set name
- Adjust tests to supply a local image path

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689728fa381c832fbf5fe6ecd95a9d34