### PR TITLE
Use only original name in store export

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -38,8 +38,7 @@ WAREHOUSE_FIELDNAMES = ["name", "warehouse_code", "image"]
 
 def format_store_row(row):
     """Return a row formatted for the store CSV."""
-    name_parts = [row["nazwa"], row["numer"]]
-    formatted_name = " ".join(part for part in name_parts if part)
+    formatted_name = row["nazwa"]
 
     return {
         "product_code": row["product_code"],

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -40,6 +40,7 @@ def test_export_includes_new_fields(tmp_path):
         rows = list(reader)
         assert reader.fieldnames == csv_utils.STORE_FIELDNAMES
         row = rows[0]
+        assert row["name"] == "Pikachu"
         assert row["currency"] == "PLN"
         assert row["producer_code"] == "1"
         assert row["stock"] == "1"


### PR DESCRIPTION
## Summary
- Export store CSV rows using only the card's name field
- Adjust export test to assert the plain name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b17224e98832f886e8a70b5bb0c74