### PR TITLE
Handle missing inventory labels safely

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -1,7 +1,7 @@
 import os
 import re
 import csv
-from tkinter import filedialog, messagebox
+from tkinter import filedialog, messagebox, TclError
 from ftp_client import FTPClient
 
 FTP_HOST = os.getenv("FTP_HOST")
@@ -260,7 +260,10 @@ def append_warehouse_csv(app, path: str = WAREHOUSE_CSV):
             writer.writerow(format_warehouse_row(row))
 
     if hasattr(app, "update_inventory_stats"):
-        app.update_inventory_stats()
+        try:
+            app.update_inventory_stats()
+        except TclError:
+            pass
 
 
 def send_csv_to_shoper(app, file_path: str):

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1334,14 +1334,17 @@ class CardEditorApp:
     def update_inventory_stats(self):
         """Refresh labels showing total item count and value."""
         count, total = csv_utils.get_inventory_stats()
-        if getattr(self, "inventory_count_label", None):
-            self.inventory_count_label.configure(
-                text=f"Łączna liczba kart: {count}"
-            )
-        if getattr(self, "inventory_value_label", None):
-            self.inventory_value_label.configure(
-                text=f"Łączna wartość: {total:.2f} PLN"
-            )
+        for attr, text in [
+            ("inventory_count_label", f"Łączna liczba kart: {count}"),
+            ("inventory_value_label", f"Łączna wartość: {total:.2f} PLN"),
+        ]:
+            widget = getattr(self, attr, None)
+            if widget:
+                try:
+                    if widget.winfo_exists():
+                        widget.configure(text=text)
+                except tk.TclError:
+                    pass
 
     def placeholder_btn(self, text: str, master=None):
         if master is None:


### PR DESCRIPTION
## Summary
- avoid TclError when updating inventory count/value labels by verifying widget existence
- guard CSV warehouse appending from errors if window is closed

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c6b4d496c832f9b813ee246f8fbbc