### PR TITLE
Skip incomplete rows in magazyn view

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2439,6 +2439,10 @@ class CardEditorApp:
             with open(csv_path, encoding="utf-8") as f:
                 reader = csv.DictReader(f, delimiter=";")
                 for row in reader:
+                    if not (row.get("name") and row.get("image")):
+                        logger.warning("Skipping row with missing name or image: %s", row)
+                        continue
+
                     idx = len(self.mag_card_rows)
                     self.mag_card_rows.append(row)
                     self.mag_card_images.append(self.mag_placeholder_photo)
@@ -2486,6 +2490,9 @@ class CardEditorApp:
             combined = unsold + sold
             for i, idx in enumerate(combined):
                 row = self.mag_card_rows[idx]
+                if not (row.get("name") and row.get("image")):
+                    logger.warning("Skipping row with missing name or image: %s", row)
+                    continue
                 photo = self.mag_card_images[idx]
                 frame = ctk.CTkFrame(list_frame, fg_color=BG_COLOR)
                 is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -33,7 +33,9 @@ def _extract_label(widget):
 def test_sold_cards_styled(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;1;;\n" "B;2;S2;K1R1P2;1;;1\n",
+        "name;number;set;warehouse_code;price;image;sold\n"
+        "A;1;S1;K1R1P1;1;foo.png;\n"
+        "B;2;S2;K1R1P2;1;foo.png;1\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- validate warehouse CSV rows to ensure `name` and `image` fields exist before displaying
- log and ignore rows missing mandatory fields to avoid broken labels
- adjust sold display test to include required image paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dd816f214832f93a4631c66fc2de3