### PR TITLE
Handle Shoper product import jobs

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -230,11 +230,13 @@ def send_csv_to_shoper(app, file_path: str):
     """Send a CSV file using the Shoper API or FTP fallback."""
     try:
         if getattr(app, "shoper_client", None):
-            app.shoper_client.import_csv(file_path)
+            result = app.shoper_client.import_csv(file_path)
+            status = result.get("status", "ok")
+            messagebox.showinfo("Sukces", f"Import zakończony: {status}")
         else:
             with FTPClient(app.FTP_HOST, app.FTP_USER, app.FTP_PASSWORD) as ftp:
                 ftp.upload_file(file_path)
-        messagebox.showinfo("Sukces", "Plik CSV został wysłany.")
+            messagebox.showinfo("Sukces", "Plik CSV został wysłany.")
     except Exception as exc:  # pragma: no cover - network failure
         messagebox.showerror("Błąd", f"Nie udało się wysłać pliku: {exc}")
 

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -1,4 +1,5 @@
 import os
+import time
 import requests
 
 
@@ -98,11 +99,32 @@ class ShoperClient:
             print("[INFO] orders/stats unavailable")
             return {}
 
-    def import_csv(self, file_path):
-        """Upload a CSV file using the Shoper API."""
+    def import_csv(self, file_path, poll_interval=2, timeout=120):
+        """Upload a CSV file and wait for the import job to finish."""
         with open(file_path, "rb") as fh:
             files = {"file": (os.path.basename(file_path), fh, "text/csv")}
-            return self.post("import/csv", files=files)
+            data = self.post("products/import", files=files)
+        job_id = data.get("job_id") or data.get("id")
+        if job_id:
+            return self._poll_import_job(job_id, poll_interval, timeout)
+        return data
+
+    def _poll_import_job(self, job_id, interval=2, timeout=120):
+        """Poll the import job until completion or failure."""
+        endpoint = f"products/import/{job_id}"
+        end_time = time.time() + timeout
+        while time.time() < end_time:
+            status = self.get(endpoint)
+            state = status.get("status") or status.get("state")
+            if state in {"completed", "finished", "done", "success"}:
+                errors = status.get("errors")
+                if errors:
+                    raise RuntimeError(f"Import completed with errors: {errors}")
+                return status
+            if state in {"failed", "error"}:
+                raise RuntimeError(f"Import failed: {status}")
+            time.sleep(interval)
+        raise RuntimeError("Import job timed out")
 
     def get_attributes(self):
         """Return a list of product attributes."""

--- a/tests/test_send_csv_to_shoper.py
+++ b/tests/test_send_csv_to_shoper.py
@@ -1,0 +1,17 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from kartoteka.csv_utils import send_csv_to_shoper
+
+def test_send_csv_shows_status(tmp_path):
+    dummy_client = SimpleNamespace(import_csv=lambda p: {"status": "completed"})
+    app = SimpleNamespace(shoper_client=dummy_client)
+    with patch("tkinter.messagebox.showinfo") as info:
+        send_csv_to_shoper(app, str(tmp_path / "file.csv"))
+        info.assert_called()
+        assert "completed" in info.call_args[0][1]
+

--- a/tests/test_shoper_client.py
+++ b/tests/test_shoper_client.py
@@ -1,3 +1,5 @@
+import time
+import pytest
 from shoper_client import ShoperClient
 
 
@@ -31,3 +33,52 @@ def test_client_endpoints(monkeypatch):
     assert captured["post"][0] == "products-attributes"
     assert captured["post"][1]["product_id"] == 1
     assert captured["post"][1]["attribute_id"] == 2
+
+
+def test_import_csv_polls_until_complete(tmp_path, monkeypatch):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("id;name\n1;test\n", encoding="utf-8")
+
+    client = ShoperClient(base_url="https://shop", token="tok")
+
+    statuses = iter([
+        {"status": "processing"},
+        {"status": "completed"},
+    ])
+
+    def fake_post(endpoint, files=None):
+        assert endpoint == "products/import"
+        assert "file" in files
+        return {"job_id": "1"}
+
+    def fake_get(endpoint, **kwargs):
+        assert endpoint == "products/import/1"
+        return next(statuses)
+
+    monkeypatch.setattr(client, "post", fake_post)
+    monkeypatch.setattr(client, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    result = client.import_csv(str(csv_file))
+    assert result["status"] == "completed"
+
+
+def test_import_csv_raises_on_error(tmp_path, monkeypatch):
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("id;name\n1;test\n", encoding="utf-8")
+
+    client = ShoperClient(base_url="https://shop", token="tok")
+
+    def fake_post(endpoint, files=None):
+        return {"job_id": "1"}
+
+    def fake_get(endpoint, **kwargs):
+        return {"status": "error", "errors": ["boom"]}
+
+    monkeypatch.setattr(client, "post", fake_post)
+    monkeypatch.setattr(client, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda s: None)
+
+    with pytest.raises(RuntimeError) as exc:
+        client.import_csv(str(csv_file))
+    assert "boom" in str(exc.value)


### PR DESCRIPTION
## Summary
- Implement `/products/import` CSV upload with job-status polling and robust error reporting.
- Report import results to users when sending CSV files.
- Add tests for import polling, error handling and user notification.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b34e5fa2c832f8b1ab9c45a1a2f06