### PR TITLE
Expand warehouse layout to ten cartons

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,12 @@ previously scattered magic numbers for thumbnail sizes, grid columns, and box
 capacities, making future tweaks much simpler.
 
 - `GRID_COLUMNS` – number of columns per box (default **4**)
+- `WAREHOUSE_GRID_COLUMNS` – number of columns in the warehouse grid (default **5**)
 - `BOX_COLUMN_CAPACITY` – slots per column (default **1000**)
-- `BOX_COUNT` – number of standard boxes (default **8**)
+- `BOX_COUNT` – number of standard boxes (default **10**)
 - `SPECIAL_BOX_NUMBER` – overflow box identifier (default **100**)
 - `SPECIAL_BOX_CAPACITY` – slots in the overflow box (default **500**)
-- `BOX_THUMB_SIZE` – pixel size of box thumbnails
+- `BOX_THUMB_SIZE` – pixel size of box thumbnails (default **128**)
 - `CARD_THUMB_SIZE` – pixel size of card thumbnails
 - `BOX_CAPACITY` – total slots per standard box (`GRID_COLUMNS * BOX_COLUMN_CAPACITY`)
 

--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -8,13 +8,14 @@ LAST_SETS_CHECK_FILE = "last_sets_check.txt"
 
 # Total card capacity per storage box.  Standard boxes hold 4000 cards in
 # four columns, while the special box ``100`` is a single 500-card column.
-BOX_CAPACITY: dict[int, int] = {**{b: 4000 for b in range(1, 9)}, 100: 500}
+BOX_COUNT = 10  # number of standard boxes
+BOX_CAPACITY: dict[int, int] = {**{b: 4000 for b in range(1, BOX_COUNT + 1)}, 100: 500}
 
-# Number of columns per storage box.  All regular boxes (1-8) have four
+# Number of columns per storage box.  All regular boxes (1-10) have four
 # columns, while the overflow box ``100`` only one.  The mapping is kept
 # explicit so the column layout can be adjusted independently of
 # :data:`BOX_CAPACITY`.
-BOX_COLUMNS: dict[int, int] = {**{b: 4 for b in range(1, 9)}, 100: 1}
+BOX_COLUMNS: dict[int, int] = {**{b: 4 for b in range(1, BOX_COUNT + 1)}, 100: 1}
 
 # Default per-column capacity for standard boxes.  Used as a fallback when
 # handling boxes outside of :data:`BOX_CAPACITY`.
@@ -63,18 +64,18 @@ def location_from_code(code: str) -> str:
 def generate_location(idx):
     """Return a warehouse code for a sequential slot index.
 
-    The first 32 000 indices map to boxes 1-8 (four 1000-card columns each).
+    The first 40 000 indices map to boxes 1-10 (four 1000-card columns each).
     Subsequent indices map to the special box 100 which has a single
     500-card column.
     """
 
