### PR TITLE
Prefer hash lookup over OpenAI for card analysis

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1013,7 +1013,13 @@ def analyze_card_image(
     preview_cb=None,
     preview_image=None,
 ):
-    """Return card details recognized from an image using a prioritized workflow."""
+    """Return card details recognized from an image.
+
+    The processing order is:
+    1. Local set-symbol hash lookup.
+    2. OpenAI Vision for text recognition.
+    3. OCR as a final fallback.
+    """
     parsed = urlparse(path)
     local_path = path if parsed.scheme not in ("http", "https") else None
     orientation = 0
@@ -1044,10 +1050,50 @@ def analyze_card_image(
     set_format = ""
 
     try:
-        # --- PRIORITY 1: OpenAI Vision ---
+        # --- PRIORITY 1: Local hash lookup for the set symbol ---
+        if local_path:
+            print("[INFO] Step 1: Matching set symbol via hash...")
+            try:
+                if not rects:
+                    rects = [(0, 0, 0, 0)]
+                if rect is None and rects:
+                    rect = rects[0]
+
+                for candidate in rects:
+                    if preview_cb and preview_image is not None:
+                        try:
+                            preview_cb(candidate, preview_image)
+                        except Exception:
+                            pass
+                    potential = identify_set_by_hash(local_path, candidate)
+                    if potential:
+                        code, name_match, diff = potential[0]
+                        if diff <= HASH_DIFF_THRESHOLD:
+                            rect = candidate
+                            set_code = code
+                            set_name = name_match
+                            print(
+                                f"[SUCCESS] Local hash analysis found a match: {name_match}"
+                            )
+                            result = {
+                                "name": name,
+                                "number": number,
+                                "total": total,
+                                "set": set_name,
+                                "set_code": set_code,
+                                "orientation": orientation,
+                                "set_format": set_format,
+                            }
+                            if debug and rect:
+                                result["rect"] = rect
+                            return result
+            except Exception as e:
+                print(f"[ERROR] Hash lookup failed: {e}")
+
+        # --- PRIORITY 2: OpenAI Vision ---
         api_key = os.getenv("OPENAI_API_KEY")
         if api_key:
-            print("[INFO] Step 1: Analyzing with OpenAI Vision...")
+            print("[INFO] Step 2: Analyzing with OpenAI Vision...")
             try:
                 name, number, total, set_name, set_code, set_format = extract_card_info_openai(path)
 
@@ -1055,7 +1101,9 @@ def analyze_card_image(
                     name = translate_to_english(name)
 
                 if name and number and set_name:
-                    print(f"[SUCCESS] OpenAI found all data: {name}, {number}, {set_name}")
+                    print(
+                        f"[SUCCESS] OpenAI found all data: {name}, {number}, {set_name}"
+                    )
                     result = {
                         "name": name,
                         "number": number,
@@ -1069,23 +1117,27 @@ def analyze_card_image(
                         result["rect"] = rect
                     return result
 
-                print("[INFO] OpenAI returned partial data. Proceeding to fallback methods.")
+                print(
+                    "[INFO] OpenAI returned partial data. Proceeding to fallback methods."
+                )
 
             except Exception as e:
                 print(f"[ERROR] OpenAI analysis failed: {e}")
                 name = number = total = set_name = ""
                 set_code = ""
         else:
-            print("[WARN] No OpenAI API key. Skipping to local analysis.")
+            print("[WARN] No OpenAI API key. Skipping to OCR.")
 
-        # --- PRIORITY 2: TCGGO API Lookup (if name and number are known) ---
+        # --- PRIORITY 3: TCGGO API Lookup (if name and number are known) ---
         if name and number:
-            print("[INFO] Step 2: Looking up sets via TCGGO API...")
+            print("[INFO] Step 3: Looking up sets via TCGGO API...")
             try:
                 api_sets = lookup_sets_from_api(name, number, total or None)
                 if len(api_sets) == 1:
                     set_code, api_set_name = api_sets[0]
-                    print(f"[SUCCESS] TCGGO API found a single match: {api_set_name}")
+                    print(
+                        f"[SUCCESS] TCGGO API found a single match: {api_set_name}"
+                    )
                     result = {
                         "name": name,
                         "number": number,
@@ -1100,13 +1152,18 @@ def analyze_card_image(
                     return result
 
                 if len(api_sets) > 1:
-                    print("[INFO] TCGGO API found multiple matches. Prompting user...")
+                    print(
+                        "[INFO] TCGGO API found multiple matches. Prompting user..."
+                    )
                     selected_code = prompt_set_selection(api_sets)
                     name_lookup = get_set_name(selected_code)
                     selected_name = (
                         name_lookup
                         if name_lookup != selected_code
-                        else next((n for c, n in api_sets if c == selected_code), selected_code)
+                        else next(
+                            (n for c, n in api_sets if c == selected_code),
+                            selected_code,
+                        )
                     )
                     print(f"[SUCCESS] User selected: {selected_name}")
                     result = {
@@ -1125,16 +1182,15 @@ def analyze_card_image(
             except Exception as e:
                 print(f"[ERROR] TCGGO API lookup failed: {e}")
 
-        # --- PRIORITY 3: Local Analysis (OCR before hash fallback) ---
+        # --- PRIORITY 4: OCR fallback ---
         if local_path:
-            print("[INFO] Step 3: Performing local analysis (OCR/hash)...")
+            print("[INFO] Step 4: Performing OCR fallback...")
             try:
                 if not rects:
                     rects = [(0, 0, 0, 0)]
-                if rect is None:
+                if rect is None and rects:
                     rect = rects[0]
 
-                # OCR has priority unless it fails to yield a valid code
                 for candidate in rects:
                     if preview_cb and preview_image is not None:
                         try:
@@ -1163,44 +1219,8 @@ def analyze_card_image(
                             return result
                         else:
                             print(f"[WARN] OCR produced unknown set code: {code}")
-
-                if set_format == "text":
-                    print("[INFO] OCR analysis did not find a valid set code and set format is text; skipping hash lookup.")
-                else:
-                    print("[INFO] OCR analysis did not find a valid set code. Trying hash...")
-
-                    for candidate in rects:
-                        if preview_cb and preview_image is not None:
-                            try:
-                                preview_cb(candidate, preview_image)
-                            except Exception:
-                                pass
-                        potential = identify_set_by_hash(local_path, candidate)
-                        if potential:
-                            code, name_match, diff = potential[0]
-                            if diff <= HASH_DIFF_THRESHOLD:
-                                rect = candidate
-                                set_code = code
-                                set_name = name_match
-                                print(
-                                    f"[SUCCESS] Local hash analysis found a match: {name_match}"
-                                )
-                                result = {
-                                    "name": name,
-                                    "number": number,
-                                    "total": total,
-                                    "set": set_name,
-                                    "set_code": set_code,
-                                    "orientation": orientation,
-                                    "set_format": set_format,
-                                }
-                                if debug and rect:
-                                    result["rect"] = rect
-                                return result
-
-                    print("[INFO] Hash analysis did not yield a confident result.")
             except Exception as e:
-                print(f"[ERROR] Local analysis failed: {e}")
+                print(f"[ERROR] OCR analysis failed: {e}")
 
         # If all methods fail, return any partial data we might have
         print("[FAIL] All analysis methods failed to find a definitive set.")
@@ -3674,13 +3694,36 @@ class CardEditorApp:
                 translate = lang_var.get() == "JP"
             except Exception:
                 translate = False
-        result = analyze_card_image(
-            path,
-            translate_name=translate,
-            debug=True,
-            preview_cb=getattr(self, "update_set_area_preview", None),
-            preview_image=getattr(self, "current_card_image", None),
-        )
+        fp_match = None
+        if (
+            getattr(self, "hash_db", None)
+            and getattr(self, "current_fingerprint", None) is not None
+        ):
+            try:
+                fp_match = self.hash_db.best_match(self.current_fingerprint)
+            except Exception:
+                fp_match = None
+
+        if fp_match:
+            meta = fp_match.meta
+            result = {
+                "name": meta.get("nazwa", meta.get("name", "")),
+                "number": meta.get("numer", meta.get("number", "")),
+                "total": meta.get("total", ""),
+                "set": meta.get("set", meta.get("set_name", "")),
+                "set_code": meta.get("set_code", ""),
+                "orientation": 0,
+                "set_format": meta.get("set_format", ""),
+            }
+        else:
+            result = analyze_card_image(
+                path,
+                translate_name=translate,
+                debug=True,
+                preview_cb=getattr(self, "update_set_area_preview", None),
+                preview_image=getattr(self, "current_card_image", None),
+            )
+
         self.root.after(0, lambda: self._apply_analysis_result(result, idx))
 
     def _apply_analysis_result(self, result, idx):

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -118,10 +118,11 @@ def test_show_card_uses_analyzer(tmp_path):
 
 def test_analyze_card_image_api_single_set(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
-    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")), \
-         patch.object(ui, "lookup_sets_from_api", return_value=[("sv01", SV01_NAME)]), \
-         patch.object(ui, "prompt_set_selection") as mock_prompt, \
-         patch.object(ui, "identify_set_by_hash") as mock_hash:
+    with patch.object(
+        ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")
+    ), patch.object(ui, "lookup_sets_from_api", return_value=[("sv01", SV01_NAME)]), patch.object(
+        ui, "prompt_set_selection"
+    ) as mock_prompt, patch.object(ui, "identify_set_by_hash", return_value=[]) as mock_hash:
         result = ui.analyze_card_image("/tmp/img.jpg")
 
     assert result == {
@@ -134,17 +135,18 @@ def test_analyze_card_image_api_single_set(monkeypatch):
         "set_format": "",
     }
     mock_prompt.assert_not_called()
-    mock_hash.assert_not_called()
+    mock_hash.assert_called_once()
 
 
 def test_analyze_card_image_api_multiple_sets(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     options = [("a", "Set A"), ("b", "Set B")]
 
-    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")), \
-         patch.object(ui, "lookup_sets_from_api", return_value=options), \
-         patch.object(ui, "prompt_set_selection", return_value="b") as mock_prompt, \
-         patch.object(ui, "identify_set_by_hash") as mock_hash:
+    with patch.object(
+        ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")
+    ), patch.object(ui, "lookup_sets_from_api", return_value=options), patch.object(
+        ui, "prompt_set_selection", return_value="b"
+    ) as mock_prompt, patch.object(ui, "identify_set_by_hash", return_value=[]) as mock_hash:
         result = ui.analyze_card_image("/tmp/img.jpg")
 
     assert result == {
@@ -157,10 +159,10 @@ def test_analyze_card_image_api_multiple_sets(monkeypatch):
         "set_format": "",
     }
     mock_prompt.assert_called_once_with(options)
-    mock_hash.assert_not_called()
+    mock_hash.assert_called_once()
 
 
-def test_analyze_card_image_api_fallback_hash(monkeypatch):
+def test_analyze_card_image_hash_preempts_openai(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     class DummyImage:
         size = (100, 100)
@@ -168,15 +170,16 @@ def test_analyze_card_image_api_fallback_hash(monkeypatch):
         def crop(self, *args, **kwargs):
             return self
 
-    with patch.object(ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")), \
-         patch.object(ui, "lookup_sets_from_api", return_value=[]), \
-         patch.object(ui, "identify_set_by_hash", return_value=[("x", "Set X", 0)]) as mock_hash, \
-         patch.object(ui, "extract_set_code_ocr", return_value=[]):
+    with patch.object(
+        ui, "extract_card_info_openai", return_value=("Pikachu", "037", "", "", "", "")
+    ) as mock_openai, patch.object(ui, "lookup_sets_from_api", return_value=[]), patch.object(
+        ui, "identify_set_by_hash", return_value=[("x", "Set X", 0)]
+    ) as mock_hash, patch.object(ui, "extract_set_code_ocr", return_value=[]):
         result = ui.analyze_card_image("/tmp/img.jpg")
 
     assert result == {
-        "name": "Pikachu",
-        "number": "037",
+        "name": "",
+        "number": "",
         "total": "",
         "set": "Set X",
         "set_code": "x",
@@ -184,6 +187,7 @@ def test_analyze_card_image_api_fallback_hash(monkeypatch):
         "set_format": "",
     }
     mock_hash.assert_called_once()
+    mock_openai.assert_not_called()
 
 
 def test_analyze_card_image_ocr(monkeypatch):
@@ -191,10 +195,11 @@ def test_analyze_card_image_ocr(monkeypatch):
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
 
-    with patch.object(ui, "identify_set_by_hash", return_value=[]) as mock_hash, \
-        patch.object(ui, "extract_set_code_ocr", return_value=[SV01_CODE]) as mock_ocr, \
-        patch.object(ui, "extract_card_info_openai") as mock_extract, \
-        patch.object(ui, "lookup_sets_from_api") as mock_lookup:
+    with patch.object(ui, "identify_set_by_hash", return_value=[]) as mock_hash, patch.object(
+        ui, "extract_set_code_ocr", return_value=[SV01_CODE]
+    ) as mock_ocr, patch.object(ui, "extract_card_info_openai") as mock_extract, patch.object(
+        ui, "lookup_sets_from_api"
+    ) as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
     assert result == {
@@ -206,7 +211,7 @@ def test_analyze_card_image_ocr(monkeypatch):
         "orientation": 0,
         "set_format": "",
     }
-    mock_hash.assert_not_called()
+    mock_hash.assert_called_once()
     mock_ocr.assert_called_once()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
@@ -217,10 +222,11 @@ def test_analyze_card_image_ocr_unknown_code(monkeypatch, capsys):
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
 
-    with patch.object(ui, "identify_set_by_hash", return_value=[]) as mock_hash, \
-        patch.object(ui, "extract_set_code_ocr", return_value=["XYZ"]) as mock_ocr, \
-        patch.object(ui, "extract_card_info_openai") as mock_extract, \
-        patch.object(ui, "lookup_sets_from_api") as mock_lookup:
+    with patch.object(ui, "identify_set_by_hash", return_value=[]) as mock_hash, patch.object(
+        ui, "extract_set_code_ocr", return_value=["XYZ"]
+    ) as mock_ocr, patch.object(ui, "extract_card_info_openai") as mock_extract, patch.object(
+        ui, "lookup_sets_from_api"
+    ) as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
     assert result == {
@@ -240,18 +246,16 @@ def test_analyze_card_image_ocr_unknown_code(monkeypatch, capsys):
     assert "OCR produced unknown set code: XYZ" in out
 
 
-def test_analyze_card_image_hash_after_ocr_failure(monkeypatch):
+def test_analyze_card_image_hash_shortcircuits_ocr(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
 
     with patch.object(
         ui, "identify_set_by_hash", return_value=[(SV01_CODE, SV01_NAME, 0)]
-    ) as mock_hash, patch.object(
-        ui, "extract_set_code_ocr", return_value=[]
-    ) as mock_ocr, patch.object(ui, "extract_card_info_openai") as mock_extract, patch.object(
-        ui, "lookup_sets_from_api"
-    ) as mock_lookup:
+    ) as mock_hash, patch.object(ui, "extract_set_code_ocr") as mock_ocr, patch.object(
+        ui, "extract_card_info_openai"
+    ) as mock_extract, patch.object(ui, "lookup_sets_from_api") as mock_lookup:
         result = ui.analyze_card_image(str(logo_path))
 
     assert result == {
@@ -263,13 +267,13 @@ def test_analyze_card_image_hash_after_ocr_failure(monkeypatch):
         "orientation": 0,
         "set_format": "",
     }
-    mock_ocr.assert_called_once()
     mock_hash.assert_called_once()
+    mock_ocr.assert_not_called()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
 
 
-def test_analyze_card_image_ocr_skips_hash(monkeypatch):
+def test_analyze_card_image_ocr_after_hash_failure(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
 
     logo_path = Path(__file__).resolve().parents[1] / "set_logos" / f"{SV01_CODE}.png"
@@ -292,7 +296,7 @@ def test_analyze_card_image_ocr_skips_hash(monkeypatch):
         "orientation": 0,
         "set_format": "",
     }
-    mock_hash.assert_not_called()
+    mock_hash.assert_called_once()
     mock_ocr.assert_called_once()
     mock_extract.assert_not_called()
     mock_lookup.assert_not_called()
@@ -535,6 +539,49 @@ def test_analyze_and_fill_translates_for_jp(monkeypatch):
         ui.CardEditorApp._analyze_and_fill(dummy, "/tmp/x", 0)
 
     name_entry.insert.assert_called_with(0, "Pikachu")
+
+
+def test_analyze_and_fill_uses_hash_db(monkeypatch):
+    name_entry = MagicMock()
+    num_entry = MagicMock()
+    set_var = MagicMock()
+    name_entry.delete = MagicMock()
+    name_entry.insert = MagicMock()
+    num_entry.delete = MagicMock()
+    num_entry.insert = MagicMock()
+    set_var.set = MagicMock()
+
+    dummy = SimpleNamespace(
+        root=SimpleNamespace(after=lambda delay, func: func()),
+        lang_var=None,
+        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var},
+        index=0,
+        stop_scan_animation=lambda: None,
+        update_set_options=lambda: None,
+        update_set_area_preview=lambda *a, **k: None,
+        hash_db=SimpleNamespace(
+            best_match=lambda fp: SimpleNamespace(
+                meta={
+                    "name": "Pika",
+                    "number": "001",
+                    "set": SV01_NAME,
+                    "set_code": SV01_CODE,
+                }
+            )
+        ),
+        current_fingerprint=object(),
+    )
+    dummy._apply_analysis_result = ui.CardEditorApp._apply_analysis_result.__get__(
+        dummy, ui.CardEditorApp
+    )
+
+    with patch.object(ui, "analyze_card_image") as mock_analyze:
+        ui.CardEditorApp._analyze_and_fill(dummy, "/tmp/x", 0)
+
+    mock_analyze.assert_not_called()
+    name_entry.insert.assert_called_with(0, "Pika")
+    num_entry.insert.assert_called_with(0, "1")
+    set_var.set.assert_called_with(SV01_NAME)
 
 
 def test_show_card_fills_from_inventory(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Check set-symbol hash before using OpenAI Vision, falling back to OCR last
- Skip costly analysis when a fingerprint match is found
- Expand tests for new hash-first analysis workflow

## Testing
- `pytest tests/test_analyze_card_image.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c3cac2458832f92679f3e7481f906