### PR TITLE
Include price in warehouse CSV exports

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -33,7 +33,7 @@ STORE_FIELDNAMES = [
     "images 1",
 ]
 
-WAREHOUSE_FIELDNAMES = ["name", "number", "set", "warehouse_code", "image"]
+WAREHOUSE_FIELDNAMES = ["name", "number", "set", "warehouse_code", "price", "image"]
 
 
 def format_store_row(row):
@@ -68,6 +68,7 @@ def format_warehouse_row(row):
         "number": row.get("numer", ""),
         "set": row.get("set", ""),
         "warehouse_code": row.get("warehouse_code", ""),
+        "price": row.get("cena") or row.get("price", ""),
         "image": row.get("image1", row.get("images", "")),
     }
 

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -47,6 +47,7 @@ def test_export_includes_new_fields(tmp_path):
         assert row["active"] == "1"
         assert row["vat"] == "23%"
         assert row["images 1"] == "img.jpg"
+        assert row["price"] == "10"
         assert "psa10_price" not in reader.fieldnames
 
 
@@ -88,7 +89,8 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
         assert row["name"] == "Pikachu"
         assert row["number"] == "1"
         assert row["set"] == "Base"
-        assert row["image"] == "img.jpg"
         assert row["warehouse_code"] == "K1R1P1"
+        assert row["price"] == "10"
+        assert row["image"] == "img.jpg"
 
 


### PR DESCRIPTION
## Summary
- capture card price when formatting warehouse rows
- extend warehouse CSV headers with a `price` column
- verify exported store and warehouse CSVs include the price

## Testing
- `pytest tests/test_export_csv.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c599d1df8832f883eaf49182203ca