### PR TITLE
Add 'Sprzedano' button to mark cards as sold

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2646,13 +2646,54 @@ class CardEditorApp:
                 font=("Inter", 16),
             ).grid(row=i, column=0, sticky="w", pady=2)
 
-        # Button to toggle sold status
-        is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
-        btn_text = "Mark as available" if is_sold else "Mark as sold"
-        toggle = lambda: self.toggle_sold(row, top)
-        ctk.CTkButton(right, text=btn_text, command=toggle).grid(
-            row=len(fields), column=0, pady=10, sticky="w"
-        )
+        # Button to mark the card as sold
+        ctk.CTkButton(
+            right,
+            text="Sprzedano",
+            command=lambda: self.mark_as_sold(row, top),
+        ).grid(row=len(fields), column=0, pady=10, sticky="w")
+
+    def mark_as_sold(self, row: dict, window=None):
+        """Mark the card as sold, update CSV and refresh views."""
+
+        csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
+        try:
+            with open(csv_path, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter=";")
+                rows = list(reader)
+                fieldnames = reader.fieldnames or []
+        except FileNotFoundError:
+            return
+
+        if "sold" not in fieldnames:
+            fieldnames.append("sold")
+
+        target = str(row.get("warehouse_code", ""))
+        for r in rows:
+            if r.get("warehouse_code") == target:
+                r["sold"] = "1"
+                row["sold"] = "1"
+                break
+
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+            writer.writeheader()
+            writer.writerows(rows)
+
+        if window is not None:
+            try:
+                window.destroy()
+            except Exception:
+                pass
+
+        if hasattr(self, "update_inventory_stats"):
+            try:
+                self.update_inventory_stats()
+            except Exception:
+                pass
+
+        if hasattr(self, "open_magazyn_window"):
+            self.open_magazyn_window()
 
     def toggle_sold(self, row: dict, window=None):
         """Toggle the sold flag for a warehouse card and update CSV."""

--- a/tests/test_show_card_details_sprzedano_button.py
+++ b/tests/test_show_card_details_sprzedano_button.py
@@ -1,0 +1,101 @@
+import csv
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from PIL import Image
+
+
+def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;10;;\n",
+        encoding="utf-8",
+    )
+
+    created = {}
+
+    class DummyButton:
+        def __init__(self, master=None, **kwargs):
+            created["kwargs"] = kwargs
+
+        def grid(self, *a, **k):
+            return self
+
+    class DummyFrame:
+        def __init__(self, *a, **k):
+            pass
+
+        def pack(self, *a, **k):
+            return self
+
+        def grid(self, *a, **k):
+            return self
+
+    class DummyLabel(DummyFrame):
+        def __init__(self, master=None, **kwargs):
+            pass
+
+    class DummyToplevel(DummyFrame):
+        def title(self, *a, **k):
+            pass
+
+        def geometry(self, *a, **k):
+            pass
+
+        def minsize(self, *a, **k):
+            pass
+
+        def destroy(self):
+            pass
+
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkToplevel=DummyToplevel,
+        CTkFrame=DummyFrame,
+        CTkLabel=DummyLabel,
+        CTkButton=DummyButton,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+
+    importlib.reload(ui)
+
+    monkeypatch.setattr(ui, "_load_image", lambda p: Image.new("RGB", (10, 10)))
+    monkeypatch.setattr(ui, "_create_image", lambda img: SimpleNamespace())
+    monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
+
+    open_mock = MagicMock()
+    stats_mock = MagicMock()
+    app = SimpleNamespace(
+        root=SimpleNamespace(),
+        open_magazyn_window=open_mock,
+        update_inventory_stats=stats_mock,
+    )
+    app.mark_as_sold = lambda r, w=None: ui.CardEditorApp.mark_as_sold(app, r, w)
+
+    row = {
+        "name": "A",
+        "number": "1",
+        "set": "S1",
+        "price": "10",
+        "warehouse_code": "K1R1P1",
+        "sold": "",
+    }
+
+    ui.CardEditorApp.show_card_details(app, row)
+
+    assert created["kwargs"]["text"] == "Sprzedano"
+
+    # Simulate button press
+    created["kwargs"]["command"]()
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = list(reader)
+        assert rows[0]["sold"] == "1"
+
+    open_mock.assert_called_once()
+    stats_mock.assert_called_once()
+


### PR DESCRIPTION
## Summary
- add a *Sprzedano* button in card details to mark a card as sold
- persist the sold flag in the CSV and refresh warehouse view and stats
- test that the new button sets the sold flag and triggers refresh

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc0f25804832fa06930669764926b