### PR TITLE
Add include_sold option to inventory stats

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -45,13 +45,16 @@ WAREHOUSE_FIELDNAMES = [
 ]
 
 
-def get_inventory_stats(path: str = WAREHOUSE_CSV):
+def get_inventory_stats(path: str = WAREHOUSE_CSV, include_sold: bool = False):
     """Return total count and value from the warehouse CSV.
 
     Parameters
     ----------
     path:
         Optional path to the warehouse CSV. Defaults to ``WAREHOUSE_CSV``.
+    include_sold:
+        If ``True``, rows marked as sold are included in the totals.
+        Defaults to ``False``.
 
     Returns
     -------
@@ -67,8 +70,9 @@ def get_inventory_stats(path: str = WAREHOUSE_CSV):
     with open(path, encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         for row in reader:
-            # Skip rows marked as sold
-            if str(row.get("sold") or "").lower() in {"1", "true", "yes"}:
+            # Skip rows marked as sold unless requested otherwise
+            sold_flag = str(row.get("sold") or "").lower()
+            if not include_sold and sold_flag in {"1", "true", "yes"}:
                 continue
             count += 1
             price_raw = str(row.get("price") or "0").replace(",", ".")

--- a/tests/test_inventory_stats.py
+++ b/tests/test_inventory_stats.py
@@ -27,3 +27,16 @@ def test_inventory_stats_excludes_sold(tmp_path):
     count, total = csv_utils.get_inventory_stats(str(csv_path))
     assert count == 1
     assert total == pytest.approx(10)
+
+
+def test_inventory_stats_includes_sold_when_requested(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;sold\n"
+        "A;1;S1;K1;10;img1;\n"
+        "B;2;S2;K2;5;img2;1\n",
+        encoding="utf-8",
+    )
+    count, total = csv_utils.get_inventory_stats(str(csv_path), include_sold=True)
+    assert count == 2
+    assert total == pytest.approx(15)


### PR DESCRIPTION
## Summary
- add optional `include_sold` flag to `get_inventory_stats`
- count sold items when `include_sold=True`
- test inventory stats with and without sold items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dbe74f998832fa225aa8bfaeb62aa