### PR TITLE
Add regression test for box 100 browse_scans indexing

### DIFF
--- a/tests/test_next_free_location.py
+++ b/tests/test_next_free_location.py
@@ -91,3 +91,30 @@ def test_browse_scans_box100(monkeypatch, tmp_path):
     assert dummy.starting_idx == expected
     assert ui.CardEditorApp.next_free_location(dummy) == "K100R1P0005"
 
+
+def test_browse_scans_sets_starting_idx_for_box100(monkeypatch, tmp_path):
+    img = tmp_path / "a.jpg"
+    img.write_bytes(b"data")
+
+    monkeypatch.setattr(ui.filedialog, "askdirectory", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        ui.filedialog, "asksaveasfilename", lambda **k: str(tmp_path / "session.csv")
+    )
+
+    dummy = SimpleNamespace(
+        start_frame=None,
+        setup_editor_ui=lambda: None,
+        progress_var=SimpleNamespace(set=lambda *a, **k: None),
+        log=lambda *a, **k: None,
+        show_card=lambda *a, **k: None,
+        start_box_var=SimpleNamespace(get=lambda: 100),
+        start_col_var=SimpleNamespace(get=lambda: 1),
+        start_pos_var=SimpleNamespace(get=lambda: 5),
+        scan_folder_var=SimpleNamespace(get=lambda: "", set=lambda v: None),
+    )
+
+    ui.CardEditorApp.browse_scans(dummy)
+
+    assert dummy.starting_idx == 8 * 4000 + 4
+    assert ui.CardEditorApp.next_free_location(dummy) == "K100R1P0005"
+


### PR DESCRIPTION
## Summary
- add a test ensuring browse_scans handles starting box 100 correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ccb735db0832f818d38a2f328b57f