### PR TITLE
Set fixed delivery value

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,6 @@ RAPIDAPI_KEY=your-key-here
 RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
 SHOPER_API_URL=https://your-store.shop/webapi/rest
 SHOPER_API_TOKEN=your-token
-SHOPER_DELIVERY_ID=1
 # API key for OpenAI (required for card text recognition via Vision)
 OPENAI_API_KEY=
 FTP_HOST=example.com

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ RAPIDAPI_KEY=your-key-here
 RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
 SHOPER_API_URL=https://your-store.shop/webapi/rest
 SHOPER_API_TOKEN=your-token
-SHOPER_DELIVERY_ID=1
 OPENAI_API_KEY=sk-...
 FTP_HOST=example.com
 FTP_USER=username
@@ -50,7 +49,7 @@ BASE_IMAGE_URL=https://your-store.shop/upload/images
 **Warning:** This file may contain private API keys and tokens. It is excluded
 from version control via `.gitignore` and should never be shared publicly.
 
-The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `SHOPER_DELIVERY_ID` sets the default shipping method id for exported CSV files. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` supplies the key for OpenAI Vision to recognise card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
+The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` supplies the key for OpenAI Vision to recognise card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
 `WAREHOUSE_CSV` controls where the local warehouse CSV is written.
 
 ## Running the App

--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -52,7 +52,7 @@ def format_store_row(row):
         "currency": row.get("currency", "PLN"),
         "availability": row.get("availability", 1),
         "unit": row.get("unit", "szt."),
-        "delivery": row.get("delivery", ""),
+        "delivery": "3 dni",
         "stock": row.get("stock", 1),
         "active": row.get("active", 1),
         "seo_title": row.get("seo_title", ""),

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -51,7 +51,6 @@ SHOPER_API_TOKEN = os.getenv("SHOPER_API_TOKEN", "").strip()
 FTP_HOST = os.getenv("FTP_HOST")
 FTP_USER = os.getenv("FTP_USER")
 FTP_PASSWORD = os.getenv("FTP_PASSWORD")
-SHOPER_DELIVERY_ID = int(os.getenv("SHOPER_DELIVERY_ID", "1"))
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if OPENAI_API_KEY:
     openai.api_key = OPENAI_API_KEY
@@ -4600,7 +4599,7 @@ class CardEditorApp:
         )
 
         data["availability"] = 1
-        data["delivery"] = SHOPER_DELIVERY_ID
+        data["delivery"] = "3 dni"
 
         cena_local = self.get_price_from_db(data["nazwa"], data["numer"], data["set"])
         is_reverse = self.type_vars["Reverse"].get()

--- a/tests/test_delivery_id.py
+++ b/tests/test_delivery_id.py
@@ -16,8 +16,7 @@ class DummyVar:
         return self.value
 
 
-def test_delivery_id_used(monkeypatch):
-    monkeypatch.setenv("SHOPER_DELIVERY_ID", "7")
+def test_delivery_field_constant():
     importlib.reload(ui)
 
     dummy = SimpleNamespace(
@@ -47,5 +46,5 @@ def test_delivery_id_used(monkeypatch):
     )
 
     ui.CardEditorApp.save_current_data(dummy)
-    assert dummy.output_data[0]["delivery"] == 7
+    assert dummy.output_data[0]["delivery"] == "3 dni"
 

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -88,4 +88,5 @@ def test_save_current_appends_session(tmp_path):
         assert rows[0]["active"] == "1"
         assert rows[0]["vat"] == "23%"
         assert rows[0]["seo_title"] == "Charizard 4 Base"
+        assert rows[0]["delivery"] == "3 dni"
 


### PR DESCRIPTION
## Summary
- Always export "3 dni" in delivery field for store CSV rows
- Remove configurable delivery ID and hardcode delivery value in UI save logic
- Update configuration and tests to expect new constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b180c6174832fbf15976b17401a04