### PR TITLE
Add monthly check for set updates

### DIFF
--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -1,8 +1,10 @@
 import csv
 import re
+from datetime import datetime
 from . import csv_utils
 
 LAST_PRODUCT_CODE_FILE = "last_product_code.txt"
+LAST_SETS_CHECK_FILE = "last_sets_check.txt"
 
 
 def load_last_product_code() -> int:
@@ -16,6 +18,24 @@ def load_last_product_code() -> int:
 def save_last_product_code(value: int) -> None:
     with open(LAST_PRODUCT_CODE_FILE, "w", encoding="utf-8") as f:
         f.write(str(int(value)))
+
+
+def load_last_sets_check() -> datetime | None:
+    try:
+        with open(LAST_SETS_CHECK_FILE, "r", encoding="utf-8") as f:
+            text = f.read().strip()
+            if not text:
+                return None
+            return datetime.fromisoformat(text)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def save_last_sets_check(value: datetime | None = None) -> None:
+    if value is None:
+        value = datetime.now()
+    with open(LAST_SETS_CHECK_FILE, "w", encoding="utf-8") as f:
+        f.write(value.isoformat())
 
 
 def location_from_code(code: str) -> str:

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3928,7 +3928,11 @@ class CardEditorApp:
 
     def startup_tasks(self):
         """Run initial setup tasks in the background."""
-        self.update_sets()
+        last_check = storage.load_last_sets_check()
+        now = datetime.datetime.now()
+        if not last_check or last_check.year != now.year or last_check.month != now.month:
+            self.update_sets()
+            storage.save_last_sets_check(now)
         self.root.after(0, self.load_set_logos)
         self.root.after(1, self.finish_startup)
 

--- a/tests/test_sets_file.py
+++ b/tests/test_sets_file.py
@@ -1,6 +1,7 @@
 import importlib
 import json
 import sys
+import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -82,4 +83,37 @@ def test_update_sets_eng(tmp_path):
 
 def test_update_sets_jp(tmp_path):
     run_update_sets(tmp_path, "tcg_sets_jp.json")
+
+
+def test_startup_tasks_skips_when_same_month():
+    now = datetime.datetime.now()
+    dummy = SimpleNamespace(
+        root=SimpleNamespace(after=lambda *a, **k: None),
+        load_set_logos=lambda: None,
+        finish_startup=lambda: None,
+        update_sets=MagicMock(),
+    )
+    with patch.object(ui.storage, "load_last_sets_check", return_value=now), patch.object(
+        ui.storage, "save_last_sets_check"
+    ) as save_mock:
+        ui.CardEditorApp.startup_tasks(dummy)
+        dummy.update_sets.assert_not_called()
+        save_mock.assert_not_called()
+
+
+def test_startup_tasks_runs_when_old_month():
+    now = datetime.datetime.now()
+    prev_month = now.replace(day=1) - datetime.timedelta(days=1)
+    dummy = SimpleNamespace(
+        root=SimpleNamespace(after=lambda *a, **k: None),
+        load_set_logos=lambda: None,
+        finish_startup=lambda: None,
+        update_sets=MagicMock(),
+    )
+    with patch.object(
+        ui.storage, "load_last_sets_check", return_value=prev_month
+    ), patch.object(ui.storage, "save_last_sets_check") as save_mock:
+        ui.CardEditorApp.startup_tasks(dummy)
+        dummy.update_sets.assert_called_once()
+        save_mock.assert_called_once()
 


### PR DESCRIPTION
## Summary
- add helpers to save and load last set update timestamp
- skip `update_sets` if it ran earlier this month
- test timestamp logic for `startup_tasks`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c3a950b60832fbeafe235310bd19d