### PR TITLE
Perform fingerprint lookup asynchronously

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3369,13 +3369,6 @@ class CardEditorApp:
         inv_entry = self.lookup_inventory_entry(cache_key) if cache_key else None
         try:
             image = Image.open(image_path)
-            if isinstance(image, Image.Image):
-                if getattr(self, "hash_db", None):
-                    self.current_fingerprint = compute_fingerprint(image.copy())
-                else:
-                    self.current_fingerprint = None
-            else:
-                self.current_fingerprint = None
         except Exception as e:
             print(f"Failed to load image {image_path}: {e}", file=sys.stderr)
             if getattr(self, "failed_cards", None) is not None:
@@ -3412,17 +3405,6 @@ class CardEditorApp:
         for var in self.type_vars.values():
             var.set(False)
 
-        fp_match = None
-        if (
-            getattr(self, "hash_db", None)
-            and self.current_fingerprint is not None
-            and getattr(self, "auto_lookup", False)
-        ):
-            try:
-                fp_match = self.hash_db.best_match(self.current_fingerprint)
-            except Exception:
-                fp_match = None
-
         skip_analysis = False
         if cache_key and cache_key in self.card_cache:
             cached = self.card_cache[cache_key]
@@ -3445,25 +3427,6 @@ class CardEditorApp:
                 0, sanitize_number(str(inv_entry.get("numer", "")))
             )
             self.entries["set"].set(inv_entry.get("set", ""))
-            self.update_set_options()
-            skip_analysis = True
-
-        elif fp_match:
-            meta = fp_match.meta
-            for field, value in meta.items():
-                entry = self.entries.get(field)
-                if entry is None:
-                    continue
-                if isinstance(entry, (tk.Entry, ctk.CTkEntry)):
-                    if field == "numer":
-                        value = sanitize_number(str(value))
-                    entry.insert(0, value)
-                elif isinstance(entry, tk.StringVar):
-                    entry.set(value)
-            if "typ" in meta:
-                for name in str(meta["typ"]).split(","):
-                    if name in self.type_vars:
-                        self.type_vars[name].set(True)
             self.update_set_options()
             skip_analysis = True
 
@@ -3593,12 +3556,12 @@ class CardEditorApp:
             except Exception:
                 translate = False
         fp_match = None
-        if (
-            getattr(self, "hash_db", None)
-            and getattr(self, "current_fingerprint", None) is not None
-        ):
+        if getattr(self, "hash_db", None) and getattr(self, "auto_lookup", False):
             try:
-                fp_match = self.hash_db.best_match(self.current_fingerprint)
+                with Image.open(path) as img:
+                    fp = compute_fingerprint(img)
+                self.current_fingerprint = fp
+                fp_match = self.hash_db.best_match(fp)
             except Exception:
                 fp_match = None
 

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -567,13 +567,24 @@ def test_analyze_and_fill_uses_hash_db(monkeypatch):
                 }
             )
         ),
-        current_fingerprint=object(),
+        auto_lookup=True,
+        current_fingerprint=None,
     )
     dummy._apply_analysis_result = ui.CardEditorApp._apply_analysis_result.__get__(
         dummy, ui.CardEditorApp
     )
 
-    with patch.object(ui, "analyze_card_image") as mock_analyze:
+    class DummyImage:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr(ui, "compute_fingerprint", lambda img: "fp")
+    with patch.object(ui.Image, "open", return_value=DummyImage()), patch.object(
+        ui, "analyze_card_image"
+    ) as mock_analyze:
         ui.CardEditorApp._analyze_and_fill(dummy, "/tmp/x", 0)
 
     mock_analyze.assert_not_called()
@@ -645,6 +656,166 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     name_entry.insert.assert_called_with(0, "Pikachu")
     num_entry.insert.assert_called_with(0, "1")
     set_var.set.assert_called_with(SV01_NAME)
