### PR TITLE
Cache inventory stats when warehouse CSV is unchanged

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import csv
+from typing import Optional, Tuple
 from tkinter import filedialog, messagebox, TclError
 from ftp_client import FTPClient
 
@@ -11,6 +12,11 @@ INVENTORY_CSV = os.getenv(
     "INVENTORY_CSV", os.getenv("WAREHOUSE_CSV", "magazyn.csv")
 )
 WAREHOUSE_CSV = os.getenv("WAREHOUSE_CSV", INVENTORY_CSV)
+
+# Track last modification time and cached statistics for the warehouse CSV
+WAREHOUSE_CSV_MTIME: Optional[float] = None
+_inventory_stats_cache: Optional[Tuple[int, float, int, float]] = None
+_inventory_stats_path: Optional[str] = None
 
 # column order for exported CSV files
 STORE_FIELDNAMES = [
@@ -45,7 +51,7 @@ WAREHOUSE_FIELDNAMES = [
 ]
 
 
-def get_inventory_stats(path: str = WAREHOUSE_CSV):
+def get_inventory_stats(path: str = WAREHOUSE_CSV, force: bool = False):
     """Return statistics for both unsold and sold items in the warehouse CSV.
 
     Parameters
@@ -66,8 +72,34 @@ def get_inventory_stats(path: str = WAREHOUSE_CSV):
     count_sold = 0
     total_sold = 0.0
 
+    global WAREHOUSE_CSV_MTIME, _inventory_stats_cache, _inventory_stats_path
+
+    # Determine current modification time if the file exists
+    try:
+        current_mtime = os.path.getmtime(path)
+    except OSError:
+        current_mtime = None
+
+    cache_valid = (
+        not force
+        and _inventory_stats_cache is not None
+        and _inventory_stats_path == path
+        and WAREHOUSE_CSV_MTIME == current_mtime
+    )
+
+    if cache_valid:
+        return _inventory_stats_cache
+
     if not os.path.exists(path):
-        return count_unsold, total_unsold, count_sold, total_sold
+        _inventory_stats_cache = (
+            count_unsold,
+            total_unsold,
+            count_sold,
+            total_sold,
+        )
+        _inventory_stats_path = path
+        WAREHOUSE_CSV_MTIME = current_mtime
+        return _inventory_stats_cache
 
     with open(path, encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
@@ -86,7 +118,15 @@ def get_inventory_stats(path: str = WAREHOUSE_CSV):
                 count_unsold += 1
                 total_unsold += price
 
-    return count_unsold, total_unsold, count_sold, total_sold
+    _inventory_stats_cache = (
+        count_unsold,
+        total_unsold,
+        count_sold,
+        total_sold,
+    )
+    _inventory_stats_path = path
+    WAREHOUSE_CSV_MTIME = current_mtime
+    return _inventory_stats_cache
 
 
 def format_store_row(row):

--- a/tests/test_inventory_stats_cache.py
+++ b/tests/test_inventory_stats_cache.py
@@ -1,0 +1,81 @@
+import builtins
+from pathlib import Path
+import os
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from kartoteka import csv_utils  # noqa: E402
+
+
+def _write_csv(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+
+
+def test_get_inventory_stats_cached(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    _write_csv(
+        csv_path,
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
+    )
+
+    first = csv_utils.get_inventory_stats(str(csv_path))
+
+    called = False
+    orig_open = builtins.open
+
+    def counting_open(*args, **kwargs):
+        nonlocal called
+        called = True
+        return orig_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+
+    second = csv_utils.get_inventory_stats(str(csv_path))
+    assert second == first
+    assert not called
+
+
+def test_get_inventory_stats_recomputes_on_change(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    _write_csv(
+        csv_path,
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
+    )
+
+    first = csv_utils.get_inventory_stats(str(csv_path))
+
+    mtime = os.path.getmtime(csv_path)
+    _write_csv(
+        csv_path,
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n" "B;2;S2;K2;5;img2\n",
+    )
+    os.utime(csv_path, (mtime + 1, mtime + 1))
+
+    second = csv_utils.get_inventory_stats(str(csv_path))
+    assert second != first
+    assert second == (2, pytest.approx(15.0), 0, pytest.approx(0.0))
+
+
+def test_get_inventory_stats_force(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    _write_csv(
+        csv_path,
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
+    )
+
+    csv_utils.get_inventory_stats(str(csv_path))
+
+    called = False
+    orig_open = builtins.open
+
+    def counting_open(*args, **kwargs):
+        nonlocal called
+        called = True
+        return orig_open(*args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", counting_open)
+
+    csv_utils.get_inventory_stats(str(csv_path), force=True)
+    assert called


### PR DESCRIPTION
## Summary
- track last modification time of the warehouse CSV
- reuse cached inventory statistics unless the file changes or recompute forced
- add tests covering cache use, recomputation on file change, and explicit force

## Testing
- `pytest`
- `pytest tests/test_inventory_stats_cache.py`


------
https://chatgpt.com/codex/tasks/task_e_689ddcc5275c832f96d4c9e5ab3c7f61