### PR TITLE
Handle multiple symbol positions when hashing cards

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -694,22 +694,37 @@ def match_set_code(value: str) -> str:
     return ""
 
 
-def get_symbol_rect(w: int, h: int) -> tuple[int, int, int, int]:
-    """Return a rectangle around the expected set symbol location.
+def get_symbol_rects(w: int, h: int) -> list[tuple[int, int, int, int]]:
+    """Return possible rectangles around expected set symbol locations.
 
-    The symbol is typically located near the bottom-left corner of a card.
-    For very small images (e.g. stand-alone set logos) the entire image is
-    returned to ensure matching still works in tests and for direct logo
-    comparisons.
+    The set symbol is usually near the bottom-left corner of a card, but
+    rotated or unusually formatted scans may place it in other corners.  This
+    helper returns a list of candidate rectangles in the following order:
+    bottom-left, bottom-right, top-left and top-right.  For very small images
+    (e.g. stand-alone set logos) the entire image is returned to ensure
+    matching still works in tests and for direct logo comparisons.
     """
 
     # Use the full image for tiny logos
     if w <= 100 and h <= 100:
-        return (0, 0, w, h)
+        return [(0, 0, w, h)]
 
+    rects = []
     upper = int(h * 0.75)
+    lower = int(h * 0.25)
     right = int(w * 0.35)
-    return (0, upper, right, h)
+    left = w - right
+
+    # Bottom-left
+    rects.append((0, upper, right, h))
+    # Bottom-right
+    rects.append((left, upper, w, h))
+    # Top-left
+    rects.append((0, 0, right, lower))
+    # Top-right
+    rects.append((left, 0, w, lower))
+
+    return rects
 
 
 def identify_set_by_hash(
@@ -901,6 +916,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
     parsed = urlparse(path)
     local_path = path if parsed.scheme not in ("http", "https") else None
     orientation = 0
+    rects: list[tuple[int, int, int, int]] = []
     rect: Optional[tuple[int, int, int, int]] = None
     if local_path and os.path.exists(local_path):
         try:
@@ -911,8 +927,11 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                     im = im.rotate(90, expand=True)
                     im.save(local_path)
                     w, h = im.size
-                rect = get_symbol_rect(w, h)
+                rects = get_symbol_rects(w, h)
+                if rects:
+                    rect = rects[0]
         except Exception:
+            rects = []
             rect = None
 
     name = number = total = set_name = ""
@@ -1000,30 +1019,35 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
     if local_path:
         print("[INFO] Step 3: Performing local analysis (hash/OCR)...")
         try:
-            if rect is None:
-                rect = (0, 0, 0, 0)
+            if not rects:
+                rects = [(0, 0, 0, 0)]
 
-            matches = identify_set_by_hash(local_path, rect)
-            if matches:
-                code, name_match, diff = matches[0]
-                if diff <= HASH_DIFF_THRESHOLD:
-                    set_code = code
-                    set_name = name_match
-                    print(f"[SUCCESS] Local hash analysis found a match: {name_match}")
-                    result = {
-                        "name": name,
-                        "number": number,
-                        "total": total,
-                        "set": set_name,
-                        "set_code": set_code,
-                        "orientation": orientation,
-                    }
-                    if debug and rect:
-                        result["rect"] = rect
-                    return result
+            for candidate in rects:
+                potential = identify_set_by_hash(local_path, candidate)
+                if potential:
+                    code, name_match, diff = potential[0]
+                    if diff <= HASH_DIFF_THRESHOLD:
+                        rect = candidate
+                        set_code = code
+                        set_name = name_match
+                        print(
+                            f"[SUCCESS] Local hash analysis found a match: {name_match}"
+                        )
+                        result = {
+                            "name": name,
+                            "number": number,
+                            "total": total,
+                            "set": set_name,
+                            "set_code": set_code,
+                            "orientation": orientation,
+                        }
+                        if debug and rect:
+                            result["rect"] = rect
+                        return result
 
             print("[INFO] Hash analysis did not yield a confident result. Trying OCR...")
 
+            rect = rect or rects[0]
             ocr_codes = extract_set_code_ocr(local_path, rect)
             for code in ocr_codes:
                 name_lookup = get_set_name(code)
@@ -3282,8 +3306,12 @@ class CardEditorApp:
             if hasattr(self, "prompt_set_selection"):
                 try:
                     with Image.open(image_path) as im:
-                        rect = get_symbol_rect(*im.size)
-                    matches = identify_set_by_hash(image_path, rect)
+                        rects = get_symbol_rects(*im.size)
+                    matches = []
+                    for r in rects:
+                        matches = identify_set_by_hash(image_path, r)
+                        if matches:
+                            break
                 except Exception:
                     matches = []
                 options = [(c, n) for c, n, _ in matches]

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -432,7 +432,7 @@ def test_analyze_card_image_horizontal_scan(tmp_path, monkeypatch):
     img_path = tmp_path / "horizontal.png"
     Image.new("RGB", (400, 200), color="white").save(img_path)
 
-    expected_rect = ui.get_symbol_rect(200, 400)
+    expected_rect = ui.get_symbol_rects(200, 400)[0]
 
     def fake_hash(path, rect):
         assert rect == expected_rect

--- a/tests/test_get_symbol_rect.py
+++ b/tests/test_get_symbol_rect.py
@@ -9,6 +9,15 @@ import kartoteka.ui as ui
 importlib.reload(ui)
 
 
-def test_get_symbol_rect_bottom_left():
+def test_get_symbol_rects_all_corners():
     w, h = 1000, 1400
-    assert ui.get_symbol_rect(w, h) == (0, int(h * 0.75), int(w * 0.35), h)
+    rects = ui.get_symbol_rects(w, h)
+    assert rects[0] == (0, int(h * 0.75), int(w * 0.35), h)
+    assert rects[1] == (int(w * 0.65), int(h * 0.75), w, h)
+    assert rects[2] == (0, 0, int(w * 0.35), int(h * 0.25))
+    assert rects[3] == (int(w * 0.65), 0, w, int(h * 0.25))
+
+
+def test_get_symbol_rects_small_image():
+    w, h = 80, 90
+    assert ui.get_symbol_rects(w, h) == [(0, 0, w, h)]


### PR DESCRIPTION
## Summary
- Replace `get_symbol_rect` with new `get_symbol_rects` returning candidate areas in all corners of a card
- Iterate over these rectangles in `analyze_card_image` and stop once a confident hash match is found
- Expand tests to cover new rectangle variants and update existing expectations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68972e30bf5c832fb75b9974444b8da2