### PR TITLE
Switch to responses API for card extraction

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -859,33 +859,32 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
             return "", "", "", "", ""
         client = openai.OpenAI(api_key=api_key)
 
-        prompt_text = (
+        PROMPT = (
             "You must return a JSON object with the Pokémon card's English name, "
             "card number in the form NNN/NNN, and English set name. The response "
             "must strictly match {\"name\":\"\", \"number\":\"\", \"set_name\":\"\"}."
         )
 
-        resp = client.chat.completions.create(
-            model="gpt-5",
+        resp = client.responses.create(
+            model=os.getenv("OPENAI_MODEL", "gpt-4o"),
             response_format={"type": "json_object"},
-            messages=[
+            input=[
                 {
                     "role": "user",
                     "content": [
-                        {"type": "text", "text": prompt_text},
-                        {"type": "image_url", "image_url": {"url": data_url}},
+                        {"type": "input_text", "text": PROMPT},
+                        {"type": "input_image", "image_url": data_url},
                     ],
                 }
             ],
-            max_completion_tokens=150,
+            max_output_tokens=150,
         )
-        
-        msg = resp.choices[0].message
-        raw = msg.content
-        if isinstance(raw, list):
-            raw = "".join(part.get("text", "") for part in raw)
+
+        raw = getattr(resp, "output_text", "")
         if not raw:
-            print("[ERROR] extract_card_info_openai got empty response from OpenAI")
+            logger.error(
+                "extract_card_info_openai got empty response from OpenAI: %r", resp
+            )
             return "", "", "", "", ""
         content = raw
 

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -29,15 +29,11 @@ def test_extract_card_info_openai_maps_set(monkeypatch, tmp_path):
     img.write_bytes(b"data")
 
     payload = {"name": "Pikachu", "number": "037/198", "set_name": SV01_CODE}
-    resp = SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content=json.dumps(payload)))]
-    )
+    resp = SimpleNamespace(output_text=json.dumps(payload))
 
     class DummyClient:
         def __init__(self, *a, **k):
-            self.chat = SimpleNamespace(
-                completions=SimpleNamespace(create=lambda *a, **k: resp)
-            )
+            self.responses = SimpleNamespace(create=lambda *a, **k: resp)
 
     monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
     name, number, total, set_name, set_code = ui.extract_card_info_openai(str(img))


### PR DESCRIPTION
## Summary
- Use `OpenAI.responses.create` with `gpt-4o` to extract card details
- Log and return empty values when the API output is empty
- Adjust tests to mock the new responses API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68986f2da148832fb564bfee542f73c7