### PR TITLE
Compose seo title from card details

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4561,7 +4561,7 @@ class CardEditorApp:
         data["producer"] = "Pokémon"
         data["producer_code"] = data["numer"]
         data["currency"] = "PLN"
-        data["seo_title"] = ""
+        data["seo_title"] = f"{data['nazwa']} {data['numer']} {data['set']}"
         data["seo_description"] = ""
         data["seo_keywords"] = ""
 

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -53,6 +53,7 @@ def test_html_generated():
     data = dummy.output_data[0]
     dummy.fetch_psa10_price.assert_called_once_with("Charizard", "4", "Base")
     assert data["psa10_price"] == PSA10_PRICE
+    assert data["seo_title"] == "Charizard 4 Base"
     assert data["short_description"].startswith("<ul")
     assert "<li>" in data["short_description"]
     assert "<img" in data["short_description"]

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -85,4 +85,5 @@ def test_save_current_appends_session(tmp_path):
         assert rows[0]["currency"] == "PLN"
         assert rows[0]["producer_code"] == "4"
         assert rows[0]["stock"] == "1"
+        assert rows[0]["seo_title"] == "Charizard 4 Base"
 


### PR DESCRIPTION
## Summary
- Compose SEO title from card name, number, and set during save
- Ensure session CSV export includes the composed seo_title

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b03012970832f875753cf62d7e73b