### PR TITLE
Add HASH_DB_FILE option for persistent fingerprint database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,4 @@ FTP_HOST=example.com
 FTP_USER=username
 FTP_PASSWORD=secret
 INVENTORY_CSV=magazyn.csv
+HASH_DB_FILE=hashes.sqlite

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ recognise duplicate scans. Each entry stores perceptual hashes and optional
 ORB descriptors together with card metadata, allowing previously processed
 images to be matched quickly.
 
-Set the `HASH_DB_PATH` environment variable to a writable SQLite file to enable
-persistent storage. When it is not provided the fingerprint database is
-disabled and no duplicate detection is performed.
+Set the `HASH_DB_FILE` environment variable to a writable SQLite file to enable
+persistent storage. The file is created automatically if it does not exist.
+When it is not provided the fingerprint database is disabled and no duplicate
+detection is performed.
 
 ### Dependencies
 
@@ -105,12 +106,12 @@ FTP_USER=username
 FTP_PASSWORD=secret
 WAREHOUSE_CSV=magazyn.csv
 BASE_IMAGE_URL=https://your-store.shop/upload/images
-HASH_DB_PATH=hashes.sqlite
+HASH_DB_FILE=hashes.sqlite
 ```
 
 - `OPENAI_API_KEY` – API key used by OpenAI Vision to extract card details from scans.
-- `HASH_DB_PATH` – path to a SQLite file used for fingerprint storage. When unset
-  duplicate detection is disabled.
+- `HASH_DB_FILE` – path to a SQLite file used for fingerprint storage. When
+  unset duplicate detection is disabled.
 
 **Warning:** This file may contain private API keys and tokens. It is excluded
 from version control via `.gitignore` and should never be shared publicly.

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -25,6 +25,7 @@ import sys
 from typing import Iterable, Optional
 from pydantic import BaseModel
 import pytesseract
+from pathlib import Path
 
 from shoper_client import ShoperClient
 from ftp_client import FTPClient
@@ -72,7 +73,7 @@ PSA_ICON_URL = "https://www.pngkey.com/png/full/231-2310791_psa-grading-standard
 AUTO_HASH_LOOKUP = os.getenv("AUTO_HASH_LOOKUP", "1") not in {"0", "false", "False"}
 
 # optional path to enable persistent fingerprint storage
-HASH_DB_PATH = os.getenv("HASH_DB_PATH")
+HASH_DB_FILE = os.getenv("HASH_DB_FILE")
 
 # minimum similarity ratio for fuzzy set code matching
 SET_CODE_MATCH_CUTOFF = 0.8
@@ -1173,7 +1174,13 @@ class CardEditorApp:
         self.file_to_key = {}
         self.product_code_map = {}
         try:
-            self.hash_db = HashDB(HASH_DB_PATH) if HashDB and HASH_DB_PATH else None
+            if HashDB and HASH_DB_FILE:
+                db_path = Path(HASH_DB_FILE)
+                db_path.parent.mkdir(parents=True, exist_ok=True)
+                db_path.touch(exist_ok=True)
+                self.hash_db = HashDB(str(db_path))
+            else:
+                self.hash_db = None
         except Exception:
             self.hash_db = None
         self.auto_lookup = AUTO_HASH_LOOKUP


### PR DESCRIPTION
## Summary
- add `HASH_DB_FILE` environment variable and load it in `ui.py`
- create fingerprint database file on first run and pass the path to `HashDB`
- document local fingerprint DB usage and configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c525b1848832fafbc954d2ca3f75a