### PR TITLE
test: verify box100 starting index

### DIFF
--- a/tests/test_next_free_location.py
+++ b/tests/test_next_free_location.py
@@ -41,6 +41,9 @@ def test_load_images_sets_start(monkeypatch, tmp_path):
     img.write_bytes(b"data")
 
     monkeypatch.setattr(ui.filedialog, "askdirectory", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        ui.filedialog, "asksaveasfilename", lambda **k: str(tmp_path / "session.csv")
+    )
 
     dummy = SimpleNamespace(
         start_frame=None,
@@ -59,4 +62,32 @@ def test_load_images_sets_start(monkeypatch, tmp_path):
     expected = (2 - 1) * 4000 + (1 - 1) * 1000 + (5 - 1)
     assert dummy.starting_idx == expected
     assert ui.CardEditorApp.next_free_location(dummy) == "K02R1P0005"
+
+
+def test_browse_scans_box100(monkeypatch, tmp_path):
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"data")
+
+    monkeypatch.setattr(ui.filedialog, "askdirectory", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        ui.filedialog, "asksaveasfilename", lambda **k: str(tmp_path / "session.csv")
+    )
+
+    dummy = SimpleNamespace(
+        start_frame=None,
+        setup_editor_ui=lambda: None,
+        progress_var=SimpleNamespace(set=lambda *a, **k: None),
+        log=lambda *a, **k: None,
+        show_card=lambda *a, **k: None,
+        start_box_var=SimpleNamespace(get=lambda: 100),
+        start_col_var=SimpleNamespace(get=lambda: 1),
+        start_pos_var=SimpleNamespace(get=lambda: 5),
+        scan_folder_var=SimpleNamespace(get=lambda: "", set=lambda v: None),
+    )
+
+    ui.CardEditorApp.browse_scans(dummy)
+
+    expected = 8 * 4000 + 4
+    assert dummy.starting_idx == expected
+    assert ui.CardEditorApp.next_free_location(dummy) == "K100R1P0005"
 


### PR DESCRIPTION
## Summary
- add regression test ensuring box 100 start values map to correct index and location

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c88f80760832fb29a332119f99d19