### PR TITLE
Handle set format from OpenAI

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -838,15 +838,17 @@ class CardInfo(BaseModel):
     name: str = ""
     number: str = ""
     set_name: str = ""
+    set_format: str = ""
 
 
 # ZMIANA: Funkcja prosi OpenAI o wszystkie dane naraz, w tym o zestaw
-def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
-    """Recognize card name, number, and set using OpenAI Vision.
+def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str]:
+    """Recognize card name, number, set, and its format using OpenAI Vision.
 
-    Returns a tuple ``(name, number, total, set_name, set_code)``.  The
-    ``set_name`` value is normalised to the canonical display name whenever a
-    matching ``set_code`` can be resolved.
+    Returns a tuple ``(name, number, total, set_name, set_code, set_format)``.
+    The ``set_name`` value is normalised to the canonical display name whenever
+    a matching ``set_code`` can be resolved. ``set_format`` is ``"text"`` or
+    ``"symbol"`` depending on how the set was detected.
     """
     try:
         parsed = urlparse(path)
@@ -858,7 +860,7 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
                 encoded = base64.b64encode(r.content).decode("utf-8")
             except Exception as e:
                 print(f"[ERROR] extract_card_info_openai failed to fetch image: {e}")
-                return "", "", "", "", ""
+                return "", "", "", "", "", ""
         else:
             mime = mimetypes.guess_type(path)[0] or "image/jpeg"
             try:
@@ -866,18 +868,19 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
                     encoded = base64.b64encode(f.read()).decode("utf-8")
             except OSError as e:
                 print(f"[ERROR] extract_card_info_openai failed to read image: {e}")
-                return "", "", "", "", ""
+                return "", "", "", "", "", ""
         data_url = f"data:{mime};base64,{encoded}"
 
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
-            return "", "", "", "", ""
+            return "", "", "", "", "", ""
         client = openai.OpenAI(api_key=api_key)
 
         PROMPT = (
             "You must return a JSON object with the Pokémon card's English name, "
-            "card number in the form NNN/NNN, and English set name. The response "
-            "must strictly match {\"name\":\"\", \"number\":\"\", \"set_name\":\"\"}."
+            "card number in the form NNN/NNN, English set name, and whether the set "
+            "is written as text or shown as a symbol. The response must strictly "
+            "match {\"name\":\"\", \"number\":\"\", \"set_name\":\"\", \"set_format\":\"\"}."
         )
 
         try:
@@ -907,12 +910,12 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
                     "extract_card_info_openai got empty response from OpenAI: %r",
                     resp,
                 )
-                return "", "", "", "", ""
+                return "", "", "", "", "", ""
             try:
                 data_dict = json.loads(raw)
             except json.JSONDecodeError:
                 logger.error("OpenAI returned non-JSON: %r", raw)
-                return "", "", "", "", ""
+                return "", "", "", "", "", ""
         except TypeError:
             resp = client.responses.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-4o"),
@@ -939,12 +942,12 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
                     "extract_card_info_openai got empty response from OpenAI: %r",
                     resp,
                 )
-                return "", "", "", "", ""
+                return "", "", "", "", "", ""
             try:
                 data_dict = json.loads(raw)
             except json.JSONDecodeError:
                 logger.error("OpenAI returned non-JSON: %r", raw)
-                return "", "", "", "", ""
+                return "", "", "", "", "", ""
 
         data = CardInfo(**data_dict)
 
@@ -959,16 +962,17 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str]:
 
         name = data.name or ""
         set_name = data.set_name or ""
+        set_format = data.set_format or ""
         set_code = ""
         if set_name:
             set_code = get_set_code(set_name)
             mapped = get_set_name(set_code)
             if mapped:
                 set_name = mapped
-        return name, number, total, set_name, set_code
+        return name, number, total, set_name, set_code, set_format
     except Exception as e:
         print(f"[ERROR] extract_card_info_openai failed: {e}")
-        return "", "", "", "", ""
+        return "", "", "", "", "", ""
 
 # ZMIANA: Całkowicie nowa, hierarchiczna logika analizy obrazu
 def analyze_card_image(path: str, translate_name: bool = False, debug: bool = False):
@@ -1000,6 +1004,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
 
     name = number = total = set_name = ""
     set_code = ""
+    set_format = ""
 
     try:
         # --- PRIORITY 1: OpenAI Vision ---
@@ -1007,7 +1012,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
         if api_key:
             print("[INFO] Step 1: Analyzing with OpenAI Vision...")
             try:
-                name, number, total, set_name, set_code = extract_card_info_openai(path)
+                name, number, total, set_name, set_code, set_format = extract_card_info_openai(path)
 
                 if translate_name and name and not name.isascii():
                     name = translate_to_english(name)
@@ -1021,6 +1026,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                         "set": set_name,
                         "set_code": set_code,
                         "orientation": orientation,
+                        "set_format": set_format,
                     }
                     if debug and rect:
                         result["rect"] = rect
@@ -1050,6 +1056,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                         "set": api_set_name,
                         "set_code": set_code,
                         "orientation": orientation,
+                        "set_format": set_format,
                     }
                     if debug and rect:
                         result["rect"] = rect
@@ -1072,6 +1079,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                         "set": selected_name,
                         "set_code": selected_code,
                         "orientation": orientation,
+                        "set_format": set_format,
                     }
                     if debug and rect:
                         result["rect"] = rect
@@ -1107,6 +1115,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                                 "set": set_name,
                                 "set_code": set_code,
                                 "orientation": orientation,
+                                "set_format": set_format,
                             }
                             if debug and rect:
                                 result["rect"] = rect
@@ -1131,6 +1140,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                                 "set": set_name,
                                 "set_code": set_code,
                                 "orientation": orientation,
+                                "set_format": set_format,
                             }
                             if debug and rect:
                                 result["rect"] = rect
@@ -1151,6 +1161,7 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
             "set": set_name,
             "set_code": set_code,
             "orientation": orientation,
+            "set_format": set_format,
         }
         if debug and rect:
             result["rect"] = rect

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -28,7 +28,12 @@ def test_extract_card_info_openai_maps_set(monkeypatch, tmp_path):
     img = tmp_path / "x.jpg"
     img.write_bytes(b"data")
 
-    payload = {"name": "Pikachu", "number": "037/198", "set_name": SV01_CODE}
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": SV01_CODE,
+        "set_format": "text",
+    }
     resp = SimpleNamespace(output_text=json.dumps(payload))
 
     class DummyClient:
@@ -36,10 +41,11 @@ def test_extract_card_info_openai_maps_set(monkeypatch, tmp_path):
             self.responses = SimpleNamespace(create=lambda *a, **k: resp)
 
     monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
-    name, number, total, set_name, set_code = ui.extract_card_info_openai(str(img))
+    name, number, total, set_name, set_code, set_format = ui.extract_card_info_openai(str(img))
     assert (name, number, total) == ("Pikachu", "037", "198")
     assert set_code == SV01_CODE
     assert set_name == SV01_NAME
+    assert set_format == "text"
 
 
 def test_show_card_uses_analyzer(tmp_path):
@@ -89,7 +95,7 @@ def test_show_card_uses_analyzer(tmp_path):
 
     with patch.object(ui.Image, "open", return_value=DummyImage()), \
          patch.object(ui.ImageTk, "PhotoImage", return_value=MagicMock()), \
-         patch.object(
+        patch.object(
             ui,
             "analyze_card_image",
             return_value={
@@ -99,6 +105,7 @@ def test_show_card_uses_analyzer(tmp_path):
                 "set": SV01_NAME,
                 "set_code": SV01_CODE,
                 "orientation": 0,
+                "set_format": "",
             },
         ) as mock_analyze:
         ui.CardEditorApp.show_card(dummy)
@@ -111,7 +118,7 @@ def test_show_card_uses_analyzer(tmp_path):
 
 def test_analyze_card_image_api_single_set(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "")), \
+    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")), \
          patch.object(ui, "lookup_sets_from_api", return_value=[("sv01", SV01_NAME)]), \
          patch.object(ui, "prompt_set_selection") as mock_prompt, \
          patch.object(ui, "identify_set_by_hash") as mock_hash:
@@ -124,6 +131,7 @@ def test_analyze_card_image_api_single_set(monkeypatch):
         "set": SV01_NAME,
         "set_code": SV01_CODE,
         "orientation": 0,
+        "set_format": "",
     }
     mock_prompt.assert_not_called()
     mock_hash.assert_not_called()
@@ -133,7 +141,7 @@ def test_analyze_card_image_api_multiple_sets(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     options = [("a", "Set A"), ("b", "Set B")]
 
-    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "")), \
+    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")), \
          patch.object(ui, "lookup_sets_from_api", return_value=options), \
          patch.object(ui, "prompt_set_selection", return_value="b") as mock_prompt, \
          patch.object(ui, "identify_set_by_hash") as mock_hash:
@@ -146,6 +154,7 @@ def test_analyze_card_image_api_multiple_sets(monkeypatch):
         "set": "Set B",
         "set_code": "b",
         "orientation": 0,
+        "set_format": "",
     }
     mock_prompt.assert_called_once_with(options)
     mock_hash.assert_not_called()
@@ -159,7 +168,7 @@ def test_analyze_card_image_api_fallback_hash(monkeypatch):
         def crop(self, *args, **kwargs):
             return self
 
-    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "")), \
+    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")), \
          patch.object(ui, "lookup_sets_from_api", return_value=[]), \
          patch.object(ui, "identify_set_by_hash", return_value=[("x", "Set X", 0)]) as mock_hash, \
          patch.object(ui, "extract_set_code_ocr", return_value=[]):
@@ -172,6 +181,7 @@ def test_analyze_card_image_api_fallback_hash(monkeypatch):
         "set": "Set X",
         "set_code": "x",
         "orientation": 0,
+        "set_format": "",
     }
     mock_hash.assert_called_once()
 
@@ -194,6 +204,7 @@ def test_analyze_card_image_ocr(monkeypatch):
         "set": SV01_NAME,
         "set_code": SV01_CODE,
         "orientation": 0,
+        "set_format": "",
     }
     mock_hash.assert_called_once()
     mock_ocr.assert_called_once()
@@ -219,6 +230,7 @@ def test_analyze_card_image_ocr_unknown_code(monkeypatch, capsys):
         "set": "",
         "set_code": "",
         "orientation": 0,
+        "set_format": "",
     }
     mock_hash.assert_called_once()
     mock_ocr.assert_called_once()
@@ -247,6 +259,7 @@ def test_analyze_card_image_hash_short_circuits_ocr(monkeypatch):
         "set": SV01_NAME,
         "set_code": SV01_CODE,
         "orientation": 0,
+        "set_format": "",
     }
     mock_hash.assert_called_once()
     mock_ocr.assert_not_called()
@@ -275,6 +288,7 @@ def test_analyze_card_image_hash_falls_back_to_ocr(monkeypatch):
         "set": SV01_NAME,
         "set_code": SV01_CODE,
         "orientation": 0,
+        "set_format": "",
     }
     mock_hash.assert_called_once()
     mock_ocr.assert_called_once()
@@ -303,7 +317,7 @@ def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
 
 def test_analyze_card_image_bad_json(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    with patch.object(ui, "extract_card_info_openai", return_value=("", "", "", "", "")), \
+    with patch.object(ui, "extract_card_info_openai", return_value=("", "", "", "", "", "")), \
         patch.object(ui, "lookup_sets_from_api", return_value=[]):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
@@ -314,12 +328,13 @@ def test_analyze_card_image_bad_json(monkeypatch):
         "set": "",
         "set_code": "",
         "orientation": 0,
+        "set_format": "",
     }
 
 
 def test_analyze_card_image_truncated_code_block(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "159", "", "")), \
+    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "159", "", "", "")), \
         patch.object(ui, "lookup_sets_from_api", return_value=[]):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
@@ -330,12 +345,13 @@ def test_analyze_card_image_truncated_code_block(monkeypatch):
         "set": "",
         "set_code": "",
         "orientation": 0,
+        "set_format": "",
     }
 
 
 def test_analyze_card_image_leading_text(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "159", "", "")), \
+    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "159", "", "", "")), \
         patch.object(ui, "lookup_sets_from_api", return_value=[]):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
@@ -346,6 +362,7 @@ def test_analyze_card_image_leading_text(monkeypatch):
         "set": "",
         "set_code": "",
         "orientation": 0,
+        "set_format": "",
     }
 
 
@@ -365,6 +382,7 @@ def test_analyze_card_image_local_hash(monkeypatch):
         "set": SV01_NAME,
         "set_code": SV01_CODE,
         "orientation": 0,
+        "set_format": "",
     }
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
@@ -379,7 +397,7 @@ def test_analyze_card_image_translate_name(monkeypatch):
     with patch.object(
         ui,
         "extract_card_info_openai",
-        return_value=("\u30d4\u30ab\u30c1\u30e5\u30a6", "037", "159", "", ""),
+        return_value=("\u30d4\u30ab\u30c1\u30e5\u30a6", "037", "159", "", "", ""),
     ), patch(
         "openai.chat.completions.create", return_value=resp_translate
     ) as mock_create, patch.object(ui, "lookup_sets_from_api", return_value=[]):
@@ -392,6 +410,7 @@ def test_analyze_card_image_translate_name(monkeypatch):
         "set": "",
         "set_code": "",
         "orientation": 0,
+        "set_format": "",
     }
     mock_create.assert_called_once()
 
@@ -415,7 +434,7 @@ def test_analyze_card_image_orientation(tmp_path, monkeypatch):
 
     with patch.object(ui, "extract_set_code_ocr", return_value=[]), \
          patch.object(ui, "identify_set_by_hash", return_value=[]), \
-         patch.object(ui, "extract_card_info_openai", return_value=("", "", "", "", "")), \
+         patch.object(ui, "extract_card_info_openai", return_value=("", "", "", "", "", "")), \
          patch.object(ui, "lookup_sets_from_api", return_value=[]):
         result = ui.analyze_card_image(str(img_path))
 
@@ -435,7 +454,7 @@ def test_analyze_card_image_horizontal_scan(tmp_path, monkeypatch):
         return [(SV01_CODE, SV01_NAME, 0)]
 
     monkeypatch.setattr(ui, "identify_set_by_hash", fake_hash)
-    monkeypatch.setattr(ui, "extract_card_info_openai", lambda *a, **k: ("", "", "", "", ""))
+    monkeypatch.setattr(ui, "extract_card_info_openai", lambda *a, **k: ("", "", "", "", "", ""))
     monkeypatch.setattr(ui, "lookup_sets_from_api", lambda *a, **k: [])
     monkeypatch.setattr(ui, "extract_set_code_ocr", lambda *a, **k: [])
 
@@ -482,7 +501,7 @@ def test_analyze_and_fill_translates_for_jp(monkeypatch):
     with patch.object(
         ui,
         "extract_card_info_openai",
-        return_value=("\u30d4\u30ab\u30c1\u30e5\u30a6", "001", "", "", ""),
+        return_value=("\u30d4\u30ab\u30c1\u30e5\u30a6", "001", "", "", "", ""),
     ), patch(
         "openai.chat.completions.create", return_value=resp_translate
     ), patch.object(ui, "lookup_sets_from_api", return_value=[]):

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -26,7 +26,12 @@ def test_parse_code_fence(monkeypatch, tmp_path):
     img = tmp_path / "x.jpg"
     img.write_bytes(b"data")
 
-    payload = {"name": "Pikachu", "number": "037/198", "set_name": SV01_CODE}
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": SV01_CODE,
+        "set_format": "text",
+    }
     resp = SimpleNamespace(output_text=f"```json\n{json.dumps(payload)}\n```")
 
     class DummyClient:
@@ -34,7 +39,8 @@ def test_parse_code_fence(monkeypatch, tmp_path):
             self.responses = SimpleNamespace(create=lambda *a, **k: resp)
 
     monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
-    name, number, total, set_name, set_code = ui.extract_card_info_openai(str(img))
+    name, number, total, set_name, set_code, set_format = ui.extract_card_info_openai(str(img))
     assert (name, number, total) == ("Pikachu", "037", "198")
     assert set_code == SV01_CODE
     assert set_name == SV01_NAME
+    assert set_format == "text"


### PR DESCRIPTION
## Summary
- Track whether a card's set was read as text or symbol with a new `set_format` field
- Request `set_format` from OpenAI and pass it through to `analyze_card_image`
- Update tests for the expanded card info tuple and returned metadata

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ae9148418832fb5c7af719837534f