### PR TITLE
Track sold cards in warehouse

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -33,7 +33,16 @@ STORE_FIELDNAMES = [
     "images 1",
 ]
 
-WAREHOUSE_FIELDNAMES = ["name", "number", "set", "warehouse_code", "price", "image"]
+# include a ``sold`` flag so individual cards can be marked as sold
+WAREHOUSE_FIELDNAMES = [
+    "name",
+    "number",
+    "set",
+    "warehouse_code",
+    "price",
+    "image",
+    "sold",
+]
 
 
 def get_inventory_stats(path: str = WAREHOUSE_CSV):
@@ -58,6 +67,9 @@ def get_inventory_stats(path: str = WAREHOUSE_CSV):
     with open(path, encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         for row in reader:
+            # Skip rows marked as sold
+            if str(row.get("sold") or "").lower() in {"1", "true", "yes"}:
+                continue
             count += 1
             price_raw = str(row.get("price") or "0").replace(",", ".")
             try:
@@ -102,6 +114,7 @@ def format_warehouse_row(row):
         "warehouse_code": row.get("warehouse_code", ""),
         "price": row.get("cena") or row.get("price", ""),
         "image": row.get("image1", row.get("images", "")),
+        "sold": row.get("sold", ""),
     }
 
 

--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -108,6 +108,9 @@ def compute_column_occupancy():
         with open(csv_utils.INVENTORY_CSV, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f, delimiter=";")
             for row in reader:
+                # Skip sold cards when calculating occupancy
+                if str(row.get("sold") or "").lower() in {"1", "true", "yes"}:
+                    continue
                 codes = str(row.get("warehouse_code") or "").split(";")
                 for code in codes:
                     code = code.strip()

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2337,17 +2337,21 @@ class CardEditorApp:
         # List of cards currently in the warehouse
         self.mag_card_images = []
         self.mag_card_rows = []
+        # unsold card labels
         self.mag_card_labels = []
+        # sold card labels for separate styling/testing
+        self.mag_sold_labels = []
         list_frame = ctk.CTkScrollableFrame(self.magazyn_frame, fg_color=BG_COLOR)
         list_frame.pack(expand=True, fill="both", padx=10, pady=10)
 
         csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
         if os.path.exists(csv_path):
+            unsold = []
+            sold = []
             with open(csv_path, encoding="utf-8") as f:
                 reader = csv.DictReader(f, delimiter=";")
                 thumb_size = int(64 * 1.3)
-                N = 4
-                for i, row in enumerate(reader):
+                for row in reader:
                     self.mag_card_rows.append(row)
                     img_path = row.get("image") or ""
                     img = _load_image(img_path)
@@ -2357,21 +2361,39 @@ class CardEditorApp:
                         img = Image.new("RGB", (thumb_size, thumb_size), "#111111")
                     photo = _create_image(img)
                     self.mag_card_images.append(photo)
