### PR TITLE
Include warehouse code in saved data and exports

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4553,6 +4553,12 @@ class CardEditorApp:
         self.file_to_key[front_file] = key
 
         data["image1"] = f"{BASE_IMAGE_URL}/{self.folder_name}/{front_file}"
+        existing_wc = ""
+        if getattr(self, "output_data", None) and 0 <= self.index < len(self.output_data):
+            current = self.output_data[self.index]
+            if current and current.get("warehouse_code"):
+                existing_wc = current["warehouse_code"]
+        data["warehouse_code"] = existing_wc or self.next_free_location()
         data["product_code"] = self.next_product_code
         self.next_product_code += 1
         data["unit"] = "szt."

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -70,6 +70,7 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
             "short_description": "s",
             "description": "d",
             "image1": "img.jpg",
+            "warehouse_code": "K1R1P1",
         }]
     )
     dummy.back_to_welcome = lambda: None
@@ -85,5 +86,6 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
         assert reader.fieldnames == csv_utils.WAREHOUSE_FIELDNAMES
         assert rows[0]["name"] == "Pikachu 1"
         assert rows[0]["image"] == "img.jpg"
+        assert rows[0]["warehouse_code"] == "K1R1P1"
 
 

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -74,3 +74,4 @@ def test_html_generated():
     assert "https://kartoteka.shop/pl/c/Base-Set" in data["description"]
     assert dummy.product_code_map == {}
     assert dummy.next_product_code == 2
+    assert data["warehouse_code"] == "K1R1P1"


### PR DESCRIPTION
## Summary
- Assign warehouse_code when saving card data using next_free_location
- Verify warehouse_code is captured during save and exported to WAREHOUSE_CSV
- Add tests to confirm warehouse_code persistence in exports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b1c531684832f8b3cd51a8e0fe1f3