### PR TITLE
Allow slash and hyphen in OCR whitelist

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -773,7 +773,8 @@ def extract_set_code_ocr(
             crop = im.crop(rect)
         crop = crop.convert("L").resize((crop.width * 3, crop.height * 3))
         raw = pytesseract.image_to_string(
-            crop, config="--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            crop,
+            config="--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ/-",
         )
     except Exception:
         return []

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -14,7 +14,6 @@ sys.modules["customtkinter"] = SimpleNamespace(
     CTkButton=MagicMock,
     CTkToplevel=MagicMock,
 )
-sys.modules["pytesseract"] = SimpleNamespace(image_to_string=MagicMock(return_value=""))
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import kartoteka.ui as ui
 importlib.reload(ui)
@@ -302,7 +301,7 @@ def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
     assert processed.size == (30, 30)
     assert (
         ocr.call_args.kwargs.get("config")
-        == "--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        == "--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ/-"
     )
 
 

--- a/tests/test_pytesseract_whitelist.py
+++ b/tests/test_pytesseract_whitelist.py
@@ -1,0 +1,16 @@
+import shutil
+import pytest
+from PIL import Image, ImageDraw, ImageFont
+import pytesseract
+
+@pytest.mark.skipif(shutil.which("tesseract") is None, reason="tesseract not installed")
+def test_pytesseract_recognizes_fraction():
+    img = Image.new("L", (200, 80), color=255)
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.truetype("DejaVuSans.ttf", 40)
+    draw.text((10, 10), "96/108", font=font, fill=0)
+    text = pytesseract.image_to_string(
+        img,
+        config="--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ/-",
+    )
+    assert text.strip() == "96/108"


### PR DESCRIPTION
## Summary
- allow OCR to recognise slashes and hyphens by extending tessedit_char_whitelist
- cover pytesseract with a test that reads "96/108" from an image snippet
- adjust existing set code OCR test for the new whitelist

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68972a3d46e0832fad76cc52903f832f