### PR TITLE
Centralize UI layout constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ flowchart TB
 The warehouse CSV uses the following columns: `name`, `number`, `set`, `warehouse_code`, `price`, `image` and `sold`.
 
 ### Layout configuration constants
-Adjust the layout in `kartoteka/ui.py` via:
+Adjust the layout in `kartoteka/ui.py` via central constants. They replace
+previously scattered magic numbers for thumbnail sizes, grid columns, and box
+capacities, making future tweaks much simpler.
 
 - `GRID_COLUMNS` – number of columns per box (default **4**)
 - `BOX_COLUMN_CAPACITY` – slots per column (default **1000**)

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2531,7 +2531,7 @@ class CardEditorApp:
 
             col_w = box_w / columns
             canvas.create_image(0, 0, image=photo, anchor="nw")
-            for c in range(1, storage.BOX_COLUMNS.get(box, 4) + 1):
+            for c in range(1, columns + 1):
                 filled = occ.get(box, {}).get(c, 0)
                 free_percent = (col_capacity - filled) / col_capacity * 100
                 x1 = (c - 1) * col_w


### PR DESCRIPTION
## Summary
- reference shared column and capacity constants when rendering box occupancy
- document layout constants for easier future tweaking

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cee4f5370832f9bad21f3fc136689