### PR TITLE
Trim OCR region to bottom 40%

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -807,6 +807,8 @@ def extract_set_code_ocr(
     try:
         with Image.open(scan_path) as im:
             crop = im.crop(rect)
+            h = crop.height
+            crop = crop.crop((0, int(h * 0.6), crop.width, h))
         from pathlib import Path
 
         debug_dir = Path("OCR")

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -310,7 +310,7 @@ def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
     ocr.assert_called_once()
     processed = ocr.call_args.args[0]
     assert processed.mode == "L"
-    assert processed.size == (40, 40)
+    assert processed.size == (40, 16)
     assert (
         ocr.call_args.kwargs.get("config")
         == "--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ/-"


### PR DESCRIPTION
## Summary
- Crop OCR candidate area to its bottom 40% and save the final crop for debugging
- Adjust OCR test to match new cropped image size

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689afa3acf90832f98fb69343160e14a