### PR TITLE
Add debug crop output for OCR

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -800,6 +800,9 @@ def extract_set_code_ocr(
     try:
         with Image.open(scan_path) as im:
             crop = im.crop(rect)
+        debug_crop = crop.convert("RGB")
+        debug_crop.save("debug_ocr_crop.png")  # zapis do pliku
+        # debug_crop.show()  # opcjonalnie, jeśli środowisko pozwala wyświetlić okno
         crop = crop.convert("L")
         crop = ImageOps.autocontrast(crop)
         crop = crop.resize((crop.width * 4, crop.height * 4))


### PR DESCRIPTION
## Summary
- save RGB debug crop for OCR in extract_set_code_ocr to inspect scanned area

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899b7761554832fb396ab964744e9a5