### PR TITLE
Add tests for warehouse box 100 and inventory stats view

### DIFF
--- a/tests/ctk_mocks.py
+++ b/tests/ctk_mocks.py
@@ -1,0 +1,89 @@
+class _Widget:
+    def pack(self, *a, **k):
+        return self
+
+    def grid(self, *a, **k):
+        return self
+
+    def destroy(self):
+        pass
+
+    def configure(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        return self
+
+    def winfo_exists(self):
+        return True
+
+
+class DummyCTkFrame(_Widget):
+    def __init__(self, master=None, fg_color=None, **kwargs):
+        self.master = master
+        self.fg_color = fg_color
+
+
+class DummyCTkLabel(_Widget):
+    def __init__(
+        self,
+        master=None,
+        text="",
+        image=None,
+        fg_color=None,
+        text_color=None,
+        compound=None,
+        **kwargs,
+    ):
+        self.master = master
+        self.text = text
+        self.image = image
+        self.fg_color = fg_color
+        self.text_color = text_color
+        self.compound = compound
+        self._bindings = {}
+
+    def bind(self, event, callback):
+        self._bindings[event] = callback
+        return self
+
+
+class DummyCTkButton(_Widget):
+    def __init__(self, master=None, **kwargs):
+        self.master = master
+        self.kwargs = kwargs
+
+
+class DummyCTkScrollableFrame(_Widget):
+    def __init__(self, master=None, fg_color=None, **kwargs):
+        self.master = master
+        self.fg_color = fg_color
+
+
+class DummyCanvas(_Widget):
+    def __init__(self, master=None, width=0, height=0, highlightthickness=0):
+        self.master = master
+        self.width_val = width
+        self.height_val = height
+        self.bg = None
+
+    def config(self, **kwargs):
+        if "bg" in kwargs:
+            self.bg = kwargs["bg"]
+
+    def create_image(self, *a, **k):
+        pass
+
+    def create_rectangle(self, *a, **k):
+        pass
+
+    def create_text(self, *a, **k):
+        pass
+
+    def delete(self, *a, **k):
+        pass
+
+    def width(self):
+        return self.width_val
+
+    def height(self):
+        return self.height_val

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -1,4 +1,18 @@
+import importlib
+import sys
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parent))
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from ctk_mocks import (  # noqa: E402
+    DummyCTkButton,
+    DummyCTkFrame,
+    DummyCTkLabel,
+    DummyCTkScrollableFrame,
+    DummyCanvas,
+)
 
 
 def test_compute_column_occupancy_box100(tmp_path, monkeypatch):
@@ -19,3 +33,44 @@ def test_generate_and_next_free_location_box100():
 
     app = SimpleNamespace(output_data=[{"warehouse_code": "K100R1P0001"}], starting_idx=idx)
     assert storage.next_free_location(app) == "K100R1P0002"
+
+
+def test_mag_box_order_contains_100(tmp_path, monkeypatch):
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+        CTkScrollableFrame=DummyCTkScrollableFrame,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text("name;warehouse_code\nA;K100R1P0001\n", encoding="utf-8")
+    monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
+    monkeypatch.setattr(ui.csv_utils, "INVENTORY_CSV", str(csv_path))
+
+    photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(
+        ui.tk, "Canvas", DummyCanvas
+    ):
+        dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        app = SimpleNamespace(
+            root=dummy_root,
+            start_frame=None,
+            pricing_frame=None,
+            shoper_frame=None,
+            frame=None,
+            magazyn_frame=None,
+            location_frame=None,
+            create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+            refresh_magazyn=lambda: None,
+            back_to_welcome=lambda: None,
+        )
+
+        ui.CardEditorApp.open_magazyn_window(app)
+
+    assert app.mag_box_order[-1] == 100
+    occ = ui.CardEditorApp.compute_column_occupancy(app)
+    assert occ[100][1] == 1

--- a/tests/test_magazyn_inventory_stats_view.py
+++ b/tests/test_magazyn_inventory_stats_view.py
@@ -14,12 +14,20 @@ from ctk_mocks import (  # noqa: E402
 )
 
 
-def test_sold_cards_styled(tmp_path):
+def test_inventory_stats_display_and_update(tmp_path, monkeypatch):
+    from kartoteka import csv_utils
+
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;1;;\n" "B;2;S2;K1R1P2;1;;1\n",
+        "name;warehouse_code;price;sold\n" "A;K1R1P1;1;\n",
         encoding="utf-8",
     )
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(csv_path))
+    monkeypatch.setattr(csv_utils, "INVENTORY_CSV", str(csv_path))
+
+    first_stats = (5, 123.45)
+    second_stats = (7, 210.0)
+    monkeypatch.setattr(csv_utils, "get_inventory_stats", lambda path=str(csv_path): first_stats)
 
     sys.modules["customtkinter"] = SimpleNamespace(
         CTkFrame=DummyCTkFrame,
@@ -32,10 +40,9 @@ def test_sold_cards_styled(tmp_path):
     importlib.reload(ui)
 
     photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
-
-    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
-         patch.object(ui.tk, "Canvas", DummyCanvas), \
-         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(
+        ui.tk, "Canvas", DummyCanvas
+    ):
         dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
         app = SimpleNamespace(
             root=dummy_root,
@@ -52,7 +59,16 @@ def test_sold_cards_styled(tmp_path):
 
         ui.CardEditorApp.open_magazyn_window(app)
 
-    assert len(app.mag_card_labels) == 1
-    assert len(app.mag_sold_labels) == 1
-    assert app.mag_sold_labels[0].text.startswith("[SOLD]")
-    assert app.mag_sold_labels[0].text_color == "#888888"
+    assert app.mag_inventory_count_label.text == f"Łączna liczba kart: {first_stats[0]}"
+    assert (
+        app.mag_inventory_value_label.text
+        == f"Łączna wartość: {first_stats[1]:.2f} PLN"
+    )
+
+    monkeypatch.setattr(ui.csv_utils, "get_inventory_stats", lambda path=str(csv_path): second_stats)
+    ui.CardEditorApp.update_inventory_stats(app)
+    assert app.mag_inventory_count_label.text == f"Łączna liczba kart: {second_stats[0]}"
+    assert (
+        app.mag_inventory_value_label.text
+        == f"Łączna wartość: {second_stats[1]:.2f} PLN"
+    )


### PR DESCRIPTION
## Summary
- introduce shared customtkinter mocks supporting `configure` and `winfo_exists`
- test styling of sold cards in magazyn view
- ensure warehouse box 100 appears in box order and occupancy calculations
- verify inventory statistics are shown and refreshed in magazyn view

## Testing
- `pytest tests/test_box100.py tests/test_magazyn_sold_display.py tests/test_magazyn_inventory_stats_view.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689cdbdd6408832f8a491019e39a3f57