### PR TITLE
Cache remote card images for thumbnails and details

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -86,6 +86,61 @@ except ValueError:
 
 _LOGO_HASHES: dict[str, tuple[imagehash.ImageHash, imagehash.ImageHash, imagehash.ImageHash]] = {}
 
+# simple cache for downloaded remote images
+_IMAGE_CACHE: dict[str, Optional[bytes]] = {}
+
+
+def _load_image(path: str) -> Optional[Image.Image]:
+    """Load image from local path or URL with caching.
+
+    Parameters
+    ----------
+    path:
+        Local filesystem path or HTTP(S) URL.
+
+    Returns
+    -------
+    Optional[Image.Image]
+        Loaded PIL Image or ``None`` on failure.
+    """
+
+    if not path:
+        return None
+
+    if os.path.exists(path):
+        try:
+            return Image.open(path)
+        except Exception as exc:  # pragma: no cover - unlikely
+            logger.warning("Failed to open image %s: %s", path, exc)
+            return None
+
+    parsed = urlparse(path)
+    if parsed.scheme in ("http", "https"):
+        cached = _IMAGE_CACHE.get(path, ...)
+        if cached is not ...:
+            if cached is None:
+                return None
+            try:
+                img = Image.open(io.BytesIO(cached))
+                img.load()
+                return img
+            except Exception:
+                return None
+        try:
+            resp = requests.get(path, timeout=5)
+            resp.raise_for_status()
+            data = resp.content
+            _IMAGE_CACHE[path] = data
+            img = Image.open(io.BytesIO(data))
+            img.load()
+            return img
+        except Exception as exc:
+            logger.warning("Failed to download image %s: %s", path, exc)
+            _IMAGE_CACHE[path] = None
+            return None
+
+    return None
+
 
 def _create_image(img: Image.Image):
     """Return a CTkImage if available, otherwise a PhotoImage."""
@@ -2292,14 +2347,12 @@ class CardEditorApp:
                 for row in reader:
                     self.mag_card_rows.append(row)
                     img_path = row.get("image") or ""
