### PR TITLE
Fix README line break for ttkbootstrap icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ installed separately.  On Linux, the `opencv-python` wheel requires the
 sudo apt-get update && sudo apt-get install -y libgl1 libglib2.0-0
 ```
 
-If your version of `ttkbootstrap` is 1.10 or newer, the buttons will display built-in icons. On older versions the icons are skipped automatically.
+If your version of `ttkbootstrap` is 1.10 or newer, the buttons will display built-in icons.
+On older versions the icons are skipped automatically.
 
 Ensure a `card_prices.csv` file with columns `name`, `number`, `set` and `price` exists in the project directory.
 


### PR DESCRIPTION
## Summary
- fix README line break for ttkbootstrap icon note

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dbb48f918832f99cf3af202bc26c4