### PR TITLE
Show message when inventory is empty

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1357,6 +1357,8 @@ class CardEditorApp:
         desc.pack(pady=5)
 
         count, total_value, _, _ = csv_utils.get_inventory_stats()
+        if count == 0 and total_value == 0:
+            messagebox.showinfo("Magazyn", "Brak kart w magazynie")
         self.inventory_count_label = ctk.CTkLabel(
             self.start_frame,
             text=f"Łączna liczba kart: {count}",
@@ -1456,6 +1458,8 @@ class CardEditorApp:
             return
 
         unsold_count, unsold_total, sold_count, sold_total = csv_utils.get_inventory_stats()
+        if unsold_count == 0 and sold_count == 0:
+            messagebox.showinfo("Magazyn", "Brak kart w magazynie")
         unsold_count_text = f"Łączna liczba kart: {unsold_count}"
         unsold_total_text = f"Łączna wartość: {unsold_total:.2f} PLN"
         sold_count_text = f"Sprzedane karty: {sold_count}"
@@ -2537,6 +2541,8 @@ class CardEditorApp:
 
         font = ("Segoe UI", 16, "bold")
         unsold_count, unsold_total, sold_count, sold_total = csv_utils.get_inventory_stats()
+        if unsold_count == 0 and sold_count == 0:
+            messagebox.showinfo("Magazyn", "Brak kart w magazynie")
         self.mag_inventory_count_label = ctk.CTkLabel(
             stats_frame,
             text=f"Łączna liczba kart: {unsold_count}",

--- a/tests/test_empty_inventory_message.py
+++ b/tests/test_empty_inventory_message.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Provide dummy customtkinter before importing UI module
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parent))
+from ctk_mocks import DummyCTkLabel  # noqa: E402
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui  # noqa: E402
+
+
+def test_update_inventory_stats_empty_shows_message(monkeypatch):
+    app = SimpleNamespace(
+        inventory_count_label=DummyCTkLabel(),
+        inventory_value_label=DummyCTkLabel(),
+    )
+    monkeypatch.setattr(
+        ui.csv_utils,
+        "get_inventory_stats",
+        lambda path=ui.csv_utils.WAREHOUSE_CSV: (0, 0.0, 0, 0.0),
+    )
+    with patch.object(ui.messagebox, "showinfo") as mock_info:
+        ui.CardEditorApp.update_inventory_stats(app)
+    mock_info.assert_called_once()
+    assert mock_info.call_args[0][1] == "Brak kart w magazynie"


### PR DESCRIPTION
## Summary
- display a friendly “Brak kart w magazynie” notification when inventory stats return zero
- test the empty inventory notification

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd03eefa4832fbcecc5a6e292bab0