### PR TITLE
Add configurable warehouse status colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A small tkinter application for organizing Pokémon card scans and exporting dat
 - Display warehouse cards as rows of thumbnails, grey out sold items and move them to the end
 - Toggle a sold flag to exclude cards from occupancy statistics
 - Automatically updates the list of card sets and downloads new logos on startup
+- Customize warehouse status colors through environment variables
 
 ## Requirements
 Install dependencies from `requirements.txt`:
@@ -37,6 +38,15 @@ installed separately.  On Linux, the `opencv-python` wheel requires the
 ```bash
 sudo apt-get update && sudo apt-get install -y libgl1 libglib2.0-0
 ```
+
+## Environment variables
+
+The application reads optional environment variables (or values in the `.env` file)
+to customize warehouse colors:
+
+- `OCCUPIED_COLOR` – color for occupied capacity segments (default `#4caf50`)
+- `FREE_COLOR` – background for columns with ≥30% free capacity (default `#ff9800`)
+- `SOLD_COLOR` – text color for sold items (default `#888888`)
 
 If your version of `ttkbootstrap` is 1.10 or newer, the buttons will display built-in icons.
 On older versions the icons are skipped automatically.

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -222,6 +222,11 @@ HOVER_COLOR = "#525252"
 TEXT_COLOR = "#FFFFFF"
 BORDER_COLOR = "#444444"
 
+# status colors for warehouse items; can be overridden via environment variables
+OCCUPIED_COLOR = os.getenv("OCCUPIED_COLOR", "#4caf50")
+FREE_COLOR = os.getenv("FREE_COLOR", "#ff9800")
+SOLD_COLOR = os.getenv("SOLD_COLOR", "#888888")
+
 # Layout constants to simplify future adjustments
 BOX_THUMB_SIZE = 200  # increased square thumbnail size for warehouse boxes in pixels
 CARD_THUMB_SIZE = 128  # larger card thumbnails in the warehouse list
@@ -2508,7 +2513,7 @@ class CardEditorApp:
                 font = None
                 if is_sold:
                     text = f"[SOLD] {text}"
-                    color = "#888888"
+                    color = SOLD_COLOR
                     if hasattr(ctk, "CTkFont"):
                         font = ctk.CTkFont(size=20, overstrike=True)
                     else:
@@ -2590,9 +2595,9 @@ class CardEditorApp:
         legend_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
         legend_frame.pack(pady=(0, 10))
         legend_items = [
-            ("#ff9800", "≥30% free"),
-            ("#4caf50", "Occupied capacity segment"),
-            ("#888888", "Sold item"),
+            (FREE_COLOR, "≥30% free"),
+            (OCCUPIED_COLOR, "Occupied capacity segment"),
+            (SOLD_COLOR, "Sold item"),
         ]
         for color, desc in legend_items:
             swatch = ctk.CTkLabel(legend_frame, text="", width=15, height=15, fg_color=color)
@@ -2694,7 +2699,7 @@ class CardEditorApp:
                 x2 = x1 + col_w
                 x_mid = x1 + col_w / 2
                 free_percent = (col_capacity - filled) / col_capacity * 100
-                bg_fill = "#ff9800" if free_percent >= 30 else ""
+                bg_fill = FREE_COLOR if free_percent >= 30 else ""
 
                 items = canvas_items.get(c)
                 seg_h = box_h / seg_count
@@ -2706,7 +2711,7 @@ class CardEditorApp:
                     for i in range(seg_count):
                         y1 = box_h - seg_h * (i + 1)
                         y2 = box_h - seg_h * i
-                        color = "#4caf50" if i < filled_sections else ""
+                        color = OCCUPIED_COLOR if i < filled_sections else ""
                         seg_id = canvas.create_rectangle(
                             x1,
                             y1,
@@ -2755,7 +2760,7 @@ class CardEditorApp:
                         y1 = box_h - seg_h * (i + 1)
                         y2 = box_h - seg_h * i
                         canvas.coords(seg_id, x1, y1, x2, y2)
-                        color = "#4caf50" if i < filled_sections else ""
+                        color = OCCUPIED_COLOR if i < filled_sections else ""
                         canvas.itemconfigure(seg_id, fill=color)
                     items["segments"] = segments
                     items["seg_count"] = seg_count

--- a/tests/test_color_overrides.py
+++ b/tests/test_color_overrides.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def test_color_env_override(monkeypatch):
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    monkeypatch.setitem(sys.modules, "customtkinter", SimpleNamespace())
+    import kartoteka.ui as ui
+    monkeypatch.setenv("SOLD_COLOR", "#123456")
+    importlib.reload(ui)
+    assert ui.SOLD_COLOR == "#123456"
+    monkeypatch.delenv("SOLD_COLOR", raising=False)
+    importlib.reload(ui)
+    assert ui.SOLD_COLOR == "#888888"

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -74,7 +74,7 @@ def test_sold_cards_styled(tmp_path):
     assert len(app.mag_sold_labels) == 1
     sold_label = _extract_label(app.mag_sold_labels[0])
     assert sold_label.text.startswith("[SOLD]")
-    assert sold_label.text_color == "#888888"
+    assert sold_label.text_color == ui.SOLD_COLOR
     font = sold_label.font
     assert getattr(font, "overstrike", False) or (
         isinstance(font, tuple) and "overstrike" in font


### PR DESCRIPTION
## Summary
- centralize sold, free, and occupied colors in `ui.py`
- allow overriding these colors via environment variables
- document color environment variables and add tests for overrides

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ddff82d5c832fac3ee05a0d235a64