### PR TITLE
Update inventory stats after warehouse mutations

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1409,6 +1409,8 @@ class CardEditorApp:
         count, total = csv_utils.get_inventory_stats()
         count_text = f"Łączna liczba kart: {count}"
         total_text = f"Łączna wartość: {total:.2f} PLN"
+        # Only attempt to update labels that actually exist to avoid
+        # attribute errors when the start screen has not been created yet.
         for attr, text in [
             ("inventory_count_label", count_text),
             ("mag_inventory_count_label", count_text),
@@ -1416,7 +1418,7 @@ class CardEditorApp:
             ("mag_inventory_value_label", total_text),
         ]:
             widget = getattr(self, attr, None)
-            if widget:
+            if widget and hasattr(widget, "winfo_exists"):
                 try:
                     if widget.winfo_exists():
                         widget.configure(text=text)
@@ -2662,6 +2664,13 @@ class CardEditorApp:
         if window is not None:
             try:
                 window.destroy()
+            except Exception:
+                pass
+
+        # Update inventory statistics after toggling the sold flag
+        if hasattr(self, "update_inventory_stats"):
+            try:
+                self.update_inventory_stats()
             except Exception:
                 pass
 
@@ -4699,6 +4708,11 @@ class CardEditorApp:
                     self.output_data.remove(row)
                 break
         self.repack_column(box, column)
+        if hasattr(self, "update_inventory_stats"):
+            try:
+                self.update_inventory_stats()
+            except Exception:
+                pass
 
     def load_csv_data(self):
         """Load a CSV file and merge duplicate rows."""

--- a/tests/test_append_warehouse_csv.py
+++ b/tests/test_append_warehouse_csv.py
@@ -1,0 +1,34 @@
+import csv
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from kartoteka import csv_utils
+
+
+def test_append_warehouse_csv_updates_stats(tmp_path):
+    path = tmp_path / "magazyn.csv"
+    app = SimpleNamespace(
+        output_data=[
+            {
+                "name": "A",
+                "number": "1",
+                "set": "S",
+                "warehouse_code": "K1",
+                "price": "2",
+                "image": "",
+                "sold": "",
+            }
+        ],
+        update_inventory_stats=MagicMock(),
+    )
+    csv_utils.append_warehouse_csv(app, path=str(path))
+    app.update_inventory_stats.assert_called_once()
+    with open(path, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+        assert rows[0]["warehouse_code"] == "K1"

--- a/tests/test_remove_warehouse_code.py
+++ b/tests/test_remove_warehouse_code.py
@@ -1,0 +1,21 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import kartoteka.ui as ui
+
+
+def test_remove_warehouse_code_updates_stats():
+    app = SimpleNamespace(
+        output_data=[{"warehouse_code": "K1R1P1"}],
+        repack_column=lambda box, col: None,
+        update_inventory_stats=MagicMock(),
+    )
+    ui.CardEditorApp.remove_warehouse_code(app, "K1R1P1")
+    assert app.output_data == []
+    app.update_inventory_stats.assert_called_once()

--- a/tests/test_toggle_sold.py
+++ b/tests/test_toggle_sold.py
@@ -19,15 +19,20 @@ def test_toggle_sold_updates_csv(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
     row = {"name": "A", "warehouse_code": "K1R1P1", "sold": ""}
-    app = SimpleNamespace(open_magazyn_window=lambda: None)
+    app = SimpleNamespace(
+        open_magazyn_window=lambda: None, update_inventory_stats=MagicMock()
+    )
 
     ui.CardEditorApp.toggle_sold(app, row)
+    app.update_inventory_stats.assert_called_once()
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
         assert rows[0]["sold"] == "1"
 
+    app.update_inventory_stats.reset_mock()
     ui.CardEditorApp.toggle_sold(app, row)
+    app.update_inventory_stats.assert_called_once()
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)


### PR DESCRIPTION
## Summary
- refresh inventory statistics whenever warehouse data changes (mark sold, add/remove cards)
- guard UI label updates against missing widgets on start screen
- add tests covering stats updates for add, remove, and sold toggles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce49406f0832fb8ede5d26e487244