### PR TITLE
feat: add PSA info to card descriptions

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -61,6 +61,7 @@ HOLO_REVERSE_MULTIPLIER = 3.5
 SET_LOGO_DIR = "set_logos"
 HASH_DIFF_THRESHOLD = 20  # hash difference threshold for accepting matches
 HASH_SIZE = (32, 32)
+PSA_ICON_URL = "https://static.rollerbros.com/psa10.png"
 
 # minimum similarity ratio for fuzzy set code matching
 SET_CODE_MATCH_CUTOFF = 0.8
@@ -4615,17 +4616,30 @@ class CardEditorApp:
             "</ul>"
         )
 
-        psa10_date = datetime.date.today().isoformat()
+        psa10_date = html.escape(datetime.date.today().isoformat())
         slug = raw_set_name.replace(" ", "-")
+        link_set = html.escape(f"https://kartoteka.shop/pl/c/{slug}")
+        psa_icon_url = html.escape(PSA_ICON_URL)
 
         data["description"] = (
             f'<div style="font-size:1.10em;line-height:1.7;">'
             f'<h2>{name} – Pokémon TCG</h2>'
-            f'<p>Karta pochodzi z zestawu {set_name} i ma numer {number}. Stan: {condition}.</p>'
-            f'<p>Wartość tej karty w ocenie PSA 10 ({psa10_date}): ok. {psa10_price} PLN</p>'
-            '<p>Czy wiesz, że…? Ta karta to klasyk wśród kolekcjonerów Pokémon.</p>'
-            f'<p>Zdjęcia przedstawiają rzeczywisty produkt lub jego odpowiednik. Jeśli szukasz więcej kart z tego setu – sprawdź '
-            f'<a href="https://kartoteka.shop/pl/c/{slug}">pozostałe oferty</a>.</p>'
+            f'<p><strong>Zestaw:</strong> {set_name}<br>'
+            f'<strong>Numer karty:</strong> {number}<br>'
+            f'<strong>Typ:</strong> {card_type}<br>'
+            f'<strong>Stan:</strong> {condition}</p>'
+            f'<div style="display:flex;align-items:center;margin:0.5em 0;">'
+            f'<img src="{psa_icon_url}" alt="PSA 10" style="height:24px;width:auto;margin-right:0.4em;"/>'
+            f'<span>Wartość tej karty w ocenie PSA 10 ({psa10_date}): ok. {psa10_price} PLN</span>'
+            f'</div>'
+            '<p>Dlaczego warto kupić w Kartoteka.shop?</p>'
+            '<ul>'
+            '<li>Oryginalne karty Pokémon</li>'
+            '<li>Bezpieczna wysyłka i solidne opakowanie</li>'
+            '<li>Profesjonalna obsługa klienta</li>'
+            '</ul>'
+            f'<p>Jeśli szukasz więcej kart z tego setu – sprawdź '
+            f'<a href="{link_set}">pozostałe oferty</a>.</p>'
             '</div>'
         )
 

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -65,12 +65,12 @@ def test_html_generated():
     assert "Typ:" in data["short_description"]
     assert "PSA" not in data["short_description"]
     assert data["description"].startswith("<div")
-    assert '<img src="https://static.rollerbros.com/psa10.png"' not in data["description"]
+    assert f'<img src="{ui.PSA_ICON_URL}"' in data["description"]
     today = datetime.date.today().isoformat()
     assert f"Wartość tej karty w ocenie PSA 10 ({today}):" in data["description"]
     assert PSA10_PRICE in data["description"]
     assert "<h2>" in data["description"]
-    assert "Czy wiesz, że" in data["description"]
+    assert data["description"].count("<li>") >= 3
     assert "https://kartoteka.shop/pl/c/Base-Set" in data["description"]
     assert dummy.product_code_map == {}
     assert dummy.next_product_code == 2


### PR DESCRIPTION
## Summary
- include PSA icon constant and use new HTML template for card descriptions
- ensure description escapes values and links to set pages
- test HTML generation for PSA section and benefits list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b2ad1c888832fafc396e4a15ae21f