### PR TITLE
Add OCR debug crop saving

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -800,9 +800,12 @@ def extract_set_code_ocr(
     try:
         with Image.open(scan_path) as im:
             crop = im.crop(rect)
-        debug_crop = crop.convert("RGB")
-        debug_crop.save("debug_ocr_crop.png")  # zapis do pliku
-        # debug_crop.show()  # opcjonalnie, jeśli środowisko pozwala wyświetlić okno
+        from pathlib import Path
+
+        debug_dir = Path("OCR")
+        debug_dir.mkdir(exist_ok=True)
+        debug_file = debug_dir / f"{Path(scan_path).stem}_set_crop.png"
+        crop.convert("RGB").save(debug_file)
         crop = crop.convert("L")
         crop = ImageOps.autocontrast(crop)
         crop = crop.resize((crop.width * 4, crop.height * 4))


### PR DESCRIPTION
## Summary
- save set code OCR crop into `OCR` directory for inspection

## Testing
- `pytest -q`
- `python - <<'PY'
from kartoteka import ui
from PIL import Image
img = Image.new('RGB',(100,100),color=(255,255,255))
scan_path='sample_scan.png'
img.save(scan_path)
ui.extract_set_code_ocr(scan_path,(10,10,60,60))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6899beb3c848832faadefc43d1e1dfe8