### PR TITLE
Use box100 dimensions for special canvas

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2408,10 +2408,14 @@ class CardEditorApp:
                 fg_color=BG_COLOR,
                 text_color=TEXT_COLOR,
             )
+            if box_num == SPECIAL_BOX_NUMBER:
+                canvas_w, canvas_h = img100.size
+            else:
+                canvas_w, canvas_h = box_w, box_h
             canvas = tk.Canvas(
                 frame,
-                width=box_w,
-                height=box_h,
+                width=canvas_w,
+                height=canvas_h,
                 highlightthickness=0,
             )
             canvas.config(bg=BG_COLOR)


### PR DESCRIPTION
## Summary
- Load and use box100.png dimensions for the special warehouse box
- Size box 100 canvas to its image to keep grid layout correct

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e49bf34a0832fb5b7a88b84b153d4