### PR TITLE
Persist last product code across sessions

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -75,6 +75,7 @@ def format_warehouse_row(row):
 
 def load_csv_data(app):
     """Load a CSV file and merge duplicate rows."""
+    from . import storage
     file_path = filedialog.askopenfilename(filetypes=[("CSV files", "*.csv")])
     if not file_path:
         return
@@ -146,6 +147,7 @@ def load_csv_data(app):
     for row in combined.values():
         row["product_code"] = app.next_product_code
         app.next_product_code += 1
+        storage.save_last_product_code(app.next_product_code - 1)
 
     if qty_field is None:
         qty_field = "ilość"

--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -2,6 +2,21 @@ import csv
 import re
 from . import csv_utils
 
+LAST_PRODUCT_CODE_FILE = "last_product_code.txt"
+
+
+def load_last_product_code() -> int:
+    try:
+        with open(LAST_PRODUCT_CODE_FILE, "r", encoding="utf-8") as f:
+            return int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        return 0
+
+
+def save_last_product_code(value: int) -> None:
+    with open(LAST_PRODUCT_CODE_FILE, "w", encoding="utf-8") as f:
+        f.write(str(int(value)))
+
 
 def location_from_code(code: str) -> str:
     match = re.match(r"K(\d+)R(\d)P(\d+)", code or "")

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1214,7 +1214,7 @@ class CardEditorApp:
         self.card_cache = {}
         self.file_to_key = {}
         self.product_code_map = {}
-        self.next_product_code = 1
+        self.next_product_code = storage.load_last_product_code() + 1
         self.price_db = self.load_price_db()
         self.folder_name = ""
         self.folder_path = ""
@@ -4612,6 +4612,7 @@ class CardEditorApp:
         data["warehouse_code"] = existing_wc or self.next_free_location()
         data["product_code"] = self.next_product_code
         self.next_product_code += 1
+        storage.save_last_product_code(self.next_product_code - 1)
         data["unit"] = "szt."
         data["category"] = f"Karty Pokémon > {data['set']}"
         data["producer"] = "Pokémon"

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -8,6 +8,7 @@ sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import kartoteka.ui as ui
 import kartoteka.csv_utils as csv_utils
+import kartoteka.storage as storage
 
 
 class DummyVar:
@@ -89,4 +90,34 @@ def test_save_current_appends_session(tmp_path):
         assert rows[0]["vat"] == "23%"
         assert rows[0]["seo_title"] == "Charizard 4 Base"
         assert rows[0]["delivery"] == "3 dni"
+
+
+def test_product_code_persists_between_sessions(tmp_path):
+    session_path = tmp_path / "session.csv"
+    last_code_file = tmp_path / "last_product_code.txt"
+
+    with patch.object(storage, "LAST_PRODUCT_CODE_FILE", str(last_code_file)):
+        dummy = make_dummy()
+        dummy.session_csv_path = str(session_path)
+        with open(session_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(
+                f, fieldnames=csv_utils.STORE_FIELDNAMES, delimiter=";"
+            )
+            writer.writeheader()
+
+        ui.CardEditorApp.save_current_data(dummy)
+
+        root = SimpleNamespace(
+            title=lambda *a, **k: None,
+            configure=lambda *a, **k: None,
+            option_add=lambda *a, **k: None,
+        )
+
+        with patch.object(ui.CardEditorApp, "load_price_db", lambda self: {}), \
+             patch.object(ui.CardEditorApp, "show_loading_screen", lambda self: None), \
+             patch.object(ui.threading, "Thread", lambda *a, **k: SimpleNamespace(start=lambda: None)), \
+             patch("kartoteka.ui.tk.StringVar", lambda *a, **k: DummyVar(k.get("value", ""))):
+            app = ui.CardEditorApp(root)
+
+        assert app.next_product_code == 2
 


### PR DESCRIPTION
## Summary
- add helpers to load/save last product code
- initialize and persist next_product_code using storage helpers
- ensure CSV import updates stored product code
- test persistence of product code between sessions

## Testing
- `pytest -q`
- `pytest kartoteka/tests/test_session_csv.py::test_product_code_persists_between_sessions -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9bdd9b88832fa02017305933d3a4