### PR TITLE
Improve card detail window sizing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2532,6 +2532,10 @@ class CardEditorApp:
         # ensure enough space for side-by-side layout
         if hasattr(top, "geometry"):
             top.geometry("600x400")
+            try:
+                top.minsize(600, 400)
+            except Exception:
+                pass
 
         container = ctk.CTkFrame(top)
         container.pack(expand=True, fill="both", padx=10, pady=10)


### PR DESCRIPTION
## Summary
- ensure the card detail pop-up can't shrink below its intended 600x400 layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cce89980c832fb2d80dc9d28efefa