-                    frame = ctk.CTkFrame(list_frame, fg_color=BG_COLOR)
-                    label = ctk.CTkLabel(
-                        frame,
-                        image=photo,
-                        text=row.get("name", ""),
-                        compound="top",
-                        text_color=TEXT_COLOR,
-                    )
-                    label.pack()
-                    frame.grid(row=i // N, column=i % N, padx=5, pady=5)
-                    label.bind("<Button-1>", lambda e, r=row: self.show_card_details(r))
-                    label.bind(
-                        "<Double-Button-1>",
-                        lambda e, r=row: self.show_card_details(r),
-                    )
+                    if str(row.get("sold") or "").lower() in {"1", "true", "yes"}:
+                        sold.append((row, photo))
+                    else:
+                        unsold.append((row, photo))
+
+            N = 4
+            # display unsold first, then sold
+            combined = unsold + sold
+            for i, (row, photo) in enumerate(combined):
+                frame = ctk.CTkFrame(list_frame, fg_color=BG_COLOR)
+                is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
+                text = row.get("name", "")
+                color = TEXT_COLOR
+                if is_sold:
+                    text = f"[SOLD] {text}"
+                    color = "#888888"
+                label = ctk.CTkLabel(
+                    frame,
+                    image=photo,
+                    text=text,
+                    compound="top",
+                    text_color=color,
+                )
+                label.pack()
+                frame.grid(row=i // N, column=i % N, padx=5, pady=5)
+                label.bind("<Button-1>", lambda e, r=row: self.show_card_details(r))
+                label.bind(
+                    "<Double-Button-1>",
+                    lambda e, r=row: self.show_card_details(r),
+                )
+                if is_sold:
+                    self.mag_sold_labels.append(label)
+                else:
                     self.mag_card_labels.append(label)
 
         btn_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
@@ -2517,6 +2539,52 @@ class CardEditorApp:
                 text=f"{label}: {val}",
                 font=("Inter", 16),
             ).grid(row=i, column=0, sticky="w", pady=2)
+
+        # Button to toggle sold status
+        is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
+        btn_text = "Mark as available" if is_sold else "Mark as sold"
+        toggle = lambda: self.toggle_sold(row, top)
+        ctk.CTkButton(right, text=btn_text, command=toggle).grid(
+            row=len(fields), column=0, pady=10, sticky="w"
+        )
+
+    def toggle_sold(self, row: dict, window=None):
+        """Toggle the sold flag for a warehouse card and update CSV."""
+
+        csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
+        try:
+            with open(csv_path, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter=";")
+                rows = list(reader)
+                fieldnames = reader.fieldnames or []
+        except FileNotFoundError:
+            return
+
+        if "sold" not in fieldnames:
+            fieldnames.append("sold")
+
+        target = str(row.get("warehouse_code", ""))
+        for r in rows:
+            if r.get("warehouse_code") == target:
+                current = str(r.get("sold") or "").lower() in {"1", "true", "yes"}
+                r["sold"] = "" if current else "1"
+                row["sold"] = r["sold"]
+                break
+
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+            writer.writeheader()
+            writer.writerows(rows)
+
+        if window is not None:
+            try:
+                window.destroy()
+            except Exception:
+                pass
+
+        # Refresh main view to reflect the change
+        if hasattr(self, "open_magazyn_window"):
+            self.open_magazyn_window()
 
     def setup_pricing_ui(self):
         """UI for quick card price lookup."""

--- a/tests/test_column_occupancy.py
+++ b/tests/test_column_occupancy.py
@@ -21,3 +21,19 @@ def test_split_codes_counted(tmp_path, monkeypatch):
     dummy = SimpleNamespace()
     occ = ui.CardEditorApp.compute_column_occupancy(dummy)
     assert occ[1][1] == 2
+
+
+def test_sold_cards_excluded_from_occupancy(tmp_path, monkeypatch):
+    from kartoteka import csv_utils
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;warehouse_code;sold\nA;K1R1P1;\nB;K1R1P2;1\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(csv_utils, "INVENTORY_CSV", str(csv_path))
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(csv_path))
+    import kartoteka.ui as ui
+    import importlib
+    importlib.reload(ui)
+    dummy = SimpleNamespace()
+    occ = ui.CardEditorApp.compute_column_occupancy(dummy)
+    assert occ[1][1] == 1

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -92,5 +92,6 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
         assert row["warehouse_code"] == "K1R1P1"
         assert row["price"] == "10"
         assert row["image"] == "img.jpg"
+        assert row.get("sold", "") == ""
 
 

--- a/tests/test_inventory_stats.py
+++ b/tests/test_inventory_stats.py
@@ -16,3 +16,14 @@ def test_get_inventory_stats(tmp_path):
     count, total = csv_utils.get_inventory_stats(str(csv_path))
     assert count == 2
     assert total == pytest.approx(15.75)
