### PR TITLE
Use per-box capacities for occupancy

### DIFF
--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -6,18 +6,17 @@ from . import csv_utils
 LAST_PRODUCT_CODE_FILE = "last_product_code.txt"
 LAST_SETS_CHECK_FILE = "last_sets_check.txt"
 
-# Number of columns per storage box.  Standard boxes (1-8) have four
-# columns, while box 100 is a shorter overflow box with a single column.
-BOX_COLUMNS: dict[int, int] = {b: 4 for b in range(1, 9)}
-BOX_COLUMNS[100] = 1
+# Total card capacity per storage box.  Standard boxes hold 4000 cards in
+# four columns, while the special box ``100`` is a single 500-card column.
+BOX_CAPACITY: dict[int, int] = {**{b: 4000 for b in range(1, 9)}, 100: 500}
 
-# Total card capacity per storage box.  Standard columns hold 1000 cards
-# each, the special box 100 has a single 500-card column.
+# Number of columns per storage box.  All regular boxes (1-8) have four
+# columns, the overflow box ``100`` only one.
+BOX_COLUMNS: dict[int, int] = {box: (1 if box == 100 else 4) for box in BOX_CAPACITY}
+
+# Default per-column capacity for standard boxes.  Used as a fallback when
+# handling boxes outside of :data:`BOX_CAPACITY`.
 BOX_COLUMN_CAPACITY = 1000
-BOX_CAPACITY: dict[int, int] = {
-    box: (500 if box == 100 else BOX_COLUMNS.get(box, 4) * BOX_COLUMN_CAPACITY)
-    for box in BOX_COLUMNS
-}
 
 
 def load_last_product_code() -> int:

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2474,7 +2474,7 @@ class CardEditorApp:
         legend_frame.pack(pady=(0, 10))
         legend_items = [
             ("#ff9800", "≥30% free"),
-            ("#4caf50", "Occupied 100-card segment"),
+            ("#4caf50", "Occupied capacity segment"),
             ("#888888", "Sold item"),
         ]
         for color, desc in legend_items:
@@ -2509,8 +2509,9 @@ class CardEditorApp:
         """Refresh storage view and color code capacity usage.
 
         A column's background turns orange when 30% or more of its
-        capacity is still free.  Individual 100-card segments become
-        green as soon as they are occupied.
+        capacity is still free.  Individual segments representing 10%
+        of the column capacity become green as soon as they are
+        occupied.
         """
         occ = self.compute_column_occupancy()
         if not self.mag_canvases:
@@ -2537,7 +2538,7 @@ class CardEditorApp:
 
             columns = storage.BOX_COLUMNS.get(box, GRID_COLUMNS)
             total_capacity = storage.BOX_CAPACITY.get(
-                box, columns * BOX_COLUMN_CAPACITY
+                box, columns * storage.BOX_COLUMN_CAPACITY
             )
             col_capacity = total_capacity // columns
 
@@ -2558,9 +2559,9 @@ class CardEditorApp:
                         width=0,
                         tags="stats",
                     )
-                # Draw 100-card sections
-                filled_sections = filled // 100
-                seg_count = max(1, col_capacity // 100)
+                # Draw proportional capacity sections
+                seg_count = 10
+                filled_sections = int(filled * seg_count / col_capacity)
                 seg_h = box_h / seg_count
                 for i in range(seg_count):
                     y1 = box_h - seg_h * (i + 1)


### PR DESCRIPTION
## Summary
- define explicit `BOX_CAPACITY` mapping for all storage boxes
- compute free space and segment fill in `refresh_magazyn` using per-box capacity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf29b328c832f8bb821bd4978d7c6