### PR TITLE
Add support for special box 100

### DIFF
--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -47,10 +47,26 @@ def location_from_code(code: str) -> str:
 
 
 def generate_location(idx):
-    pos = idx % 1000 + 1
-    column = (idx // 1000) % 4 + 1
-    box = (idx // 4000) + 1
-    return f"K{box:02d}R{column}P{pos:04d}"
+    """Return a warehouse code for a sequential slot index.
+
+    The first 32 000 indices map to boxes 1-8 (four 1000-card columns each).
+    Subsequent indices map to the special box 100 which has a single
+    500-card column.
+    """
+
+    if idx < 8 * 4000:
+        pos = idx % 1000 + 1
+        column = (idx // 1000) % 4 + 1
+        box = (idx // 4000) + 1
+        return f"K{box:02d}R{column}P{pos:04d}"
+
+    idx -= 8 * 4000
+    if idx < 500:
+        # box 100, only one column
+        pos = idx + 1
+        return f"K100R1P{pos:04d}"
+
+    raise ValueError("Index out of range for known storage boxes")
 
 
 def next_free_location(app):
@@ -66,7 +82,10 @@ def next_free_location(app):
             box = int(match.group(1))
             column = int(match.group(2))
             pos = int(match.group(3))
-            idx = (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
+            if box == 100:
+                idx = 8 * 4000 + (pos - 1)
+            else:
+                idx = (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
             used.add(idx)
 
     idx = getattr(app, "starting_idx", 0)
@@ -76,7 +95,15 @@ def next_free_location(app):
 
 
 def compute_column_occupancy():
+    """Return count of used slots per box column.
+
+    Boxes 1-8 have four 1000-card columns.  Box 100 is a special
+    short box with a single 500-card column divided into five 100-card
+    segments.
+    """
+
     occ = {b: {c: 0 for c in range(1, 5)} for b in range(1, 9)}
+    occ[100] = {1: 0}
     try:
         with open(csv_utils.INVENTORY_CSV, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f, delimiter=";")

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2299,7 +2299,8 @@ class CardEditorApp:
         # Order boxes so that the grid layout is:
         # row0 -> K1 K2 K5 K6
         # row1 -> K3 K4 K7 K8
-        self.mag_box_order = [1, 2, 5, 6, 3, 4, 7, 8]
+        # row2 -> K100
+        self.mag_box_order = [1, 2, 5, 6, 3, 4, 7, 8, 100]
         self.mag_canvases = []
         self.mag_labels = []
         for i, box_num in enumerate(self.mag_box_order):
@@ -2423,11 +2424,19 @@ class CardEditorApp:
             else:
                 box_w, box_h = self.mag_box_photo.width(), self.mag_box_photo.height()
                 photo = self.mag_box_photo
-            col_w = box_w / 4
+
+            if box == 100:
+                capacity = 500
+                columns = 1
+            else:
+                capacity = 1000
+                columns = 4
+
+            col_w = box_w / columns
             canvas.create_image(0, 0, image=photo, anchor="nw")
-            for c in range(1, 5):
+            for c in range(1, columns + 1):
                 filled = occ.get(box, {}).get(c, 0)
-                free_percent = (1000 - filled) / 10
+                free_percent = (capacity - filled) / capacity * 100
                 x1 = (c - 1) * col_w
                 x_mid = x1 + col_w / 2
                 if free_percent >= 30:
@@ -2442,8 +2451,9 @@ class CardEditorApp:
                     )
                 # Draw 100-card sections
                 filled_sections = filled // 100
-                seg_h = box_h / 10
-                for i in range(10):
+                seg_count = capacity // 100
+                seg_h = box_h / seg_count
+                for i in range(seg_count):
                     y1 = box_h - seg_h * (i + 1)
                     y2 = box_h - seg_h * i
                     color = "#c8f7c8" if i < filled_sections else ""

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+
+
+def test_compute_column_occupancy_box100(tmp_path, monkeypatch):
+    from kartoteka import csv_utils, storage
+
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text("name;warehouse_code\nA;K100R1P0001\n", encoding="utf-8")
+    monkeypatch.setattr(csv_utils, "INVENTORY_CSV", str(csv_path))
+    occ = storage.compute_column_occupancy()
+    assert occ[100][1] == 1
+
+
+def test_generate_and_next_free_location_box100():
+    from kartoteka import storage
+
+    idx = 8 * 4000
+    assert storage.generate_location(idx) == "K100R1P0001"
+
+    app = SimpleNamespace(output_data=[{"warehouse_code": "K100R1P0001"}], starting_idx=idx)
+    assert storage.next_free_location(app) == "K100R1P0002"


### PR DESCRIPTION
## Summary
- include new Box 100 in warehouse grid with 500-card capacity display
- account for Box 100 in column occupancy calculations and location generation
- test coverage for Box 100 occupancy and location helpers

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c7d134a94832f8ad94f7e13740aff