### PR TITLE
Revise PSA HTML description and tests

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4590,14 +4590,12 @@ class CardEditorApp:
 
         data["description"] = (
             f'<div style="font-size:1.10em;line-height:1.7;">'
-            f'<p>{name} – Pokémon TCG</p>'
-            f'<p>Karta pochodzi z zestawu {set_name} i ma numer {number}. '
-            f'Typ karty: {card_type}. Stan: {condition}.</p>'
-            '<p>Każda karta jest dokładnie sprawdzana przed wysyłką i odpowiednio '
-            'zabezpieczana – trafia do Ciebie w idealnym stanie, gotowa do gry lub kolekcji.</p>'
+            f'<h2>{name} – Pokémon TCG</h2>'
+            f'<p>Karta pochodzi z zestawu {set_name} i ma numer {number}. Stan: {condition}.</p>'
             f'<p>Wartość tej karty w ocenie PSA 10 ({psa10_date}): ok. {psa10_price} PLN</p>'
+            '<p>Czy wiesz, że…? Ta karta to klasyk wśród kolekcjonerów Pokémon.</p>'
             f'<p>Zdjęcia przedstawiają rzeczywisty produkt lub jego odpowiednik. Jeśli szukasz więcej kart z tego setu – sprawdź '
-            f'<a href="?{href_query}">pozostałe oferty</a>.</p>'
+            f'<a href="/szukaj?{href_query}">pozostałe oferty</a>.</p>'
             '</div>'
         )
 

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 import datetime
-from urllib.parse import urlencode
 
 sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -64,13 +63,14 @@ def test_html_generated():
     assert "Numer karty: 4" in data["short_description"]
     assert "Stan: NM" in data["short_description"]
     assert "Typ:" in data["short_description"]
-    assert "<img" not in data["short_description"]
-    assert "PSA 10" not in data["short_description"]
+    assert "PSA" not in data["short_description"]
     assert data["description"].startswith("<div")
     assert '<img src="https://static.rollerbros.com/psa10.png"' not in data["description"]
     today = datetime.date.today().isoformat()
     assert f"Wartość tej karty w ocenie PSA 10 ({today}):" in data["description"]
-    assert urlencode({"set": "Base"}) in data["description"]
     assert PSA10_PRICE in data["description"]
+    assert "<h2>" in data["description"]
+    assert "Czy wiesz, że" in data["description"]
+    assert "/szukaj?set=Base" in data["description"]
     assert dummy.product_code_map == {}
     assert dummy.next_product_code == 2


### PR DESCRIPTION
## Summary
- ensure generated short description omits PSA references and update tests
- integrate new PSA description template with heading, info paragraph, and search link

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b1145f688832f9706375571663a6f