### PR TITLE
Prioritize OCR over hashing in card analysis

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1088,42 +1088,16 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
             except Exception as e:
                 print(f"[ERROR] TCGGO API lookup failed: {e}")
 
-        # --- PRIORITY 3: Local Analysis (Hash/OCR as last resort) ---
+        # --- PRIORITY 3: Local Analysis (OCR before hash fallback) ---
         if local_path:
-            print("[INFO] Step 3: Performing local analysis (hash/OCR)...")
+            print("[INFO] Step 3: Performing local analysis (OCR/hash)...")
             try:
                 if not rects:
                     rects = [(0, 0, 0, 0)]
                 if rect is None:
                     rect = rects[0]
 
-                for candidate in rects:
-                    potential = identify_set_by_hash(local_path, candidate)
-                    if potential:
-                        code, name_match, diff = potential[0]
-                        if diff <= HASH_DIFF_THRESHOLD:
-                            rect = candidate
-                            set_code = code
-                            set_name = name_match
-                            print(
-                                f"[SUCCESS] Local hash analysis found a match: {name_match}"
-                            )
-                            result = {
-                                "name": name,
-                                "number": number,
-                                "total": total,
-                                "set": set_name,
-                                "set_code": set_code,
-                                "orientation": orientation,
-                                "set_format": set_format,
-                            }
-                            if debug and rect:
-                                result["rect"] = rect
-                            return result
-
-                print("[INFO] Hash analysis did not yield a confident result. Trying OCR...")
-
-                # Evaluate OCR on every candidate rectangle before declaring failure
+                # OCR has priority unless it fails to yield a valid code
                 for candidate in rects:
                     ocr_codes = extract_set_code_ocr(local_path, candidate)
                     for code in ocr_codes:
@@ -1148,7 +1122,36 @@ def analyze_card_image(path: str, translate_name: bool = False, debug: bool = Fa
                         else:
                             print(f"[WARN] OCR produced unknown set code: {code}")
 
-                print("[INFO] OCR analysis did not find a valid set code.")
+                if set_format == "text":
+                    print("[INFO] OCR analysis did not find a valid set code and set format is text; skipping hash lookup.")
+                else:
+                    print("[INFO] OCR analysis did not find a valid set code. Trying hash...")
+
+                    for candidate in rects:
+                        potential = identify_set_by_hash(local_path, candidate)
+                        if potential:
+                            code, name_match, diff = potential[0]
+                            if diff <= HASH_DIFF_THRESHOLD:
+                                rect = candidate
+                                set_code = code
+                                set_name = name_match
+                                print(
+                                    f"[SUCCESS] Local hash analysis found a match: {name_match}"
+                                )
+                                result = {
+                                    "name": name,
+                                    "number": number,
+                                    "total": total,
+                                    "set": set_name,
+                                    "set_code": set_code,
+                                    "orientation": orientation,
+                                    "set_format": set_format,
+                                }
+                                if debug and rect:
+                                    result["rect"] = rect
+                                return result
+
+                    print("[INFO] Hash analysis did not yield a confident result.")
             except Exception as e:
                 print(f"[ERROR] Local analysis failed: {e}")
 

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -206,7 +206,7 @@ def test_analyze_card_image_ocr(monkeypatch):
         "orientation": 0,
         "set_format": "",
     }
-    mock_hash.assert_called_once()
+    mock_hash.assert_not_called()
     mock_ocr.assert_called_once()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
@@ -240,16 +240,18 @@ def test_analyze_card_image_ocr_unknown_code(monkeypatch, capsys):
     assert "OCR produced unknown set code: XYZ" in out
 
 
-def test_analyze_card_image_hash_short_circuits_ocr(monkeypatch):
+def test_analyze_card_image_hash_after_ocr_failure(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
 
     with patch.object(
         ui, "identify_set_by_hash", return_value=[(SV01_CODE, SV01_NAME, 0)]
-    ) as mock_hash, patch.object(ui, "extract_set_code_ocr") as mock_ocr, patch.object(
-        ui, "extract_card_info_openai"
-    ) as mock_extract, patch.object(ui, "lookup_sets_from_api") as mock_lookup:
+    ) as mock_hash, patch.object(
+        ui, "extract_set_code_ocr", return_value=[]
+    ) as mock_ocr, patch.object(ui, "extract_card_info_openai") as mock_extract, patch.object(
+        ui, "lookup_sets_from_api"
+    ) as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
     assert result == {
@@ -261,13 +263,13 @@ def test_analyze_card_image_hash_short_circuits_ocr(monkeypatch):
         "orientation": 0,
         "set_format": "",
     }
+    mock_ocr.assert_called_once()
     mock_hash.assert_called_once()
-    mock_ocr.assert_not_called()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
 
 
-def test_analyze_card_image_hash_falls_back_to_ocr(monkeypatch):
+def test_analyze_card_image_ocr_skips_hash(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
@@ -290,7 +292,7 @@ def test_analyze_card_image_hash_falls_back_to_ocr(monkeypatch):
         "orientation": 0,
         "set_format": "",
     }
-    mock_hash.assert_called_once()
+    mock_hash.assert_not_called()
     mock_ocr.assert_called_once()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()


### PR DESCRIPTION
## Summary
- update `analyze_card_image` to check `set_format` and run OCR before hash matching, only falling back to hashes when OCR fails
- expand tests to cover OCR-first logic and ensure hashing is skipped when text format or OCR succeeds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aeac9add0832fb759485102b39f13