### PR TITLE
Add configurable box column counts and dynamic capacity display

### DIFF
--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -6,12 +6,18 @@ from . import csv_utils
 LAST_PRODUCT_CODE_FILE = "last_product_code.txt"
 LAST_SETS_CHECK_FILE = "last_sets_check.txt"
 
-# Total card capacity per storage box.  Standard boxes (1-8) hold 4
-# columns of 1000 cards each.  Box 100 is a shorter overflow box with a
-# single 500-card column.
+# Number of columns per storage box.  Standard boxes (1-8) have four
+# columns, while box 100 is a shorter overflow box with a single column.
+BOX_COLUMNS: dict[int, int] = {b: 4 for b in range(1, 9)}
+BOX_COLUMNS[100] = 1
+
+# Total card capacity per storage box.  Standard columns hold 1000 cards
+# each, the special box 100 has a single 500-card column.
 BOX_COLUMN_CAPACITY = 1000
-BOX_CAPACITY = {b: 4 * BOX_COLUMN_CAPACITY for b in range(1, 9)}
-BOX_CAPACITY[100] = 500
+BOX_CAPACITY: dict[int, int] = {
+    box: (500 if box == 100 else BOX_COLUMNS.get(box, 4) * BOX_COLUMN_CAPACITY)
+    for box in BOX_COLUMNS
+}
 
 
 def load_last_product_code() -> int:
@@ -106,15 +112,15 @@ def compute_column_occupancy():
 
     The result is a nested dictionary mapping ``box -> column -> used
     slots``.  The set of boxes and the number of columns per box are
-    derived from :data:`BOX_CAPACITY` so changes in storage layout only
+    derived from :data:`BOX_COLUMNS` so changes in storage layout only
     require updating that mapping.
     """
 
     occ: dict[int, dict[int, int]] = {}
-    for box, cap in BOX_CAPACITY.items():
-        # Standard boxes have columns of ``BOX_COLUMN_CAPACITY`` slots.
-        columns = max(1, cap // BOX_COLUMN_CAPACITY)
-        occ[box] = {c: 0 for c in range(1, columns + 1)}
+    for box in BOX_CAPACITY:
+        occ[box] = {
+            c: 0 for c in range(1, BOX_COLUMNS.get(box, 4) + 1)
+        }
     try:
         with open(csv_utils.INVENTORY_CSV, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f, delimiter=";")

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2523,19 +2523,15 @@ class CardEditorApp:
                 box_w, box_h = photo_obj.width(), photo_obj.height()
                 photo = photo_obj
 
-            if box == SPECIAL_BOX_NUMBER:
-                columns = 1
-            else:
-                columns = GRID_COLUMNS
-
+            columns = storage.BOX_COLUMNS.get(box, GRID_COLUMNS)
             total_capacity = storage.BOX_CAPACITY.get(
-                box, GRID_COLUMNS * BOX_COLUMN_CAPACITY
+                box, columns * BOX_COLUMN_CAPACITY
             )
             col_capacity = total_capacity // columns
 
             col_w = box_w / columns
             canvas.create_image(0, 0, image=photo, anchor="nw")
-            for c in range(1, columns + 1):
+            for c in range(1, storage.BOX_COLUMNS.get(box, 4) + 1):
                 filled = occ.get(box, {}).get(c, 0)
                 free_percent = (col_capacity - filled) / col_capacity * 100
                 x1 = (c - 1) * col_w


### PR DESCRIPTION
## Summary
- Introduce `BOX_COLUMNS` mapping to define column counts per box
- Derive box capacities and occupancy loops from the new mapping
- Update warehouse canvas drawing to respect per-column capacities

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ceac52a48832fa3927c04ecacd087