### PR TITLE
Handle API warnings/errors when importing CSV

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -231,8 +231,14 @@ def send_csv_to_shoper(app, file_path: str):
     try:
         if getattr(app, "shoper_client", None):
             result = app.shoper_client.import_csv(file_path)
-            status = result.get("status", "ok")
-            messagebox.showinfo("Sukces", f"Import zakończony: {status}")
+            errors = result.get("errors") or []
+            warnings = result.get("warnings") or []
+            status = (result.get("status") or "").lower()
+            if errors or warnings or status not in {"completed", "finished", "done", "success"}:
+                issues = "\n".join(map(str, errors + warnings)) or f"Status: {status or 'nieznany'}"
+                messagebox.showerror("Błąd", f"Import zakończony z problemami:\n{issues}")
+            else:
+                messagebox.showinfo("Sukces", f"Import zakończony: {status}")
         else:
             with FTPClient(app.FTP_HOST, app.FTP_USER, app.FTP_PASSWORD) as ftp:
                 ftp.upload_file(file_path)

--- a/tests/test_send_csv_to_shoper.py
+++ b/tests/test_send_csv_to_shoper.py
@@ -7,11 +7,30 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from kartoteka.csv_utils import send_csv_to_shoper
 
-def test_send_csv_shows_status(tmp_path):
+
+def test_send_csv_shows_status_on_success(tmp_path):
     dummy_client = SimpleNamespace(import_csv=lambda p: {"status": "completed"})
     app = SimpleNamespace(shoper_client=dummy_client)
-    with patch("tkinter.messagebox.showinfo") as info:
+    with patch("tkinter.messagebox.showinfo") as info, patch(
+        "tkinter.messagebox.showerror"
+    ) as error:
         send_csv_to_shoper(app, str(tmp_path / "file.csv"))
-        info.assert_called()
+        info.assert_called_once()
+        error.assert_not_called()
         assert "completed" in info.call_args[0][1]
+
+
+def test_send_csv_shows_errors_and_warnings(tmp_path):
+    dummy_client = SimpleNamespace(
+        import_csv=lambda p: {"status": "completed", "warnings": ["warn"], "errors": ["err"]}
+    )
+    app = SimpleNamespace(shoper_client=dummy_client)
+    with patch("tkinter.messagebox.showinfo") as info, patch(
+        "tkinter.messagebox.showerror"
+    ) as error:
+        send_csv_to_shoper(app, str(tmp_path / "file.csv"))
+        error.assert_called_once()
+        info.assert_not_called()
+        msg = error.call_args[0][1]
+        assert "warn" in msg and "err" in msg
 


### PR DESCRIPTION
## Summary
- Validate import_csv API response for warnings/errors before showing success
- Add tests for successful and problematic CSV imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b361cc76c832fb934afb036da1ec2