### PR TITLE
Use CTk widgets and colors in magazyn view

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2474,9 +2474,7 @@ class CardEditorApp:
             self.location_frame = None
 
         self.root.minsize(1000, 700)
-        self.magazyn_frame = tk.Frame(
-            self.root, bg=self.root.cget("background")
-        )
+        self.magazyn_frame = ctk.CTkFrame(self.root, fg_color=BG_COLOR)
         self.magazyn_frame.pack(expand=True, fill="both", padx=10, pady=10)
 
         img_path = os.path.join(os.path.dirname(__file__), "box.png")
@@ -2487,9 +2485,7 @@ class CardEditorApp:
             img = Image.new("RGB", (150, 150), "#111111")
         self.mag_box_photo = ImageTk.PhotoImage(img)
 
-        container = tk.Frame(
-            self.magazyn_frame, bg=self.root.cget("background")
-        )
+        container = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
         container.pack(padx=10, pady=10)
 
         # Order boxes so that the grid layout is:
@@ -2499,25 +2495,28 @@ class CardEditorApp:
         self.mag_canvases = []
         self.mag_labels = []
         for i, box_num in enumerate(self.mag_box_order):
-            frame = tk.Frame(container, bg=self.root.cget("background"))
-            lbl = tk.Label(frame, text=f"K{box_num}", bg=self.root.cget("background"))
+            frame = ctk.CTkFrame(container, fg_color=BG_COLOR)
+            lbl = ctk.CTkLabel(
+                frame,
+                text=f"K{box_num}",
+                fg_color=BG_COLOR,
+                text_color=TEXT_COLOR,
+            )
             lbl.pack()
             canvas = tk.Canvas(
                 frame,
                 width=self.mag_box_photo.width(),
                 height=self.mag_box_photo.height(),
-                bg="#111111",
                 highlightthickness=0,
             )
+            canvas.config(bg=BG_COLOR)
             canvas.create_image(0, 0, image=self.mag_box_photo, anchor="nw")
             canvas.pack()
             frame.grid(row=i // 4, column=i % 4, padx=5, pady=5)
             self.mag_canvases.append(canvas)
             self.mag_labels.append(lbl)
 
-        btn_frame = tk.Frame(
-            self.magazyn_frame, bg=self.root.cget("background")
-        )
+        btn_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
         btn_frame.pack(pady=5)
 
         self.create_button(
@@ -2594,6 +2593,7 @@ class CardEditorApp:
                     x_mid,
                     self.mag_box_photo.height() / 2,
                     text=f"C{c}: {free_percent:.0f}%",
+                    fill=TEXT_COLOR,
                     tags="stats",
                 )
 

--- a/tests/test_magazyn_label_colors.py
+++ b/tests/test_magazyn_label_colors.py
@@ -1,0 +1,100 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+from pathlib import Path
+
+# Dummy widgets to simulate customtkinter components
+class _Widget:
+    def pack(self, *a, **k):
+        return self
+
+    def grid(self, *a, **k):
+        return self
+
+    def destroy(self):
+        pass
+
+
+class DummyCTkFrame(_Widget):
+    def __init__(self, master=None, fg_color=None, **kwargs):
+        self.master = master
+        self.fg_color = fg_color
+
+
+class DummyCTkLabel(_Widget):
+    def __init__(self, master=None, text="", fg_color=None, text_color=None, **kwargs):
+        self.master = master
+        self.text = text
+        self.fg_color = fg_color
+        self.text_color = text_color
+
+
+class DummyCTkButton(_Widget):
+    def __init__(self, master=None, **kwargs):
+        self.master = master
+        self.kwargs = kwargs
+
+
+class DummyCanvas(_Widget):
+    def __init__(self, master=None, width=0, height=0, highlightthickness=0):
+        self.master = master
+        self.width_val = width
+        self.height_val = height
+        self.bg = None
+
+    def config(self, **kwargs):
+        if "bg" in kwargs:
+            self.bg = kwargs["bg"]
+
+    def create_image(self, *a, **k):
+        pass
+
+    def create_rectangle(self, *a, **k):
+        pass
+
+    def create_text(self, *a, **k):
+        pass
+
+    def delete(self, *a, **k):
+        pass
+
+    def width(self):
+        return self.width_val
+
+    def height(self):
+        return self.height_val
+
+def test_magazyn_label_colors():
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
+
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
+         patch.object(ui.tk, "Canvas", DummyCanvas):
+        dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        app = SimpleNamespace(
+            root=dummy_root,
+            start_frame=None,
+            pricing_frame=None,
+            shoper_frame=None,
+            frame=None,
+            magazyn_frame=None,
+            location_frame=None,
+            create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+            refresh_magazyn=lambda: None,
+            back_to_welcome=lambda: None,
+        )
+
+        ui.CardEditorApp.open_magazyn_window(app)
+
+    label = app.mag_labels[0]
+    assert label.fg_color == ui.BG_COLOR
+    assert label.text_color == ui.TEXT_COLOR


### PR DESCRIPTION
## Summary
- Switch magazyn view to CTkFrame and CTkLabel, applying BG_COLOR and TEXT_COLOR
- Apply BG_COLOR to canvas backgrounds and TEXT_COLOR to text overlays
- Add test verifying magazyn label inherits proper colors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c5c6f86bc832fa35ebfa4a58fcb2e