### PR TITLE
Use set slug links for set pages in descriptions

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4585,7 +4585,7 @@ class CardEditorApp:
         )
 
         psa10_date = datetime.date.today().isoformat()
-        href_query = urlencode({"set": raw_set_name})
+        slug = raw_set_name.replace(" ", "-")
 
         data["description"] = (
             f'<div style="font-size:1.10em;line-height:1.7;">'
@@ -4594,7 +4594,7 @@ class CardEditorApp:
             f'<p>Wartość tej karty w ocenie PSA 10 ({psa10_date}): ok. {psa10_price} PLN</p>'
             '<p>Czy wiesz, że…? Ta karta to klasyk wśród kolekcjonerów Pokémon.</p>'
             f'<p>Zdjęcia przedstawiają rzeczywisty produkt lub jego odpowiednik. Jeśli szukasz więcej kart z tego setu – sprawdź '
-            f'<a href="/szukaj?{href_query}">pozostałe oferty</a>.</p>'
+            f'<a href="https://kartoteka.shop/pl/c/{slug}">pozostałe oferty</a>.</p>'
             '</div>'
         )
 

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -24,7 +24,7 @@ def make_dummy():
         entries={
             "nazwa": DummyVar("Charizard"),
             "numer": DummyVar("4"),
-            "set": DummyVar("Base"),
+            "set": DummyVar("Base Set"),
             "język": DummyVar("ENG"),
             "stan": DummyVar("NM"),
             "cena": DummyVar(""),
@@ -52,14 +52,14 @@ def test_html_generated():
     dummy = make_dummy()
     ui.CardEditorApp.save_current_data(dummy)
     data = dummy.output_data[0]
-    dummy.fetch_psa10_price.assert_called_once_with("Charizard", "4", "Base")
+    dummy.fetch_psa10_price.assert_called_once_with("Charizard", "4", "Base Set")
     assert data["psa10_price"] == PSA10_PRICE
     assert data["active"] == 1
     assert data["vat"] == "23%"
-    assert data["seo_title"] == "Charizard 4 Base"
+    assert data["seo_title"] == "Charizard 4 Base Set"
     assert data["short_description"].startswith("<ul")
     assert "<li>" in data["short_description"]
-    assert "Zestaw: Base" in data["short_description"]
+    assert "Zestaw: Base Set" in data["short_description"]
     assert "Numer karty: 4" in data["short_description"]
     assert "Stan: NM" in data["short_description"]
     assert "Typ:" in data["short_description"]
@@ -71,6 +71,6 @@ def test_html_generated():
     assert PSA10_PRICE in data["description"]
     assert "<h2>" in data["description"]
     assert "Czy wiesz, że" in data["description"]
-    assert "/szukaj?set=Base" in data["description"]
+    assert "https://kartoteka.shop/pl/c/Base-Set" in data["description"]
     assert dummy.product_code_map == {}
     assert dummy.next_product_code == 2


### PR DESCRIPTION
## Summary
- Link to the set page at kartoteka.shop using a slugified set name instead of the old search query link
- Update save_current_data HTML test to assert the new set link format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b1b265024832f96710497db580092