### PR TITLE
Expose sold inventory stats

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -45,43 +45,48 @@ WAREHOUSE_FIELDNAMES = [
 ]
 
 
-def get_inventory_stats(path: str = WAREHOUSE_CSV, include_sold: bool = False):
-    """Return total count and value from the warehouse CSV.
+def get_inventory_stats(path: str = WAREHOUSE_CSV):
+    """Return statistics for both unsold and sold items in the warehouse CSV.
 
     Parameters
     ----------
     path:
         Optional path to the warehouse CSV. Defaults to ``WAREHOUSE_CSV``.
-    include_sold:
-        If ``True``, rows marked as sold are included in the totals.
-        Defaults to ``False``.
 
     Returns
     -------
-    tuple[int, float]
-        Number of rows and the sum of the ``price`` column.
+    tuple[int, float, int, float]
+        ``(count_unsold, total_unsold, count_sold, total_sold)`` where each
+        count is the number of rows and each total is the sum of the ``price``
+        column for items in the respective category.
     """
 
-    count = 0
-    total = 0.0
+    count_unsold = 0
+    total_unsold = 0.0
+    count_sold = 0
+    total_sold = 0.0
+
     if not os.path.exists(path):
-        return count, total
+        return count_unsold, total_unsold, count_sold, total_sold
 
     with open(path, encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         for row in reader:
-            # Skip rows marked as sold unless requested otherwise
-            sold_flag = str(row.get("sold") or "").lower()
-            if not include_sold and sold_flag in {"1", "true", "yes"}:
-                continue
-            count += 1
+            sold_flag = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
             price_raw = str(row.get("price") or "0").replace(",", ".")
             try:
-                total += float(price_raw)
+                price = float(price_raw)
             except ValueError:
                 continue
 
-    return count, total
+            if sold_flag:
+                count_sold += 1
+                total_sold += price
+            else:
+                count_unsold += 1
+                total_unsold += price
+
+    return count_unsold, total_unsold, count_sold, total_sold
 
 
 def format_store_row(row):

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1330,7 +1330,7 @@ class CardEditorApp:
         )
         desc.pack(pady=5)
 
-        count, total_value = csv_utils.get_inventory_stats()
+        count, total_value, _, _ = csv_utils.get_inventory_stats()
         self.inventory_count_label = ctk.CTkLabel(
             self.start_frame,
             text=f"Łączna liczba kart: {count}",
@@ -1414,6 +1414,8 @@ class CardEditorApp:
             "mag_inventory_count_label",
             "inventory_value_label",
             "mag_inventory_value_label",
+            "mag_sold_count_label",
+            "mag_sold_value_label",
         ]:
             widget = getattr(self, attr, None)
             if widget and hasattr(widget, "winfo_exists"):
@@ -1427,11 +1429,16 @@ class CardEditorApp:
         if not widgets:
             return
 
-        count, total = csv_utils.get_inventory_stats()
-        count_text = f"Łączna liczba kart: {count}"
-        total_text = f"Łączna wartość: {total:.2f} PLN"
+        unsold_count, unsold_total, sold_count, sold_total = csv_utils.get_inventory_stats()
+        unsold_count_text = f"Łączna liczba kart: {unsold_count}"
+        unsold_total_text = f"Łączna wartość: {unsold_total:.2f} PLN"
+        sold_count_text = f"Sprzedane karty: {sold_count}"
+        sold_total_text = f"Wartość sprzedanych: {sold_total:.2f} PLN"
         for attr, widget in widgets:
-            text = count_text if "count" in attr else total_text
+            if "sold" in attr:
+                text = sold_count_text if "count" in attr else sold_total_text
+            else:
+                text = unsold_count_text if "count" in attr else unsold_total_text
             try:
                 widget.configure(text=text)
             except tk.TclError:
@@ -2461,21 +2468,35 @@ class CardEditorApp:
         stats_frame.pack(pady=(0, 10), anchor="center")
 
         font = ("Segoe UI", 16, "bold")
-        count, total = csv_utils.get_inventory_stats()
+        unsold_count, unsold_total, sold_count, sold_total = csv_utils.get_inventory_stats()
         self.mag_inventory_count_label = ctk.CTkLabel(
             stats_frame,
-            text=f"Łączna liczba kart: {count}",
+            text=f"Łączna liczba kart: {unsold_count}",
             text_color=TEXT_COLOR,
             font=font,
         )
         self.mag_inventory_count_label.pack()
         self.mag_inventory_value_label = ctk.CTkLabel(
             stats_frame,
-            text=f"Łączna wartość: {total:.2f} PLN",
+            text=f"Łączna wartość: {unsold_total:.2f} PLN",
             text_color=TEXT_COLOR,
             font=font,
         )
         self.mag_inventory_value_label.pack()
+        self.mag_sold_count_label = ctk.CTkLabel(
+            stats_frame,
+            text=f"Sprzedane karty: {sold_count}",
+            text_color=TEXT_COLOR,
+            font=font,
+        )
+        self.mag_sold_count_label.pack()
+        self.mag_sold_value_label = ctk.CTkLabel(
+            stats_frame,
+            text=f"Wartość sprzedanych: {sold_total:.2f} PLN",
+            text_color=TEXT_COLOR,
+            font=font,
+        )
+        self.mag_sold_value_label.pack()
 
         # legend for color coding in the storage view
         legend_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)

--- a/tests/test_inventory_stats.py
+++ b/tests/test_inventory_stats.py
@@ -13,9 +13,13 @@ def test_get_inventory_stats(tmp_path):
         "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10.5;img1\n" "B;2;S2;K2;5,25;img2\n",
         encoding="utf-8",
     )
-    count, total = csv_utils.get_inventory_stats(str(csv_path))
-    assert count == 2
-    assert total == pytest.approx(15.75)
+    count_unsold, total_unsold, count_sold, total_sold = csv_utils.get_inventory_stats(
+        str(csv_path)
+    )
+    assert count_unsold == 2
+    assert total_unsold == pytest.approx(15.75)
+    assert count_sold == 0
+    assert total_sold == pytest.approx(0)
 
 
 def test_inventory_stats_excludes_sold(tmp_path):
@@ -24,19 +28,10 @@ def test_inventory_stats_excludes_sold(tmp_path):
         "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1;10;img1;\n" "B;2;S2;K2;5;img2;1\n",
         encoding="utf-8",
     )
-    count, total = csv_utils.get_inventory_stats(str(csv_path))
-    assert count == 1
-    assert total == pytest.approx(10)
-
-
-def test_inventory_stats_includes_sold_when_requested(tmp_path):
-    csv_path = tmp_path / "magazyn.csv"
-    csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;sold\n"
-        "A;1;S1;K1;10;img1;\n"
-        "B;2;S2;K2;5;img2;1\n",
-        encoding="utf-8",
+    count_unsold, total_unsold, count_sold, total_sold = csv_utils.get_inventory_stats(
+        str(csv_path)
     )
-    count, total = csv_utils.get_inventory_stats(str(csv_path), include_sold=True)
-    assert count == 2
-    assert total == pytest.approx(15)
+    assert count_unsold == 1
+    assert total_unsold == pytest.approx(10)
+    assert count_sold == 1
+    assert total_sold == pytest.approx(5)

--- a/tests/test_magazyn_inventory_stats_view.py
+++ b/tests/test_magazyn_inventory_stats_view.py
@@ -25,8 +25,8 @@ def test_inventory_stats_display_and_update(tmp_path, monkeypatch):
     monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(csv_path))
     monkeypatch.setattr(csv_utils, "INVENTORY_CSV", str(csv_path))
 
-    first_stats = (5, 123.45)
-    second_stats = (7, 210.0)
+    first_stats = (5, 123.45, 2, 50.0)
+    second_stats = (7, 210.0, 3, 60.0)
     monkeypatch.setattr(csv_utils, "get_inventory_stats", lambda path=str(csv_path): first_stats)
 
     sys.modules["customtkinter"] = SimpleNamespace(
@@ -64,6 +64,11 @@ def test_inventory_stats_display_and_update(tmp_path, monkeypatch):
         app.mag_inventory_value_label.text
         == f"Łączna wartość: {first_stats[1]:.2f} PLN"
     )
+    assert app.mag_sold_count_label.text == f"Sprzedane karty: {first_stats[2]}"
+    assert (
+        app.mag_sold_value_label.text
+        == f"Wartość sprzedanych: {first_stats[3]:.2f} PLN"
+    )
 
     monkeypatch.setattr(ui.csv_utils, "get_inventory_stats", lambda path=str(csv_path): second_stats)
     ui.CardEditorApp.update_inventory_stats(app)
@@ -71,4 +76,9 @@ def test_inventory_stats_display_and_update(tmp_path, monkeypatch):
     assert (
         app.mag_inventory_value_label.text
         == f"Łączna wartość: {second_stats[1]:.2f} PLN"
+    )
+    assert app.mag_sold_count_label.text == f"Sprzedane karty: {second_stats[2]}"
+    assert (
+        app.mag_sold_value_label.text
+        == f"Wartość sprzedanych: {second_stats[3]:.2f} PLN"
     )

--- a/tests/test_update_inventory_stats_no_labels.py
+++ b/tests/test_update_inventory_stats_no_labels.py
@@ -12,6 +12,10 @@ import kartoteka.ui as ui  # noqa: E402
 
 def test_update_inventory_stats_without_labels(monkeypatch):
     """Calling update_inventory_stats without labels should not error."""
-    monkeypatch.setattr(ui.csv_utils, "get_inventory_stats", lambda path=ui.csv_utils.WAREHOUSE_CSV: (1, 2.0))
+    monkeypatch.setattr(
+        ui.csv_utils,
+        "get_inventory_stats",
+        lambda path=ui.csv_utils.WAREHOUSE_CSV: (1, 2.0, 3, 4.0),
+    )
     app = SimpleNamespace()
     ui.CardEditorApp.update_inventory_stats(app)


### PR DESCRIPTION
## Summary
- extend `get_inventory_stats` to return unsold and sold counts and totals
- show unsold and sold metrics in the magazyn view and keep labels up to date
- adjust tests for new inventory statistics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dc4361b3c832fb6d1b98c6b1b0613