### PR TITLE
Use HTML list in short description and include PSA 10 price

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4563,15 +4563,22 @@ class CardEditorApp:
         set_name = html.escape(data["set"])
         card_type = html.escape(data["typ"])
         condition = html.escape(data["stan"])
+        psa10_price = html.escape(data.get("psa10_price", ""))
+
+        psa10_li = (
+            f'<li style="margin-top:0.3em;">PSA 10: ok. {psa10_price} PLN</li>'
+            if psa10_price
+            else '<li style="margin-top:0.3em;">PSA 10: ok. ??? PLN</li>'
+        )
 
         data["short_description"] = (
-            f"<p><strong>{name}</strong></p>"
-            "<!-- <ul> -->"
-            f'<ul style="margin:0 0 0.7em 1.2em;">'
-            f'<li>Zestaw: {set_name}</li>'
-            f'<li>Numer karty: {number}</li>'
-            f'<li>Typ: {card_type}</li>'
-            f'<li>Stan: {condition}</li>'
+            f'<ul style="margin:0 0 0.7em 1.2em; padding:0; font-size:1.14em;">'
+            f'<li><strong>{name}</strong></li>'
+            f'<li style="margin-top:0.3em;">Zestaw: {set_name}</li>'
+            f'<li style="margin-top:0.3em;">Numer karty: {number}</li>'
+            f'<li style="margin-top:0.3em;">Stan: {condition}</li>'
+            f'<li style="margin-top:0.3em;">Typ: {card_type}</li>'
+            f"{psa10_li}"
             "</ul>"
         )
 

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -47,9 +47,11 @@ def test_html_generated():
     dummy = make_dummy()
     ui.CardEditorApp.save_current_data(dummy)
     data = dummy.output_data[0]
-    assert "<ul>" in data["short_description"]
-    assert data["short_description"].startswith("<p><strong>")
+    assert data["short_description"].startswith(
+        '<ul style="margin:0 0 0.7em 1.2em; padding:0; font-size:1.14em;">'
+    )
     assert "<li>" in data["short_description"]
+    assert "PSA 10: ok." in data["short_description"]
     assert data["description"].count("<p>") >= 2
     assert dummy.product_code_map == {}
     assert dummy.next_product_code == 2


### PR DESCRIPTION
## Summary
- replace short_description with styled HTML list referencing card details
- show optional PSA 10 price in short_description
- adjust HTML generation tests for new format

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aeefdce40832fb29f858f7177746e