### PR TITLE
Respect manually entered price

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4662,27 +4662,33 @@ class CardEditorApp:
         data["availability"] = 1
         data["delivery"] = "3 dni"
 
-        cena_local = self.get_price_from_db(data["nazwa"], data["numer"], data["set"])
-        is_reverse = self.type_vars["Reverse"].get()
-        is_holo = self.type_vars["Holo"].get()
-        if cena_local is not None:
-            cena_local = self.apply_variant_multiplier(
-                cena_local, is_reverse=is_reverse, is_holo=is_holo
-            )
-            data["cena"] = str(cena_local)
+        price = data.get("cena", "").strip()
+        if price:
+            data["cena"] = price
         else:
-            fetched = self.fetch_card_price(
-                data["nazwa"],
-                data["numer"],
-                data["set"],
+            cena_local = self.get_price_from_db(
+                data["nazwa"], data["numer"], data["set"]
             )
-            if fetched is not None:
-                fetched = self.apply_variant_multiplier(
-                    fetched, is_reverse=is_reverse, is_holo=is_holo
+            is_reverse = self.type_vars["Reverse"].get()
+            is_holo = self.type_vars["Holo"].get()
+            if cena_local is not None:
+                cena_local = self.apply_variant_multiplier(
+                    cena_local, is_reverse=is_reverse, is_holo=is_holo
                 )
-                data["cena"] = str(fetched)
+                data["cena"] = str(cena_local)
             else:
-                data["cena"] = ""
+                fetched = self.fetch_card_price(
+                    data["nazwa"],
+                    data["numer"],
+                    data["set"],
+                )
+                if fetched is not None:
+                    fetched = self.apply_variant_multiplier(
+                        fetched, is_reverse=is_reverse, is_holo=is_holo
+                    )
+                    data["cena"] = str(fetched)
+                else:
+                    data["cena"] = ""
 
         self.output_data[self.index] = data
         if getattr(self, "session_csv_path", None):

--- a/tests/test_manual_price.py
+++ b/tests/test_manual_price.py
@@ -1,0 +1,52 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+    def get(self):
+        return self.value
+
+
+def make_dummy(price):
+    return SimpleNamespace(
+        entries={
+            "nazwa": DummyVar("Charizard"),
+            "numer": DummyVar("4"),
+            "set": DummyVar("Base Set"),
+            "język": DummyVar("ENG"),
+            "stan": DummyVar("NM"),
+            "cena": DummyVar(price),
+            "psa10_price": DummyVar("")
+        },
+        type_vars={"Reverse": DummyVar(False), "Holo": DummyVar(False)},
+        card_cache={},
+        cards=["/tmp/char.jpg"],
+        index=0,
+        folder_name="folder",
+        file_to_key={},
+        product_code_map={},
+        next_product_code=1,
+        next_free_location=lambda: "K1R1P1",
+        generate_location=lambda idx: "K1R1P1",
+        output_data=[None],
+        get_price_from_db=MagicMock(return_value=None),
+        fetch_card_price=MagicMock(return_value=None),
+        fetch_psa10_price=MagicMock(return_value="123"),
+    )
+
+
+def test_manual_price_used():
+    importlib.reload(ui)
+    dummy = make_dummy("15.50")
+    ui.CardEditorApp.save_current_data(dummy)
+    assert dummy.output_data[0]["cena"] == "15.50"
+    dummy.get_price_from_db.assert_not_called()
+    dummy.fetch_card_price.assert_not_called()


### PR DESCRIPTION
## Summary
- skip price fetching when a manual price is provided
- test that manual prices are used without querying database

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c1b5eeeac832fb2e3085bb3f84133