### PR TITLE
Add strikethrough styling for sold cards

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2413,14 +2413,22 @@ class CardEditorApp:
                 is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
                 text = row.get("name", "")
                 color = TEXT_COLOR
+                font = None
                 if is_sold:
                     text = f"[SOLD] {text}"
                     color = "#888888"
+                    if hasattr(ctk, "CTkFont"):
+                        font = ctk.CTkFont(overstrike=True)
+                    else:
+                        font = ("TkDefaultFont", 12, "overstrike")
 
                 img_label = ctk.CTkLabel(frame, image=photo, text="")
                 img_label.pack()
 
-                label = ctk.CTkLabel(frame, text=text, text_color=color)
+                label_kwargs = {"text": text, "text_color": color}
+                if font is not None:
+                    label_kwargs["font"] = font
+                label = ctk.CTkLabel(frame, **label_kwargs)
                 label.pack()
 
                 frame.grid(row=i // N, column=i % N, padx=5, pady=5)

--- a/tests/ctk_mocks.py
+++ b/tests/ctk_mocks.py
@@ -32,6 +32,7 @@ class DummyCTkLabel(_Widget):
         fg_color=None,
         text_color=None,
         compound=None,
+        font=None,
         **kwargs,
     ):
         self.master = master
@@ -40,6 +41,7 @@ class DummyCTkLabel(_Widget):
         self.fg_color = fg_color
         self.text_color = text_color
         self.compound = compound
+        self.font = font
         self._bindings = {}
 
     def bind(self, event, callback):

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -56,3 +56,7 @@ def test_sold_cards_styled(tmp_path):
     assert len(app.mag_sold_labels) == 1
     assert app.mag_sold_labels[0].text.startswith("[SOLD]")
     assert app.mag_sold_labels[0].text_color == "#888888"
+    font = app.mag_sold_labels[0].font
+    assert getattr(font, "overstrike", False) or (
+        isinstance(font, tuple) and "overstrike" in font
+    )


### PR DESCRIPTION
## Summary
- Draw sold cards with strikethrough text in inventory view
- Support font storage in CTk label mocks
- Verify strikethrough styling in sold card tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbf767efc832faa80e57301cb7df5