### PR TITLE
Persist card variant flags and test warehouse export

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4941,9 +4941,9 @@ class CardEditorApp:
         set_name = data.get("set")
         if not data["psa10_price"]:
             data["psa10_price"] = self.fetch_psa10_price(name, number, set_name)
-        data["typ"] = ",".join(
-            [name for name, var in self.type_vars.items() if var.get()]
-        )
+        types = {name: var.get() for name, var in self.type_vars.items()}
+        data["typ"] = ",".join([name for name, selected in types.items() if selected])
+        data["types"] = types
         fp = getattr(self, "current_fingerprint", None)
         if (
             fp is None
@@ -4970,7 +4970,7 @@ class CardEditorApp:
         data["ilość"] = 1
         self.card_cache[key] = {
             "entries": {k: v for k, v in data.items()},
-            "types": {name: var.get() for name, var in self.type_vars.items()},
+            "types": types,
         }
 
         front_path = self.cards[self.index]

--- a/tests/test_append_warehouse_csv.py
+++ b/tests/test_append_warehouse_csv.py
@@ -32,3 +32,26 @@ def test_append_warehouse_csv_updates_stats(tmp_path):
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
         assert rows[0]["warehouse_code"] == "K1"
+
+
+def test_append_warehouse_csv_writes_variant(tmp_path):
+    path = tmp_path / "magazyn.csv"
+    app = SimpleNamespace(
+        output_data=[
+            {
+                "name": "A",
+                "number": "1",
+                "set": "S",
+                "warehouse_code": "K1",
+                "price": "2",
+                "image": "",
+                "types": {"Holo": True, "Reverse": False},
+            }
+        ],
+        update_inventory_stats=MagicMock(),
+    )
+    csv_utils.append_warehouse_csv(app, path=str(path))
+    with open(path, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        row = next(reader)
+        assert row["variant"] == "holo"

--- a/tests/test_variant_flags.py
+++ b/tests/test_variant_flags.py
@@ -1,0 +1,93 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+
+def test_save_and_reload_variant_flags(tmp_path):
+    class DummyVar:
+        def __init__(self, value=""):
+            self.value = value
+        def get(self):
+            return self.value
+        def set(self, v):
+            self.value = v
+        def focus_set(self):
+            pass
+    class DummyEntry:
+        def __init__(self, *a, **k):
+            self.value = ""
+        def delete(self, *a, **k):
+            self.value = ""
+        def insert(self, *a, **k):
+            self.value = a[1] if len(a) > 1 else ""
+    tk_mod = ModuleType("tkinter")
+    tk_mod.StringVar = DummyVar
+    tk_mod.BooleanVar = DummyVar
+    tk_mod.Entry = DummyEntry
+    tk_mod.END = "end"
+    tk_mod.TclError = Exception
+    tk_mod.filedialog = MagicMock()
+    tk_mod.messagebox = MagicMock()
+    tk_mod.simpledialog = MagicMock()
+    ttk_mod = ModuleType("tkinter.ttk")
+    ctk_mod = ModuleType("customtkinter")
+    class DummyCTkEntry:  # pragma: no cover - only for isinstance checks
+        pass
+    ctk_mod.CTkEntry = DummyCTkEntry
+    img_path = tmp_path / "card.jpg"
+    Image.new("RGB", (10, 10), "white").save(img_path)
+    with patch.dict(sys.modules, {"tkinter": tk_mod, "tkinter.ttk": ttk_mod, "customtkinter": ctk_mod}):
+        sys.path.append(str(Path(__file__).resolve().parents[1]))
+        import kartoteka.ui as ui
+        importlib.reload(ui)
+        dummy = SimpleNamespace(
+            entries={
+                "nazwa": DummyVar("Charizard"),
+                "numer": DummyVar("4"),
+                "set": DummyVar("Base Set"),
+                "język": DummyVar("ENG"),
+                "stan": DummyVar("NM"),
+                "cena": DummyVar(""),
+                "psa10_price": DummyVar(""),
+            },
+            type_vars={"Reverse": DummyVar(True), "Holo": DummyVar(False)},
+            card_cache={},
+            cards=[str(img_path)],
+            index=0,
+            folder_name="folder",
+            file_to_key={},
+            product_code_map={},
+            next_product_code=1,
+            next_free_location=lambda: "K1R1P1",
+            generate_location=lambda idx: "K1R1P1",
+            output_data=[None],
+            get_price_from_db=lambda *a: None,
+            fetch_card_price=lambda *a: None,
+            fetch_psa10_price=lambda *a: "0",
+            progress_var=SimpleNamespace(set=lambda s: None),
+            image_label=SimpleNamespace(configure=lambda **kw: None),
+            update_set_options=lambda: None,
+            lookup_inventory_entry=lambda key: None,
+            failed_cards=[],
+            image_objects=[],
+            _analyze_and_fill=lambda *a, **k: None,
+            auto_lookup=False,
+            hash_db=None,
+        )
+        with patch.object(ui.ImageTk, "PhotoImage", return_value=SimpleNamespace()), \
+             patch.object(ui.threading, "Thread", lambda *a, **k: SimpleNamespace(start=lambda: None)):
+            ui.CardEditorApp.save_current_data(dummy)
+            row = dummy.output_data[0]
+            assert row["types"] == {"Reverse": True, "Holo": False}
+            dummy.type_vars["Reverse"].set(False)
+            dummy.type_vars["Holo"].set(False)
+            key = "Charizard|4|Base Set"
+            dummy.file_to_key[os.path.basename(str(img_path))] = key
+            ui.CardEditorApp.show_card(dummy)
+            assert dummy.type_vars["Reverse"].get() is True
+            assert dummy.type_vars["Holo"].get() is False


### PR DESCRIPTION
## Summary
- capture checkbox selections for each card into `row['types']`
- verify `append_warehouse_csv` writes variant column
- test saving and reloading of variant flags

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e4af2b91c832f9bd887851594eda9