### PR TITLE
Update magazyn window title

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2334,6 +2334,7 @@ class CardEditorApp:
 
     def open_magazyn_window(self):
         """Display storage occupancy inside the main window."""
+        self.root.title("Podgląd magazynu")
         if self.start_frame is not None:
             self.start_frame.destroy()
             self.start_frame = None

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -55,7 +55,10 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(
         ui.tk, "Canvas", DummyCanvas
     ):
-        dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        dummy_root = SimpleNamespace(
+            minsize=lambda *a, **k: None,
+            title=lambda *a, **k: None,
+        )
         app = SimpleNamespace(
             root=dummy_root,
             start_frame=None,

--- a/tests/test_magazyn_inventory_stats_view.py
+++ b/tests/test_magazyn_inventory_stats_view.py
@@ -43,7 +43,10 @@ def test_inventory_stats_display_and_update(tmp_path, monkeypatch):
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(
         ui.tk, "Canvas", DummyCanvas
     ):
-        dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        dummy_root = SimpleNamespace(
+            minsize=lambda *a, **k: None,
+            title=lambda *a, **k: None,
+        )
         app = SimpleNamespace(
             root=dummy_root,
             start_frame=None,

--- a/tests/test_magazyn_label_colors.py
+++ b/tests/test_magazyn_label_colors.py
@@ -91,7 +91,10 @@ def test_magazyn_label_colors():
 
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
          patch.object(ui.tk, "Canvas", DummyCanvas):
-        dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        dummy_root = SimpleNamespace(
+            minsize=lambda *a, **k: None,
+            title=lambda *a, **k: None,
+        )
         app = SimpleNamespace(
             root=dummy_root,
             start_frame=None,

--- a/tests/test_magazyn_show_card_details.py
+++ b/tests/test_magazyn_show_card_details.py
@@ -136,7 +136,10 @@ def test_show_card_details_receives_row(tmp_path):
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
          patch.object(ui.tk, "Canvas", DummyCanvas), \
          patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
-        dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        dummy_root = SimpleNamespace(
+            minsize=lambda *a, **k: None,
+            title=lambda *a, **k: None,
+        )
         captured = {}
 
         def fake_show(row):

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -54,7 +54,10 @@ def test_sold_cards_styled(tmp_path):
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
          patch.object(ui.tk, "Canvas", DummyCanvas), \
          patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
-        dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+        dummy_root = SimpleNamespace(
+            minsize=lambda *a, **k: None,
+            title=lambda *a, **k: None,
+        )
         app = SimpleNamespace(
             root=dummy_root,
             start_frame=None,

--- a/tests/test_remote_image_loading.py
+++ b/tests/test_remote_image_loading.py
@@ -141,7 +141,10 @@ def test_open_magazyn_window_remote_thumbnail(tmp_path):
     placeholder_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
     photo_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
 
-    dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+    dummy_root = SimpleNamespace(
+        minsize=lambda *a, **k: None,
+        title=lambda *a, **k: None,
+    )
 
     app = SimpleNamespace(
         root=dummy_root,
@@ -185,7 +188,10 @@ def test_show_card_details_remote_uses_cache(tmp_path):
 
     photo_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
 
-    dummy_root = SimpleNamespace(minsize=lambda *a, **k: None)
+    dummy_root = SimpleNamespace(
+        minsize=lambda *a, **k: None,
+        title=lambda *a, **k: None,
+    )
 
     app = SimpleNamespace(
         root=dummy_root,


### PR DESCRIPTION
## Summary
- Set the main window title to "Podgląd magazynu" when opening magazyn view
- Update tests with dummy `title` methods on stubbed root objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e36d50fb0832f86b1b17ea8224a9a