### PR TITLE
Display inventory stats on welcome screen

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -36,6 +36,38 @@ STORE_FIELDNAMES = [
 WAREHOUSE_FIELDNAMES = ["name", "number", "set", "warehouse_code", "price", "image"]
 
 
+def get_inventory_stats(path: str = WAREHOUSE_CSV):
+    """Return total count and value from the warehouse CSV.
+
+    Parameters
+    ----------
+    path:
+        Optional path to the warehouse CSV. Defaults to ``WAREHOUSE_CSV``.
+
+    Returns
+    -------
+    tuple[int, float]
+        Number of rows and the sum of the ``price`` column.
+    """
+
+    count = 0
+    total = 0.0
+    if not os.path.exists(path):
+        return count, total
+
+    with open(path, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        for row in reader:
+            count += 1
+            price_raw = str(row.get("price") or "0").replace(",", ".")
+            try:
+                total += float(price_raw)
+            except ValueError:
+                continue
+
+    return count, total
+
+
 def format_store_row(row):
     """Return a row formatted for the store CSV."""
     formatted_name = row["nazwa"]
@@ -226,6 +258,9 @@ def append_warehouse_csv(app, path: str = WAREHOUSE_CSV):
             if row is None:
                 continue
             writer.writerow(format_warehouse_row(row))
+
+    if hasattr(app, "update_inventory_stats"):
+        app.update_inventory_stats()
 
 
 def send_csv_to_shoper(app, file_path: str):

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1257,6 +1257,20 @@ class CardEditorApp:
         )
         desc.pack(pady=5)
 
+        count, total_value = csv_utils.get_inventory_stats()
+        self.inventory_count_label = ctk.CTkLabel(
+            self.start_frame,
+            text=f"Łączna liczba kart: {count}",
+            text_color=TEXT_COLOR,
+        )
+        self.inventory_count_label.pack()
+        self.inventory_value_label = ctk.CTkLabel(
+            self.start_frame,
+            text=f"Łączna wartość: {total_value:.2f} PLN",
+            text_color=TEXT_COLOR,
+        )
+        self.inventory_value_label.pack(pady=(0, 5))
+
         author = ctk.CTkLabel(
             self.start_frame,
             text="Twórca: BOGUCKI | Właściciel: kartoteka.shop",
@@ -1316,6 +1330,18 @@ class CardEditorApp:
             command=self.open_config_dialog,
             fg_color="#404040",
         ).pack(side="left", padx=10, pady=5)
+
+    def update_inventory_stats(self):
+        """Refresh labels showing total item count and value."""
+        count, total = csv_utils.get_inventory_stats()
+        if getattr(self, "inventory_count_label", None):
+            self.inventory_count_label.configure(
+                text=f"Łączna liczba kart: {count}"
+            )
+        if getattr(self, "inventory_value_label", None):
+            self.inventory_value_label.configure(
+                text=f"Łączna wartość: {total:.2f} PLN"
+            )
 
     def placeholder_btn(self, text: str, master=None):
         if master is None:

--- a/tests/test_inventory_stats.py
+++ b/tests/test_inventory_stats.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from kartoteka import csv_utils
+
+
+def test_get_inventory_stats(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10.5;img1\n" "B;2;S2;K2;5,25;img2\n",
+        encoding="utf-8",
+    )
+    count, total = csv_utils.get_inventory_stats(str(csv_path))
+    assert count == 2
+    assert total == pytest.approx(15.75)


### PR DESCRIPTION
## Summary
- add `get_inventory_stats` helper to read card count and total value from warehouse CSV
- show inventory count and value on the welcome screen with auto-refresh method
- refresh stats after appending to warehouse and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c5b313680832fb74f16d5d2672d37