### PR TITLE
Guard optional hash DB and document env

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ recognise duplicate scans. Each entry stores perceptual hashes and optional
 ORB descriptors together with card metadata, allowing previously processed
 images to be matched quickly.
 
+Set the `HASH_DB_PATH` environment variable to a writable SQLite file to enable
+persistent storage. When it is not provided the fingerprint database is
+disabled and no duplicate detection is performed.
+
 ### Dependencies
 
 Fingerprinting relies on [`numpy`](https://numpy.org), [`Pillow`](https://python-pillow.org) and
@@ -101,9 +105,12 @@ FTP_USER=username
 FTP_PASSWORD=secret
 WAREHOUSE_CSV=magazyn.csv
 BASE_IMAGE_URL=https://your-store.shop/upload/images
+HASH_DB_PATH=hashes.sqlite
 ```
 
 - `OPENAI_API_KEY` – API key used by OpenAI Vision to extract card details from scans.
+- `HASH_DB_PATH` – path to a SQLite file used for fingerprint storage. When unset
+  duplicate detection is disabled.
 
 **Warning:** This file may contain private API keys and tokens. It is excluded
 from version control via `.gitignore` and should never be shared publicly.

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -34,7 +34,10 @@ from urllib.parse import urlencode, urlparse
 import io
 import webbrowser
 import logging
-from hash_db import HashDB
+try:
+    from hash_db import HashDB
+except Exception:  # pragma: no cover - optional dependency
+    HashDB = None  # type: ignore[assignment]
 from fingerprint import compute_fingerprint
 
 ENV_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env")
@@ -67,6 +70,9 @@ PSA_ICON_URL = "https://www.pngkey.com/png/full/231-2310791_psa-grading-standard
 
 # toggle automatic fingerprint lookup via environment variable
 AUTO_HASH_LOOKUP = os.getenv("AUTO_HASH_LOOKUP", "1") not in {"0", "false", "False"}
+
+# optional path to enable persistent fingerprint storage
+HASH_DB_PATH = os.getenv("HASH_DB_PATH")
 
 # minimum similarity ratio for fuzzy set code matching
 SET_CODE_MATCH_CUTOFF = 0.8
@@ -1166,7 +1172,10 @@ class CardEditorApp:
         self.card_cache = {}
         self.file_to_key = {}
         self.product_code_map = {}
-        self.hash_db = HashDB()
+        try:
+            self.hash_db = HashDB(HASH_DB_PATH) if HashDB and HASH_DB_PATH else None
+        except Exception:
+            self.hash_db = None
         self.auto_lookup = AUTO_HASH_LOOKUP
         self.current_fingerprint = None
         self.next_product_code = storage.load_last_product_code() + 1
@@ -3361,7 +3370,10 @@ class CardEditorApp:
         try:
             image = Image.open(image_path)
             if isinstance(image, Image.Image):
-                self.current_fingerprint = compute_fingerprint(image.copy())
+                if getattr(self, "hash_db", None):
+                    self.current_fingerprint = compute_fingerprint(image.copy())
+                else:
+                    self.current_fingerprint = None
             else:
                 self.current_fingerprint = None
         except Exception as e:
@@ -4435,13 +4447,17 @@ class CardEditorApp:
             [name for name, var in self.type_vars.items() if var.get()]
         )
         fp = getattr(self, "current_fingerprint", None)
-        if fp is None and getattr(self, "current_image_path", None):
+        if (
+            fp is None
+            and getattr(self, "current_image_path", None)
+            and getattr(self, "hash_db", None)
+        ):
             try:
                 with Image.open(self.current_image_path) as img:
                     fp = compute_fingerprint(img)
             except Exception:
                 fp = None
-        self.current_fingerprint = fp
+            self.current_fingerprint = fp
         if fp is not None and getattr(self, "hash_db", None):
             meta = {
                 k: data.get(k, "")


### PR DESCRIPTION
## Summary
- Handle missing HashDB gracefully and read optional `HASH_DB_PATH`
- Skip fingerprint work when the hash database is unavailable
- Document `HASH_DB_PATH` environment variable for persistent fingerprint storage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c491450e4832fb8fc831c9c378ba9