### PR TITLE
Load thumbnails asynchronously

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2387,35 +2387,80 @@ class CardEditorApp:
         self.mag_card_labels = []
         # sold card labels for separate styling/testing
         self.mag_sold_labels = []
+        # image label references for async updates
+        self.mag_card_image_labels: list[Optional[ctk.CTkLabel]] = []
         list_frame = ctk.CTkScrollableFrame(self.magazyn_frame, fg_color=BG_COLOR)
         list_frame.pack(expand=True, fill="both", padx=10, pady=10)
 
         csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
         if os.path.exists(csv_path):
-            unsold = []
-            sold = []
+            # lists of indices to maintain ordering
+            unsold: list[int] = []
+            sold: list[int] = []
+
+            thumb_size = CARD_THUMB_SIZE
+            placeholder_img = Image.new("RGB", (thumb_size, thumb_size), "#111111")
+            self.mag_placeholder_photo = _create_image(placeholder_img)
+
+            # reset containers
+            self.mag_card_rows = []
+            self.mag_card_images = []
+            self.mag_card_image_labels = []
+            self._image_threads = []
+
             with open(csv_path, encoding="utf-8") as f:
                 reader = csv.DictReader(f, delimiter=";")
-                thumb_size = CARD_THUMB_SIZE
                 for row in reader:
+                    idx = len(self.mag_card_rows)
                     self.mag_card_rows.append(row)
+                    self.mag_card_images.append(self.mag_placeholder_photo)
+                    self.mag_card_image_labels.append(None)
+
                     img_path = row.get("image") or ""
-                    img = _load_image(img_path)
-                    if img is not None:
-                        img.thumbnail((thumb_size, thumb_size))
+                    is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
+                    if is_sold:
+                        sold.append(idx)
                     else:
-                        img = Image.new("RGB", (thumb_size, thumb_size), "#111111")
-                    photo = _create_image(img)
-                    self.mag_card_images.append(photo)
-                    if str(row.get("sold") or "").lower() in {"1", "true", "yes"}:
-                        sold.append((row, photo))
+                        unsold.append(idx)
+
+                    if urlparse(img_path).scheme in ("http", "https"):
+                        def _worker(i=idx, url=img_path):
+                            img = _load_image(url)
+                            if img is None:
+                                return
+                            img.thumbnail((thumb_size, thumb_size))
+                            photo = _create_image(img)
+
+                            def _update() -> None:
+                                self.mag_card_images[i] = photo
+                                lbl = self.mag_card_image_labels[i]
+                                if lbl is not None:
+                                    if hasattr(lbl, "configure"):
+                                        lbl.configure(image=photo)
+                                    else:  # simple dummy widgets in tests
+                                        lbl.image = photo
+
+                            after = getattr(self.root, "after", None)
+                            if callable(after):
+                                after(0, _update)
+                            else:
+                                _update()
+
+                        th = threading.Thread(target=_worker, daemon=True)
+                        th.start()
+                        self._image_threads.append(th)
                     else:
-                        unsold.append((row, photo))
+                        img = _load_image(img_path)
+                        if img is not None:
+                            img.thumbnail((thumb_size, thumb_size))
+                            photo = _create_image(img)
+                            self.mag_card_images[idx] = photo
 
             N = 4
-            # display unsold first, then sold
             combined = unsold + sold
-            for i, (row, photo) in enumerate(combined):
+            for i, idx in enumerate(combined):
+                row = self.mag_card_rows[idx]
+                photo = self.mag_card_images[idx]
                 frame = ctk.CTkFrame(list_frame, fg_color=BG_COLOR)
                 is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
                 text = row.get("name", "")
@@ -2431,6 +2476,7 @@ class CardEditorApp:
 
                 img_label = ctk.CTkLabel(frame, image=photo, text="")
                 img_label.pack()
+                self.mag_card_image_labels[idx] = img_label
 
                 label_kwargs = {"text": text, "text_color": color}
                 if font is not None:

--- a/tests/test_remote_image_loading.py
+++ b/tests/test_remote_image_loading.py
@@ -138,6 +138,7 @@ def test_open_magazyn_window_remote_thumbnail(tmp_path):
     Image.new("RGB", (10, 10), "white").save(img_bytes, format="PNG")
     img_bytes = img_bytes.getvalue()
 
+    placeholder_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
     photo_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
 
     dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
@@ -158,11 +159,14 @@ def test_open_magazyn_window_remote_thumbnail(tmp_path):
 
     resp = SimpleNamespace(content=img_bytes, raise_for_status=lambda: None)
 
-    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
+    side_effects = [SimpleNamespace(width=lambda:1, height=lambda:1), SimpleNamespace(width=lambda:1, height=lambda:1), placeholder_mock, photo_mock]
+    with patch.object(ui.ImageTk, "PhotoImage", side_effect=side_effects), \
          patch.object(ui.tk, "Canvas", DummyCanvas), \
          patch.object(ui.requests, "get", return_value=resp) as mock_get, \
          patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
         ui.CardEditorApp.open_magazyn_window(app)
+        for t in app._image_threads:
+            t.join()
 
     assert mock_get.called
     assert app.mag_card_images[0] is photo_mock
@@ -204,6 +208,8 @@ def test_show_card_details_remote_uses_cache(tmp_path):
          patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
         # first load thumbnails
         ui.CardEditorApp.open_magazyn_window(app)
+        for t in app._image_threads:
+            t.join()
         # then show details which should reuse cache and not trigger new request
         ui.CardEditorApp.show_card_details(app, app.mag_card_rows[0])
 


### PR DESCRIPTION
## Summary
- Load warehouse thumbnails in background threads and update UI once fetched
- Show placeholder images until real thumbnails appear
- Update tests to accommodate asynchronous thumbnail loading

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dc5da65dc832f957bdce02f037dd0