### PR TITLE
Persist HashDB entries and avoid duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ persistent storage. The file is created automatically if it does not exist.
 When it is not provided the fingerprint database is disabled and no duplicate
 detection is performed.
 
+During a scan the application initialises :class:`HashDB` with this file so
+fingerprints are written to disk rather than a transient in-memory database.  A
+new entry is stored via ``add_card_from_fp`` for every card that is processed
+and the information is reused on subsequent scans to recognise cards
+automatically. Identical fingerprints are ignored, preventing accidental
+duplicate rows.
+
 ### Dependencies
 
 Fingerprinting relies on [`numpy`](https://numpy.org), [`Pillow`](https://python-pillow.org) and
@@ -110,8 +117,8 @@ HASH_DB_FILE=hashes.sqlite
 ```
 
 - `OPENAI_API_KEY` – API key used by OpenAI Vision to extract card details from scans.
-- `HASH_DB_FILE` – path to a SQLite file used for fingerprint storage. When
-  unset duplicate detection is disabled.
+- `HASH_DB_FILE` – path to a writable SQLite file used for fingerprint storage.
+  The application stores fingerprints in this file on each scan and reuses it across sessions for automatic card recognition. When unset duplicate detection is disabled.
 
 **Warning:** This file may contain private API keys and tokens. It is excluded
 from version control via `.gitignore` and should never be shared publicly.

--- a/hash_db.py
+++ b/hash_db.py
@@ -104,6 +104,13 @@ class HashDB:
             )
             """
         )
+        # prevent storing duplicate fingerprints
+        cur.execute(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_hashes
+            ON cards (phash, dhash, tile_phash, orb)
+            """
+        )
         self.conn.commit()
 
     # ------------------------------------------------------------------
@@ -163,12 +170,32 @@ class HashDB:
 
         phash, dhash, tile_phash, orb = self._serialise_fp(fp)
         cur = self.conn.cursor()
+        # return existing row id if the fingerprint is already stored
         cur.execute(
-            "INSERT INTO cards (phash, dhash, tile_phash, orb, meta) VALUES (?, ?, ?, ?, ?)",
-            (phash, dhash, tile_phash, orb, json.dumps(meta_dict, ensure_ascii=False)),
+            "SELECT id FROM cards WHERE phash=? AND dhash=? AND tile_phash=? AND orb=?",
+            (phash, dhash, tile_phash, orb),
         )
-        self.conn.commit()
-        return int(cur.lastrowid)
+        row = cur.fetchone()
+        if row is not None:
+            return int(row["id"])
+
+        try:
+            cur.execute(
+                "INSERT INTO cards (phash, dhash, tile_phash, orb, meta) VALUES (?, ?, ?, ?, ?)",
+                (phash, dhash, tile_phash, orb, json.dumps(meta_dict, ensure_ascii=False)),
+            )
+            self.conn.commit()
+            return int(cur.lastrowid)
+        except sqlite3.IntegrityError:
+            # another process might have inserted the same fingerprint concurrently
+            cur.execute(
+                "SELECT id FROM cards WHERE phash=? AND dhash=? AND tile_phash=? AND orb=?",
+                (phash, dhash, tile_phash, orb),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise
+            return int(row["id"])
 
     # ------------------------------------------------------------------
     # query helpers

--- a/tests/test_hash_db_integration.py
+++ b/tests/test_hash_db_integration.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+from PIL import Image, ImageDraw
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from hash_db import HashDB
+
+
+def _create_sample_image(path: Path) -> None:
+    img = Image.new("RGB", (64, 64), "white")
+    draw = ImageDraw.Draw(img)
+    draw.rectangle([16, 16, 48, 48], fill="black")
+    img.save(path)
+
+
+def test_scan_rescan_persists_and_deduplicates(tmp_path):
+    db_path = tmp_path / "hashes.sqlite"
+    img_path = tmp_path / "sample.png"
+    _create_sample_image(img_path)
+
+    db = HashDB(str(db_path))
+    first_id = db.add_card_from_image(str(img_path), meta={"name": "sample"})
+    db.conn.close()
+
+    db2 = HashDB(str(db_path))
+    candidate = db2.best_match(str(img_path))
+    assert candidate is not None
+    assert candidate.meta["name"] == "sample"
+
+    duplicate_id = db2.add_card_from_image(str(img_path), meta={"name": "sample"})
+    assert duplicate_id == first_id
+
+    cur = db2.conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM cards")
+    assert cur.fetchone()[0] == 1


### PR DESCRIPTION
## Summary
- ensure `HashDB` creates a unique index and skips inserting duplicate fingerprints
- document `HASH_DB_FILE` usage and automatic card recognition
- add integration test covering persistent matching and duplicate protection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c74d4c954832fbd820ffe8bef6f7e