### PR TITLE
Handle Markdown-fenced OpenAI responses

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -882,7 +882,13 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
                 ],
                 max_output_tokens=150,
             )
-            raw = getattr(resp, "output_text", "").strip()
+            raw = getattr(resp, "output_text", "")
+            raw = raw.strip().strip("`")
+            if raw.startswith("json"):
+                raw = raw[len("json") :].lstrip()
+            match = re.search(r"{.*}", raw, re.DOTALL)
+            if match:
+                raw = match.group(0)
             if not raw:
                 logger.error(
                     "extract_card_info_openai got empty response from OpenAI: %r",
@@ -893,31 +899,7 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
                 data_dict = json.loads(raw)
             except json.JSONDecodeError:
                 logger.error("OpenAI returned non-JSON: %r", raw)
-                resp = client.responses.create(
-                    model=os.getenv("OPENAI_MODEL", "gpt-4o"),
-                    input=[
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "input_text", "text": PROMPT},
-                                {"type": "input_image", "image_url": data_url},
-                            ],
-                        }
-                    ],
-                    max_output_tokens=150,
-                )
-                raw = getattr(resp, "output_text", "").strip()
-                if not raw:
-                    logger.error(
-                        "extract_card_info_openai got empty response from OpenAI: %r",
-                        resp,
-                    )
-                    return "", "", "", "", ""
-                try:
-                    data_dict = json.loads(raw)
-                except json.JSONDecodeError:
-                    logger.error("OpenAI returned non-JSON: %r", raw)
-                    return "", "", "", "", ""
+                return "", "", "", "", ""
         except TypeError:
             resp = client.responses.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-4o"),
@@ -932,7 +914,13 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
                 ],
                 max_output_tokens=150,
             )
-            raw = getattr(resp, "output_text", "").strip()
+            raw = getattr(resp, "output_text", "")
+            raw = raw.strip().strip("`")
+            if raw.startswith("json"):
+                raw = raw[len("json") :].lstrip()
+            match = re.search(r"{.*}", raw, re.DOTALL)
+            if match:
+                raw = match.group(0)
             if not raw:
                 logger.error(
                     "extract_card_info_openai got empty response from OpenAI: %r",

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+from pathlib import Path
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import tkinter as tk
+
+sys.modules["customtkinter"] = SimpleNamespace(
+    CTkEntry=tk.Entry,
+    CTkImage=MagicMock(),
+    CTkButton=MagicMock,
+    CTkToplevel=MagicMock,
+)
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+SV01_CODE = "sv01"
+SV01_NAME = ui.get_set_name(SV01_CODE)
+
+
+def test_parse_code_fence(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
+
+    payload = {"name": "Pikachu", "number": "037/198", "set_name": SV01_CODE}
+    resp = SimpleNamespace(output_text=f"```json\n{json.dumps(payload)}\n```")
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.responses = SimpleNamespace(create=lambda *a, **k: resp)
+
+    monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
+    name, number, total, set_name, set_code = ui.extract_card_info_openai(str(img))
+    assert (name, number, total) == ("Pikachu", "037", "198")
+    assert set_code == SV01_CODE
+    assert set_name == SV01_NAME


### PR DESCRIPTION
## Summary
- Strip markdown fences and extra prefixes from OpenAI output before JSON decoding
- Log and fail fast when OpenAI returns non-JSON
- Add regression test ensuring fenced responses are parsed correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899a7c15ecc832fa7aa2c6f7c29a28c