+
+
+def test_show_card_skips_fingerprint_without_auto_lookup(tmp_path, monkeypatch):
+    img = tmp_path / "card.jpg"
+    img.write_bytes(b"data")
+
+    name_entry = MagicMock()
+    num_entry = MagicMock()
+    set_var = MagicMock()
+    name_entry.delete = MagicMock()
+    name_entry.insert = MagicMock()
+    name_entry.focus_set = MagicMock()
+    num_entry.delete = MagicMock()
+    num_entry.insert = MagicMock()
+    set_var.set = MagicMock()
+
+    class DummyImage:
+        size = (100, 100)
+
+        def thumbnail(self, *a, **k):
+            pass
+
+        def copy(self):
+            return self
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class DummyThread:
+        def __init__(self, target, args=(), kwargs=None, daemon=None):
+            self.target = target
+            self.args = args
+            self.kwargs = kwargs or {}
+
+        def start(self):
+            self.target(*self.args, **self.kwargs)
+
+    dummy = SimpleNamespace(
+        cards=[str(img)],
+        index=0,
+        image_objects=[],
+        image_label=MagicMock(),
+        progress_var=SimpleNamespace(set=lambda *a, **k: None),
+        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var},
+        type_vars={},
+        card_cache={},
+        file_to_key={},
+        _guess_key_from_filename=lambda *a, **k: None,
+        lookup_inventory_entry=lambda *a, **k: None,
+        update_set_options=lambda *a, **k: None,
+        root=SimpleNamespace(after=lambda *a, **k: None),
+        auto_lookup=False,
+        hash_db=SimpleNamespace(best_match=lambda *a, **k: None),
+    )
+
+    dummy.start_scan_animation = lambda *a, **k: None
+    dummy.stop_scan_animation = lambda *a, **k: None
+    dummy._analyze_and_fill = lambda *a, **k: None
+
+    fp_mock = MagicMock()
+    monkeypatch.setattr(ui, "compute_fingerprint", fp_mock)
+    monkeypatch.setattr(ui, "analyze_card_image", lambda *a, **k: {})
+    monkeypatch.setattr(ui.threading, "Thread", DummyThread)
+    with patch.object(ui.Image, "open", return_value=DummyImage()), patch.object(
+        ui.ImageTk, "PhotoImage", return_value=MagicMock()
+    ):
+        ui.CardEditorApp.show_card(dummy)
+
+    fp_mock.assert_not_called()
+
+
+def test_show_card_fingerprint_lookup_thread(tmp_path, monkeypatch):
+    img = tmp_path / "card.jpg"
+    img.write_bytes(b"data")
+
+    name_entry = MagicMock()
+    num_entry = MagicMock()
+    set_var = MagicMock()
+    name_entry.delete = MagicMock()
+    name_entry.insert = MagicMock()
+    name_entry.focus_set = MagicMock()
+    num_entry.delete = MagicMock()
+    num_entry.insert = MagicMock()
+    set_var.set = MagicMock()
+
+    class DummyImage:
+        size = (100, 100)
+
+        def thumbnail(self, *a, **k):
+            pass
+
+        def copy(self):
+            return self
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    class DummyThread:
+        def __init__(self, target, args=(), kwargs=None, daemon=None):
+            self.target = target
+            self.args = args
+            self.kwargs = kwargs or {}
+
+        def start(self):
+            self.target(*self.args, **self.kwargs)
+
+    best_match = MagicMock(
+        return_value=SimpleNamespace(
+            meta={"nazwa": "Pika", "numer": "001", "set": "Set X"}
+        )
+    )
+    dummy = SimpleNamespace(
+        cards=[str(img)],
+        index=0,
+        image_objects=[],
+        image_label=MagicMock(),
+        progress_var=SimpleNamespace(set=lambda *a, **k: None),
+        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var},
+        type_vars={},
+        card_cache={},
+        file_to_key={},
+        _guess_key_from_filename=lambda *a, **k: None,
+        lookup_inventory_entry=lambda *a, **k: None,
+        update_set_options=lambda *a, **k: None,
+        root=SimpleNamespace(after=lambda delay, func: func()),
+        auto_lookup=True,
+        hash_db=SimpleNamespace(best_match=best_match),
+    )
+
+    dummy.start_scan_animation = lambda *a, **k: None
+    dummy.stop_scan_animation = lambda *a, **k: None
+    dummy._analyze_and_fill = ui.CardEditorApp._analyze_and_fill.__get__(
+        dummy, ui.CardEditorApp
+    )
+    dummy._apply_analysis_result = ui.CardEditorApp._apply_analysis_result.__get__(
+        dummy, ui.CardEditorApp
+    )
+
+    fp_mock = MagicMock(return_value="fp")
+    analyze_mock = MagicMock(return_value={})
+    monkeypatch.setattr(ui, "compute_fingerprint", fp_mock)
+    monkeypatch.setattr(ui, "analyze_card_image", analyze_mock)
+    monkeypatch.setattr(ui.threading, "Thread", DummyThread)
+    with patch.object(ui.Image, "open", return_value=DummyImage()), patch.object(
+        ui.ImageTk, "PhotoImage", return_value=MagicMock()
+    ):
+        ui.CardEditorApp.show_card(dummy)
+
+    fp_mock.assert_called_once()
+    best_match.assert_called_once_with("fp")
+    analyze_mock.assert_not_called()
+    name_entry.insert.assert_called_with(0, "Pika")
+    num_entry.insert.assert_called_with(0, "1")
+    set_var.set.assert_called_with("Set X")
 
 
 def test_fetch_card_data_auto_set(monkeypatch):


### PR DESCRIPTION
## Summary
- only compute card fingerprints when hash DB and auto lookup are enabled
- resolve hash DB matches in a background worker and sync results back via `root.after`
- test that fingerprinting is optional and runs in a worker when enabled

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c4e9919fc832f807f0fbc461cdde0