-    if idx < 8 * 4000:
+    if idx < BOX_COUNT * 4000:
         pos = idx % 1000 + 1
         column = (idx // 1000) % 4 + 1
         box = (idx // 4000) + 1
         return f"K{box:02d}R{column}P{pos:04d}"
 
-    idx -= 8 * 4000
+    idx -= BOX_COUNT * 4000
     if idx < 500:
         # box 100, only one column
         pos = idx + 1
@@ -97,7 +98,7 @@ def next_free_location(app):
             column = int(match.group(2))
             pos = int(match.group(3))
             if box == 100:
-                idx = 8 * 4000 + (pos - 1)
+                idx = BOX_COUNT * 4000 + (pos - 1)
             else:
                 idx = (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
             used.add(idx)

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -228,11 +228,12 @@ FREE_COLOR = os.getenv("FREE_COLOR", "#ff9800")
 SOLD_COLOR = os.getenv("SOLD_COLOR", "#888888")
 
 # Layout constants to simplify future adjustments
-BOX_THUMB_SIZE = 200  # increased square thumbnail size for warehouse boxes in pixels
+BOX_THUMB_SIZE = 128  # square thumbnail size for warehouse boxes in pixels
 CARD_THUMB_SIZE = 128  # larger card thumbnails in the warehouse list
-GRID_COLUMNS = 4  # number of columns in warehouse grid and per storage box
+GRID_COLUMNS = 4  # number of columns per storage box
+WAREHOUSE_GRID_COLUMNS = 5  # number of columns in the warehouse grid
 BOX_COLUMN_CAPACITY = 1000  # slots per column in a regular box
-BOX_COUNT = 8  # number of standard boxes
+BOX_COUNT = 10  # number of standard boxes
 SPECIAL_BOX_NUMBER = 100  # identifier for the large overflow box
 SPECIAL_BOX_CAPACITY = 500  # slots in the special box
 BOX_CAPACITY = GRID_COLUMNS * BOX_COLUMN_CAPACITY  # slots in a standard box
@@ -2376,11 +2377,8 @@ class CardEditorApp:
         container = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
         container.pack(padx=10, pady=10)
 
-        # Order boxes so that the grid layout is:
-        # row0 -> K1 K2 K5 K6
-        # row1 -> K3 K4 K7 K8
-        # row2 -> K100
-        self.mag_box_order = [1, 2, 5, 6, 3, 4, 7, BOX_COUNT, SPECIAL_BOX_NUMBER]
+        # Display cartons in numerical order and place the special overflow box last
+        self.mag_box_order = list(range(1, BOX_COUNT + 1)) + [SPECIAL_BOX_NUMBER]
         self.mag_canvases = []
         self.mag_labels = []
         for i, box_num in enumerate(self.mag_box_order):
@@ -2409,7 +2407,10 @@ class CardEditorApp:
                 photo = photo_obj
             canvas.create_image(0, 0, image=photo, anchor="nw")
             canvas.pack()
-            frame.grid(row=i // GRID_COLUMNS, column=i % GRID_COLUMNS, padx=5, pady=5)
+            row, col = divmod(i, WAREHOUSE_GRID_COLUMNS)
+            if box_num == SPECIAL_BOX_NUMBER:
+                col = WAREHOUSE_GRID_COLUMNS // 2
+            frame.grid(row=row, column=col, padx=5, pady=5)
             self.mag_canvases.append(canvas)
             self.mag_labels.append(lbl)
 

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -28,7 +28,7 @@ def test_compute_column_occupancy_box100(tmp_path, monkeypatch):
 def test_generate_and_next_free_location_box100():
     from kartoteka import storage
 
-    idx = 8 * 4000
+    idx = storage.BOX_COUNT * storage.BOX_CAPACITY[1]
     assert storage.generate_location(idx) == "K100R1P0001"
 
     app = SimpleNamespace(output_data=[{"warehouse_code": "K100R1P0001"}], starting_idx=idx)

--- a/tests/test_next_free_location.py
+++ b/tests/test_next_free_location.py
@@ -87,7 +87,7 @@ def test_browse_scans_box100(monkeypatch, tmp_path):
 
     ui.CardEditorApp.browse_scans(dummy)
 
-    expected = 8 * 4000 + 4
+    expected = ui.BOX_COUNT * ui.BOX_CAPACITY + 4
     assert dummy.starting_idx == expected
     assert ui.CardEditorApp.next_free_location(dummy) == "K100R1P0005"
 
@@ -115,6 +115,6 @@ def test_browse_scans_sets_starting_idx_for_box100(monkeypatch, tmp_path):
 
     ui.CardEditorApp.browse_scans(dummy)
 
-    assert dummy.starting_idx == 8 * 4000 + 4
+    assert dummy.starting_idx == ui.BOX_COUNT * ui.BOX_CAPACITY + 4
     assert ui.CardEditorApp.next_free_location(dummy) == "K100R1P0005"
 


### PR DESCRIPTION
## Summary
- shrink warehouse box thumbnails and allow ten standard cartons
- add WAREHOUSE_GRID_COLUMNS for warehouse grid and center special box
- update storage utilities and tests for increased carton count

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e31899d50832fba198a348280bd9c