### PR TITLE
Add default active and VAT fields to saved data

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4561,6 +4561,8 @@ class CardEditorApp:
         data["producer"] = "Pokémon"
         data["producer_code"] = data["numer"]
         data["currency"] = "PLN"
+        data["active"] = 1
+        data["vat"] = "23%"
         data["seo_title"] = f"{data['nazwa']} {data['numer']} {data['set']}"
         data["seo_description"] = ""
         data["seo_keywords"] = ""

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -53,6 +53,8 @@ def test_html_generated():
     data = dummy.output_data[0]
     dummy.fetch_psa10_price.assert_called_once_with("Charizard", "4", "Base")
     assert data["psa10_price"] == PSA10_PRICE
+    assert data["active"] == 1
+    assert data["vat"] == "23%"
     assert data["seo_title"] == "Charizard 4 Base"
     assert data["short_description"].startswith("<ul")
     assert "<li>" in data["short_description"]

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -85,5 +85,7 @@ def test_save_current_appends_session(tmp_path):
         assert rows[0]["currency"] == "PLN"
         assert rows[0]["producer_code"] == "4"
         assert rows[0]["stock"] == "1"
+        assert rows[0]["active"] == "1"
+        assert rows[0]["vat"] == "23%"
         assert rows[0]["seo_title"] == "Charizard 4 Base"
 


### PR DESCRIPTION
## Summary
- Automatically populate `active` and `vat` defaults when saving card data
- Verify exported session rows include these new fields

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b06db27c0832f9211c8b895a4e1a6