### PR TITLE
Ensure warehouse UI attributes remain accessible after refactor

### DIFF
--- a/tests/test_magazyn_show_card_details.py
+++ b/tests/test_magazyn_show_card_details.py
@@ -82,6 +82,22 @@ class DummyCanvas(_Widget):
         return self.height_val
 
 
+def _extract_label(widget):
+    """Return the innermost label regardless of wrapping structure."""
+    seen = set()
+    current = widget
+    while id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, dict) and "label" in current:
+            current = current["label"]
+            continue
+        if hasattr(current, "label"):
+            current = current.label
+            continue
+        break
+    return current
+
+
 def test_show_card_details_receives_row(tmp_path):
     # Prepare CSV and image
     img_path = tmp_path / "card.png"
@@ -141,7 +157,14 @@ def test_show_card_details_receives_row(tmp_path):
         )
 
         ui.CardEditorApp.open_magazyn_window(app)
-        label = app.mag_card_labels[0]
+
+        # mag_canvases should remain defined and contain canvas-like objects
+        assert hasattr(app, "mag_canvases")
+        assert app.mag_canvases
+        canvas_widget = getattr(app.mag_canvases[0], "canvas", app.mag_canvases[0])
+        assert hasattr(canvas_widget, "create_image")
+
+        label = _extract_label(app.mag_card_labels[0])
         label._bindings["<Button-1>"](None)
 
     assert captured["row"]["name"] == "Test Card"

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -14,6 +14,22 @@ from ctk_mocks import (  # noqa: E402
 )
 
 
+def _extract_label(widget):
+    """Return the innermost label regardless of wrapping structure."""
+    seen = set()
+    current = widget
+    while id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, dict) and "label" in current:
+            current = current["label"]
+            continue
+        if hasattr(current, "label"):
+            current = current.label
+            continue
+        break
+    return current
+
+
 def test_sold_cards_styled(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
@@ -54,9 +70,10 @@ def test_sold_cards_styled(tmp_path):
 
     assert len(app.mag_card_labels) == 1
     assert len(app.mag_sold_labels) == 1
-    assert app.mag_sold_labels[0].text.startswith("[SOLD]")
-    assert app.mag_sold_labels[0].text_color == "#888888"
-    font = app.mag_sold_labels[0].font
+    sold_label = _extract_label(app.mag_sold_labels[0])
+    assert sold_label.text.startswith("[SOLD]")
+    assert sold_label.text_color == "#888888"
+    font = sold_label.font
     assert getattr(font, "overstrike", False) or (
         isinstance(font, tuple) and "overstrike" in font
     )


### PR DESCRIPTION
## Summary
- Add helper to tests to extract nested label widgets
- Assert that `mag_canvases` remains defined and canvas-like after opening warehouse window
- Adjust sold card style test to handle possible wrapper objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc2da3364832fb5afc0065253a873