-                    photo = None
-                    if img_path and os.path.exists(img_path):
-                        try:
-                            img = Image.open(img_path)
-                            img.thumbnail((64, 64))
-                            photo = _create_image(img)
-                        except Exception:
-                            photo = None
+                    img = _load_image(img_path)
+                    if img is not None:
+                        img.thumbnail((64, 64))
+                    else:
+                        img = Image.new("RGB", (64, 64), "#111111")
+                    photo = _create_image(img)
                     self.mag_card_images.append(photo)
                     label = ctk.CTkLabel(
                         list_frame,
@@ -2415,12 +2468,8 @@ class CardEditorApp:
         top.title(row.get("name", "Card"))
 
         img_path = row.get("image") or ""
-        if img_path and os.path.exists(img_path):
-            try:
-                img = Image.open(img_path)
-            except Exception:
-                img = Image.new("RGB", (300, 300), "#111111")
-        else:
+        img = _load_image(img_path)
+        if img is None:
             img = Image.new("RGB", (300, 300), "#111111")
         img.thumbnail((300, 300))
         photo = _create_image(img)

--- a/tests/test_remote_image_loading.py
+++ b/tests/test_remote_image_loading.py
@@ -1,0 +1,212 @@
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+from pathlib import Path
+import csv
+import io
+from PIL import Image
+
+
+# Dummy widgets to simulate customtkinter components
+class _Widget:
+    def pack(self, *a, **k):
+        return self
+
+    def grid(self, *a, **k):
+        return self
+
+    def destroy(self):
+        pass
+
+
+class DummyCTkFrame(_Widget):
+    def __init__(self, master=None, fg_color=None, **kwargs):
+        self.master = master
+        self.fg_color = fg_color
+
+
+class DummyCTkLabel(_Widget):
+    def __init__(self, master=None, text="", image=None, fg_color=None, text_color=None, compound=None, anchor=None, **kwargs):
+        self.master = master
+        self.text = text
+        self.image = image
+        self.fg_color = fg_color
+        self.text_color = text_color
+        self.compound = compound
+        self.anchor = anchor
+
+    def bind(self, event, callback):
+        return self
+
+
+class DummyCTkButton(_Widget):
+    def __init__(self, master=None, **kwargs):
+        self.master = master
+        self.kwargs = kwargs
+
+
+class DummyCTkScrollableFrame(_Widget):
+    def __init__(self, master=None, fg_color=None, **kwargs):
+        self.master = master
+        self.fg_color = fg_color
+
+
+class DummyCTkToplevel(_Widget):
+    def __init__(self, master=None):
+        self.master = master
+        self.children = []
+
+    def title(self, *a, **k):
+        return self
+
+
+class DummyCanvas(_Widget):
+    def __init__(self, master=None, width=0, height=0, highlightthickness=0):
+        self.master = master
+        self.width_val = width
+        self.height_val = height
+        self.bg = None
+
+    def config(self, **kwargs):
+        if "bg" in kwargs:
+            self.bg = kwargs["bg"]
+
+    def create_image(self, *a, **k):
+        pass
+
+    def create_rectangle(self, *a, **k):
+        pass
+
+    def create_text(self, *a, **k):
+        pass
+
+    def delete(self, *a, **k):
+        pass
+
+    def width(self):
+        return self.width_val
+
+    def height(self):
+        return self.height_val
+
+
+def _setup_module(tmp_path):
+    """Import ``ui`` module with dummy customtkinter widgets."""
+
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+        CTkScrollableFrame=DummyCTkScrollableFrame,
+        CTkToplevel=DummyCTkToplevel,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+    return ui
+
+
+def _write_csv(path, image_url):
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["name", "number", "set", "warehouse_code", "price", "image"],
+            delimiter=";",
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "name": "Remote Card",
+                "number": "001",
+                "set": "Base",
+                "warehouse_code": "K1R1P1",
+                "price": "9.99",
+                "image": image_url,
+            }
+        )
+
+
+def test_open_magazyn_window_remote_thumbnail(tmp_path):
+    ui = _setup_module(tmp_path)
+
+    url = "https://example.com/card.png"
+    csv_path = tmp_path / "magazyn.csv"
+    _write_csv(csv_path, url)
+
+    img_bytes = io.BytesIO()
+    Image.new("RGB", (10, 10), "white").save(img_bytes, format="PNG")
+    img_bytes = img_bytes.getvalue()
+
+    photo_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
+
+    dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+
+    app = SimpleNamespace(
+        root=dummy_root,
+        start_frame=None,
+        pricing_frame=None,
+        shoper_frame=None,
+        frame=None,
+        magazyn_frame=None,
+        location_frame=None,
+        create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+        refresh_magazyn=lambda: None,
+        back_to_welcome=lambda: None,
+        show_card_details=lambda *a, **k: None,
+    )
+
+    resp = SimpleNamespace(content=img_bytes, raise_for_status=lambda: None)
+
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
+         patch.object(ui.tk, "Canvas", DummyCanvas), \
+         patch.object(ui.requests, "get", return_value=resp) as mock_get, \
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
+        ui.CardEditorApp.open_magazyn_window(app)
+
+    assert mock_get.called
+    assert app.mag_card_images[0] is photo_mock
+
+
+def test_show_card_details_remote_uses_cache(tmp_path):
+    ui = _setup_module(tmp_path)
+
+    url = "https://example.com/card.png"
+    csv_path = tmp_path / "magazyn.csv"
+    _write_csv(csv_path, url)
+
+    img_bytes = io.BytesIO()
+    Image.new("RGB", (20, 20), "white").save(img_bytes, format="PNG")
+    img_bytes = img_bytes.getvalue()
+
+    photo_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
+
+    dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+
+    app = SimpleNamespace(
+        root=dummy_root,
+        start_frame=None,
+        pricing_frame=None,
+        shoper_frame=None,
+        frame=None,
+        magazyn_frame=None,
+        location_frame=None,
+        create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+        refresh_magazyn=lambda: None,
+        back_to_welcome=lambda: None,
+    )
+
+    resp = SimpleNamespace(content=img_bytes, raise_for_status=lambda: None)
+
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
+         patch.object(ui.tk, "Canvas", DummyCanvas), \
+         patch.object(ui.requests, "get", return_value=resp) as mock_get, \
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
+        # first load thumbnails
+        ui.CardEditorApp.open_magazyn_window(app)
+        # then show details which should reuse cache and not trigger new request
+        ui.CardEditorApp.show_card_details(app, app.mag_card_rows[0])
+
+    # only one HTTP request despite two image loads
+    assert mock_get.call_count == 1
+


### PR DESCRIPTION
## Summary
- cache downloaded images and load them from URLs when building the magazyn list
- allow `show_card_details` to fetch remote images when local files are missing
- cover remote thumbnail and detail handling with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c730f5a8c832face4a9f4b0aeca78