### PR TITLE
Include product details in warehouse CSV export

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -33,7 +33,7 @@ STORE_FIELDNAMES = [
     "images 1",
 ]
 
-WAREHOUSE_FIELDNAMES = ["name", "warehouse_code", "image"]
+WAREHOUSE_FIELDNAMES = ["name", "number", "set", "warehouse_code", "image"]
 
 
 def format_store_row(row):
@@ -63,11 +63,10 @@ def format_store_row(row):
 
 def format_warehouse_row(row):
     """Return a row formatted for the warehouse CSV."""
-    name_parts = [row.get("nazwa"), row.get("numer")]
-    formatted_name = " ".join(part for part in name_parts if part)
-
     return {
-        "name": formatted_name,
+        "name": row.get("nazwa", ""),
+        "number": row.get("numer", ""),
+        "set": row.get("set", ""),
         "warehouse_code": row.get("warehouse_code", ""),
         "image": row.get("image1", row.get("images", "")),
     }

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -84,8 +84,11 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
         assert reader.fieldnames == csv_utils.WAREHOUSE_FIELDNAMES
-        assert rows[0]["name"] == "Pikachu 1"
-        assert rows[0]["image"] == "img.jpg"
-        assert rows[0]["warehouse_code"] == "K1R1P1"
+        row = rows[0]
+        assert row["name"] == "Pikachu"
+        assert row["number"] == "1"
+        assert row["set"] == "Base"
+        assert row["image"] == "img.jpg"
+        assert row["warehouse_code"] == "K1R1P1"
 
 


### PR DESCRIPTION
## Summary
- extend warehouse CSV fields with `nazwa`, `numer`, and `set`
- populate the new warehouse columns
- adjust tests for expanded column set
- switch warehouse headers to English `name`/`number`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c28165c94832f89257eb502037300