### PR TITLE
Fetch PSA10 price when missing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4532,6 +4532,11 @@ class CardEditorApp:
         the index."""
         data = {k: v.get() for k, v in self.entries.items()}
         data.setdefault("psa10_price", "")
+        name = data.get("nazwa")
+        number = data.get("numer")
+        set_name = data.get("set")
+        if not data["psa10_price"]:
+            data["psa10_price"] = self.fetch_psa10_price(name, number, set_name)
         data["typ"] = ",".join(
             [name for name, var in self.type_vars.items() if var.get()]
         )

--- a/tests/test_delivery_id.py
+++ b/tests/test_delivery_id.py
@@ -43,6 +43,7 @@ def test_delivery_id_used(monkeypatch):
         output_data=[None],
         get_price_from_db=lambda *a: None,
         fetch_card_price=lambda *a: None,
+        fetch_psa10_price=lambda *a, **k: "",
     )
 
     ui.CardEditorApp.save_current_data(dummy)

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -39,6 +39,7 @@ def make_dummy():
         output_data=[None],
         get_price_from_db=lambda *a: None,
         fetch_card_price=lambda *a: None,
+        fetch_psa10_price=MagicMock(return_value="123"),
     )
 
 
@@ -47,6 +48,8 @@ def test_html_generated():
     dummy = make_dummy()
     ui.CardEditorApp.save_current_data(dummy)
     data = dummy.output_data[0]
+    dummy.fetch_psa10_price.assert_called_once_with("Charizard", "4", "Base")
+    assert data["psa10_price"] == "123"
     assert data["short_description"].startswith(
         '<ul style="margin:0 0 0.7em 1.2em; padding:0; font-size:1.14em;">'
     )

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -42,6 +42,7 @@ def make_dummy():
         output_data=[None],
         get_price_from_db=lambda *a: None,
         fetch_card_price=lambda *a: None,
+        fetch_psa10_price=lambda *a, **k: "",
     )
 
 


### PR DESCRIPTION
## Summary
- fetch PSA10 price in `save_current_data` when the field is empty
- mock PSA10 price fetcher in tests and validate stored value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689af0719f60832f92e0989c4cfce6ba