### PR TITLE
Add warehouse card list and detail view

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2516,6 +2516,44 @@ class CardEditorApp:
             self.mag_canvases.append(canvas)
             self.mag_labels.append(lbl)
 
+        # List of cards currently in the warehouse
+        self.mag_card_images = []
+        self.mag_card_rows = []
+        self.mag_card_labels = []
+        list_frame = ctk.CTkScrollableFrame(self.magazyn_frame, fg_color=BG_COLOR)
+        list_frame.pack(expand=True, fill="both", padx=10, pady=10)
+
+        csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
+        if os.path.exists(csv_path):
+            with open(csv_path, encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter=";")
+                for row in reader:
+                    self.mag_card_rows.append(row)
+                    img_path = row.get("image") or ""
+                    photo = None
+                    if img_path and os.path.exists(img_path):
+                        try:
+                            img = Image.open(img_path)
+                            img.thumbnail((64, 64))
+                            photo = ImageTk.PhotoImage(img)
+                        except Exception:
+                            photo = None
+                    self.mag_card_images.append(photo)
+                    label = ctk.CTkLabel(
+                        list_frame,
+                        image=photo,
+                        text=row.get("name", ""),
+                        compound="left",
+                        anchor="w",
+                    )
+                    label.pack(fill="x", padx=5, pady=2)
+                    label.bind("<Button-1>", lambda e, r=row: self.show_card_details(r))
+                    label.bind(
+                        "<Double-Button-1>",
+                        lambda e, r=row: self.show_card_details(r),
+                    )
+                    self.mag_card_labels.append(label)
+
         btn_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
         btn_frame.pack(pady=5)
 
@@ -2596,6 +2634,37 @@ class CardEditorApp:
                     fill=TEXT_COLOR,
                     tags="stats",
                 )
+
+    def show_card_details(self, row: dict):
+        """Display details for a selected warehouse card."""
+
+        top = ctk.CTkToplevel(self.root)
+        top.title(row.get("name", "Card"))
+
+        img_path = row.get("image") or ""
+        if img_path and os.path.exists(img_path):
+            try:
+                img = Image.open(img_path)
+            except Exception:
+                img = Image.new("RGB", (300, 300), "#111111")
+        else:
+            img = Image.new("RGB", (300, 300), "#111111")
+        img.thumbnail((300, 300))
+        photo = ImageTk.PhotoImage(img)
+        img_lbl = ctk.CTkLabel(top, image=photo, text="")
+        img_lbl.image = photo  # keep reference
+        img_lbl.pack(pady=10)
+
+        fields = [
+            ("name", "Name"),
+            ("number", "Number"),
+            ("set", "Set"),
+            ("price", "Price"),
+            ("warehouse_code", "Warehouse Code"),
+        ]
+        for key, label in fields:
+            val = row.get(key, "")
+            ctk.CTkLabel(top, text=f"{label}: {val}").pack(anchor="w")
 
     def setup_pricing_ui(self):
         """UI for quick card price lookup."""

--- a/tests/test_magazyn_show_card_details.py
+++ b/tests/test_magazyn_show_card_details.py
@@ -3,6 +3,8 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import patch
 from pathlib import Path
+import csv
+from PIL import Image
 
 # Dummy widgets to simulate customtkinter components
 class _Widget:
@@ -23,11 +25,14 @@ class DummyCTkFrame(_Widget):
 
 
 class DummyCTkLabel(_Widget):
-    def __init__(self, master=None, text="", fg_color=None, text_color=None, **kwargs):
+    def __init__(self, master=None, text="", image=None, fg_color=None, text_color=None, compound=None, anchor=None, **kwargs):
         self.master = master
         self.text = text
+        self.image = image
         self.fg_color = fg_color
         self.text_color = text_color
+        self.compound = compound
+        self.anchor = anchor
         self._bindings = {}
 
     def bind(self, event, callback):
@@ -76,7 +81,30 @@ class DummyCanvas(_Widget):
     def height(self):
         return self.height_val
 
-def test_magazyn_label_colors():
+
+def test_show_card_details_receives_row(tmp_path):
+    # Prepare CSV and image
+    img_path = tmp_path / "card.png"
+    Image.new("RGB", (10, 10), "white").save(img_path)
+    csv_path = tmp_path / "magazyn.csv"
+    with open(csv_path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["name", "number", "set", "warehouse_code", "price", "image"],
+            delimiter=";",
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "name": "Test Card",
+                "number": "001",
+                "set": "Base",
+                "warehouse_code": "K1R1P1",
+                "price": "9.99",
+                "image": str(img_path),
+            }
+        )
+
     sys.modules["customtkinter"] = SimpleNamespace(
         CTkFrame=DummyCTkFrame,
         CTkLabel=DummyCTkLabel,
@@ -90,8 +118,14 @@ def test_magazyn_label_colors():
     photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
 
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
-         patch.object(ui.tk, "Canvas", DummyCanvas):
+         patch.object(ui.tk, "Canvas", DummyCanvas), \
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
         dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        captured = {}
+
+        def fake_show(row):
+            captured["row"] = row
+
         app = SimpleNamespace(
             root=dummy_root,
             start_frame=None,
@@ -103,10 +137,12 @@ def test_magazyn_label_colors():
             create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
             refresh_magazyn=lambda: None,
             back_to_welcome=lambda: None,
+            show_card_details=fake_show,
         )
 
         ui.CardEditorApp.open_magazyn_window(app)
+        label = app.mag_card_labels[0]
+        label._bindings["<Button-1>"](None)
 
-    label = app.mag_labels[0]
-    assert label.fg_color == ui.BG_COLOR
-    assert label.text_color == ui.TEXT_COLOR
+    assert captured["row"]["name"] == "Test Card"
+    assert captured["row"]["warehouse_code"] == "K1R1P1"


### PR DESCRIPTION
## Summary
- load `magazyn.csv` entries in a scrollable list with thumbnails and click handlers
- provide `show_card_details` popup with large image and card metadata
- add tests for card selection callback and adjust existing widgets stubs

## Testing
- `pytest tests/test_magazyn_label_colors.py tests/test_magazyn_show_card_details.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c5fc2b2ec832fbe9ed97e8672ee1d