+
+
+def test_inventory_stats_excludes_sold(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1;10;img1;\n" "B;2;S2;K2;5;img2;1\n",
+        encoding="utf-8",
+    )
+    count, total = csv_utils.get_inventory_stats(str(csv_path))
+    assert count == 1
+    assert total == pytest.approx(10)

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -1,0 +1,122 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+# Dummy widgets to simulate customtkinter components
+class _Widget:
+    def pack(self, *a, **k):
+        return self
+
+    def grid(self, *a, **k):
+        return self
+
+    def destroy(self):
+        pass
+
+
+class DummyCTkFrame(_Widget):
+    def __init__(self, master=None, fg_color=None, **kwargs):
+        self.master = master
+        self.fg_color = fg_color
+
+
+class DummyCTkLabel(_Widget):
+    def __init__(self, master=None, text="", image=None, fg_color=None, text_color=None, compound=None, **kwargs):
+        self.master = master
+        self.text = text
+        self.image = image
+        self.fg_color = fg_color
+        self.text_color = text_color
+        self.compound = compound
+        self._bindings = {}
+
+    def bind(self, event, callback):
+        self._bindings[event] = callback
+        return self
+
+
+class DummyCTkButton(_Widget):
+    def __init__(self, master=None, **kwargs):
+        self.master = master
+        self.kwargs = kwargs
+
+
+class DummyCTkScrollableFrame(_Widget):
+    def __init__(self, master=None, fg_color=None, **kwargs):
+        self.master = master
+        self.fg_color = fg_color
+
+
+class DummyCanvas(_Widget):
+    def __init__(self, master=None, width=0, height=0, highlightthickness=0):
+        self.master = master
+        self.width_val = width
+        self.height_val = height
+        self.bg = None
+
+    def config(self, **kwargs):
+        if "bg" in kwargs:
+            self.bg = kwargs["bg"]
+
+    def create_image(self, *a, **k):
+        pass
+
+    def create_rectangle(self, *a, **k):
+        pass
+
+    def create_text(self, *a, **k):
+        pass
+
+    def delete(self, *a, **k):
+        pass
+
+    def width(self):
+        return self.width_val
+
+    def height(self):
+        return self.height_val
+
+
+def test_sold_cards_styled(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;1;;\n" "B;2;S2;K1R1P2;1;;1\n",
+        encoding="utf-8",
+    )
+
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+        CTkScrollableFrame=DummyCTkScrollableFrame,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
+
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
+         patch.object(ui.tk, "Canvas", DummyCanvas), \
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
+        dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        app = SimpleNamespace(
+            root=dummy_root,
+            start_frame=None,
+            pricing_frame=None,
+            shoper_frame=None,
+            frame=None,
+            magazyn_frame=None,
+            location_frame=None,
+            create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+            refresh_magazyn=lambda: None,
+            back_to_welcome=lambda: None,
+        )
+
+        ui.CardEditorApp.open_magazyn_window(app)
+
+    assert len(app.mag_card_labels) == 1
+    assert len(app.mag_sold_labels) == 1
+    assert app.mag_sold_labels[0].text.startswith("[SOLD]")

--- a/tests/test_toggle_sold.py
+++ b/tests/test_toggle_sold.py
@@ -1,0 +1,34 @@
+import csv
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import kartoteka.ui as ui
+
+
+def test_toggle_sold_updates_csv(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;10;;\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
+    row = {"name": "A", "warehouse_code": "K1R1P1", "sold": ""}
+    app = SimpleNamespace(open_magazyn_window=lambda: None)
+
+    ui.CardEditorApp.toggle_sold(app, row)
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+        assert rows[0]["sold"] == "1"
+
+    ui.CardEditorApp.toggle_sold(app, row)
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+        assert rows[0]["sold"] == ""


### PR DESCRIPTION
## Summary
- Extend warehouse CSV schema with a new `sold` flag and ignore sold entries in inventory stats.
- Render sold cards distinctly in the warehouse view, provide a toggle to mark/unmark as sold, and refresh the UI.
- Exclude sold cards from column occupancy calculations and persist status changes to CSV.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c82ff425c832f8578d903ccf33778