### PR TITLE
Remove PSA10 icon from generated short descriptions

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4575,15 +4575,6 @@ class CardEditorApp:
         condition = html.escape(data["stan"])
         psa10_price = html.escape(data.get("psa10_price", "") or "???")
 
-        psa10_icon = (
-            '<img src="https://static.rollerbros.com/psa10.png" '
-            'alt="PSA 10" style="height:1em; margin-left:0.3em;">'
-        )
-
-        psa10_li = (
-            f'<li style="margin-top:0.3em;">PSA 10: ok. {psa10_price} PLN {psa10_icon}</li>'
-        )
-
         data["short_description"] = (
             f'<ul style="margin:0 0 0.7em 1.2em; padding:0; font-size:1.14em;">'
             f'<li><strong>{name}</strong></li>'
@@ -4591,7 +4582,6 @@ class CardEditorApp:
             f'<li style="margin-top:0.3em;">Numer karty: {number}</li>'
             f'<li style="margin-top:0.3em;">Stan: {condition}</li>'
             f'<li style="margin-top:0.3em;">Typ: {card_type}</li>'
-            f"{psa10_li}"
             "</ul>"
         )
 
@@ -4605,7 +4595,7 @@ class CardEditorApp:
             f'Typ karty: {card_type}. Stan: {condition}.</p>'
             '<p>Każda karta jest dokładnie sprawdzana przed wysyłką i odpowiednio '
             'zabezpieczana – trafia do Ciebie w idealnym stanie, gotowa do gry lub kolekcji.</p>'
-            f'<p>Wartość tej karty w ocenie PSA 10 ({psa10_date}): ok. {psa10_price} PLN {psa10_icon}</p>'
+            f'<p>Wartość tej karty w ocenie PSA 10 ({psa10_date}): ok. {psa10_price} PLN</p>'
             f'<p>Zdjęcia przedstawiają rzeczywisty produkt lub jego odpowiednik. Jeśli szukasz więcej kart z tego setu – sprawdź '
             f'<a href="?{href_query}">pozostałe oferty</a>.</p>'
             '</div>'

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -60,10 +60,14 @@ def test_html_generated():
     assert data["seo_title"] == "Charizard 4 Base"
     assert data["short_description"].startswith("<ul")
     assert "<li>" in data["short_description"]
-    assert "<img" in data["short_description"]
-    assert "PSA 10: ok." in data["short_description"]
+    assert "Zestaw: Base" in data["short_description"]
+    assert "Numer karty: 4" in data["short_description"]
+    assert "Stan: NM" in data["short_description"]
+    assert "Typ:" in data["short_description"]
+    assert "<img" not in data["short_description"]
+    assert "PSA 10" not in data["short_description"]
     assert data["description"].startswith("<div")
-    assert '<img src="https://static.rollerbros.com/psa10.png"' in data["description"]
+    assert '<img src="https://static.rollerbros.com/psa10.png"' not in data["description"]
     today = datetime.date.today().isoformat()
     assert f"Wartość tej karty w ocenie PSA 10 ({today}):" in data["description"]
     assert urlencode({"set": "Base"}) in data["description"]


### PR DESCRIPTION
## Summary
- Simplify `save_current_data` by removing PSA10 icon and list item variables
- Build short descriptions without PSA10 references or images
- Update HTML generation tests to match new description output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b100ea564832fba254a07816d5b07