### PR TITLE
Localize card title fallback

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -35,6 +35,7 @@ from urllib.parse import urlencode, urlparse
 import io
 import webbrowser
 import logging
+from gettext import gettext as _
 try:
     from hash_db import HashDB
 except Exception:  # pragma: no cover - optional dependency
@@ -2711,7 +2712,7 @@ class CardEditorApp:
         """Display details for a selected warehouse card."""
 
         top = ctk.CTkToplevel(self.root)
-        top.title(row.get("name", "Card"))
+        top.title(row.get("name", _("Karta")))
         # ensure enough space for side-by-side layout
         if hasattr(top, "geometry"):
             top.geometry("600x400")

--- a/tests/test_show_card_details_default_name.py
+++ b/tests/test_show_card_details_default_name.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+
+from PIL import Image
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import kartoteka.ui as ui
+from tests.ctk_mocks import DummyCTkFrame, DummyCTkLabel, DummyCTkButton
+
+
+def test_show_card_details_uses_localized_fallback(monkeypatch):
+    top = SimpleNamespace(
+        title=lambda t: setattr(top, "title_value", t),
+        geometry=lambda *a, **k: None,
+        minsize=lambda *a, **k: None,
+    )
+    monkeypatch.setattr(ui.ctk, "CTkToplevel", lambda master: top)
+    monkeypatch.setattr(ui.ctk, "CTkFrame", DummyCTkFrame)
+    monkeypatch.setattr(ui.ctk, "CTkLabel", DummyCTkLabel)
+    monkeypatch.setattr(ui.ctk, "CTkButton", DummyCTkButton)
+    monkeypatch.setattr(ui, "_load_image", lambda path: Image.new("RGB", (1, 1)))
+    monkeypatch.setattr(ui, "_create_image", lambda img: SimpleNamespace())
+    app = SimpleNamespace(root=None, mark_as_sold=lambda *a, **k: None)
+    ui.CardEditorApp.show_card_details(app, {})
+    assert top.title_value == "Karta"


### PR DESCRIPTION
## Summary
- Localize card detail window title with gettext and use "Karta" as fallback
- Add regression test validating localized fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689dcd0aad1c832f9e5784806691ede8