### PR TITLE
Average Cardmarket price metrics with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 - Load images from a folder and review them one by one
 - Fetch card prices from a local database (`card_prices.csv`)
 - Automatically query the TCGGO API when a price is missing
+- Cardmarket price is calculated as the average of the 30-day average and trend
+  price when both metrics are available, falling back to the lowest near-mint
+  price otherwise
 - Display card images when available, falling back to `image`, `imageUrl` or `image_url` if `images.large` is not provided
 - Prices for "Holo" or "Reverse" variants are calculated by multiplying the base price by **3.5**
 - View alternative API results via the **Inne warianty** button

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -587,23 +587,47 @@ def choose_nearest_locations(order_list, output_data):
 
 
 def extract_cardmarket_price(card):
-    """Return the best available Cardmarket price for a card.
+    """Return an approximate Cardmarket price for a card.
 
-    The function checks multiple possible fields in the ``cardmarket`` price
-    section and returns the first non-zero value.  If none of the fields are
-    present or they evaluate to zero, ``None`` is returned.
+    The function prefers the arithmetic mean of ``30d_average`` and
+    ``trendPrice`` when both metrics are present and greater than zero.  If
+    only one of them is available the respective value is returned.  When
+    neither metric is usable the function falls back to ``lowest_near_mint``.
+    ``None`` is returned when no positive price can be determined.
     """
 
     cardmarket = card.get("prices", {}).get("cardmarket", {}) or {}
-    for field in ["30d_average", "trendPrice", "trend_price", "lowest_near_mint"]:
-        price = cardmarket.get(field)
+
+    def _get_float(key: str) -> float:
         try:
-            value = float(price)
+            return float(cardmarket.get(key, 0) or 0)
         except (TypeError, ValueError):
-            continue
-        if value:
-            print(f"[DEBUG] Using Cardmarket field '{field}' with value {value}")
-            return value
+            return 0.0
+
+    avg_30d = _get_float("30d_average")
+    trend = _get_float("trendPrice") or _get_float("trend_price")
+
+    values = [v for v in (avg_30d, trend) if v > 0]
+    if len(values) == 2:
+        value = sum(values) / 2
+        print(
+            f"[DEBUG] Using mean of Cardmarket fields '30d_average' ({avg_30d}) and "
+            f"'trendPrice' ({trend}) -> {value}"
+        )
+        return value
+    if len(values) == 1:
+        value = values[0]
+        field = "30d_average" if avg_30d > 0 else "trendPrice"
+        print(f"[DEBUG] Using Cardmarket field '{field}' with value {value}")
+        return value
+
+    lowest = _get_float("lowest_near_mint")
+    if lowest > 0:
+        print(
+            f"[DEBUG] Using Cardmarket field 'lowest_near_mint' with value {lowest}"
+        )
+        return lowest
+
     return None
 
 

--- a/tests/test_extract_cardmarket_price.py
+++ b/tests/test_extract_cardmarket_price.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+importlib.reload(ui)
+
+
+def test_combined_price():
+    card = {"prices": {"cardmarket": {"30d_average": 10, "trendPrice": 14}}}
+    assert ui.extract_cardmarket_price(card) == (10 + 14) / 2
+
+
+def test_single_metric_fallback():
+    card = {"prices": {"cardmarket": {"trendPrice": 14}}}
+    assert ui.extract_cardmarket_price(card) == 14
+
+
+def test_lowest_near_mint_fallback():
+    card = {"prices": {"cardmarket": {"lowest_near_mint": 5}}}
+    assert ui.extract_cardmarket_price(card) == 5


### PR DESCRIPTION
## Summary
- compute Cardmarket price by averaging `30d_average` and `trendPrice` metrics
- document price calculation in README
- cover combined and fallback scenarios with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba28fe044832f971a298f3f056a5d