### PR TITLE
Add default store CSV fields

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -27,7 +27,10 @@ STORE_FIELDNAMES = [
     "unit",
     "delivery",
     "stock",
+    "active",
     "seo_title",
+    "vat",
+    "images 1",
 ]
 
 WAREHOUSE_FIELDNAMES = ["name", "warehouse_code", "image"]
@@ -52,7 +55,10 @@ def format_store_row(row):
         "unit": row.get("unit", "szt."),
         "delivery": row.get("delivery", ""),
         "stock": row.get("stock", 1),
+        "active": row.get("active", 1),
         "seo_title": row.get("seo_title", ""),
+        "vat": row.get("vat", "23%"),
+        "images 1": row.get("image1", row.get("images", "")),
     }
 
 

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -43,8 +43,10 @@ def test_export_includes_new_fields(tmp_path):
         assert row["currency"] == "PLN"
         assert row["producer_code"] == "1"
         assert row["stock"] == "1"
+        assert row["active"] == "1"
+        assert row["vat"] == "23%"
+        assert row["images 1"] == "img.jpg"
         assert "psa10_price" not in reader.fieldnames
-        assert "vat" not in reader.fieldnames
 
 
 def test_export_appends_warehouse(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- include extra Shoper export fields like active, SEO title, VAT and first image
- default these fields in `format_store_row`
- adjust export CSV test expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b04a7dad8832f9cf25827c3b71586