### PR TITLE
Run startup tasks via Tkinter event loop

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1338,7 +1338,7 @@ class CardEditorApp:
         self.in_scan = False
         self.current_image_path = ""
         self.show_loading_screen()
-        threading.Thread(target=self.startup_tasks, daemon=True).start()
+        self.root.after(0, self.startup_tasks)
 
     def setup_welcome_screen(self):
         """Display a simple welcome screen before loading scans."""
@@ -4246,14 +4246,23 @@ class CardEditorApp:
         self.gif_label.after(delay, self.animate_loading_gif, next_index)
 
     def startup_tasks(self):
-        """Run initial setup tasks in the background."""
+        """Run initial setup tasks on the main thread."""
         last_check = storage.load_last_sets_check()
         now = datetime.datetime.now()
+
+        def continue_startup():
+            self.load_set_logos()
+            self.finish_startup()
+
         if not last_check or last_check.year != now.year or last_check.month != now.month:
-            self.update_sets()
-            storage.save_last_sets_check(now)
-        self.root.after(0, self.load_set_logos)
-        self.root.after(1, self.finish_startup)
+            def run_updates():
+                self.update_sets()
+                storage.save_last_sets_check(now)
+                self.root.after(0, continue_startup)
+
+            self.root.after(0, run_updates)
+        else:
+            self.root.after(0, continue_startup)
 
     def finish_startup(self):
         """Finalize initialization after background tasks complete."""

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -111,11 +111,12 @@ def test_product_code_persists_between_sessions(tmp_path):
             title=lambda *a, **k: None,
             configure=lambda *a, **k: None,
             option_add=lambda *a, **k: None,
+            after=lambda delay, func, *args: func(*args),
         )
 
         with patch.object(ui.CardEditorApp, "load_price_db", lambda self: {}), \
              patch.object(ui.CardEditorApp, "show_loading_screen", lambda self: None), \
-             patch.object(ui.threading, "Thread", lambda *a, **k: SimpleNamespace(start=lambda: None)), \
+             patch.object(ui.CardEditorApp, "startup_tasks", lambda self: None), \
              patch("kartoteka.ui.tk.StringVar", lambda *a, **k: DummyVar(k.get("value", ""))):
             app = ui.CardEditorApp(root)
 

--- a/tests/test_sets_file.py
+++ b/tests/test_sets_file.py
@@ -88,7 +88,7 @@ def test_update_sets_jp(tmp_path):
 def test_startup_tasks_skips_when_same_month():
     now = datetime.datetime.now()
     dummy = SimpleNamespace(
-        root=SimpleNamespace(after=lambda *a, **k: None),
+        root=SimpleNamespace(after=lambda delay, func, *args: func(*args)),
         load_set_logos=lambda: None,
         finish_startup=lambda: None,
         update_sets=MagicMock(),
@@ -105,7 +105,7 @@ def test_startup_tasks_runs_when_old_month():
     now = datetime.datetime.now()
     prev_month = now.replace(day=1) - datetime.timedelta(days=1)
     dummy = SimpleNamespace(
-        root=SimpleNamespace(after=lambda *a, **k: None),
+        root=SimpleNamespace(after=lambda delay, func, *args: func(*args)),
         load_set_logos=lambda: None,
         finish_startup=lambda: None,
         update_sets=MagicMock(),


### PR DESCRIPTION
## Summary
- Schedule `CardEditorApp` startup tasks using `root.after` instead of spawning a thread
- Chain `update_sets`, logo loading and startup completion through the Tk event loop
- Adjust tests to execute callbacks scheduled with `after`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e93c5074832fbc72736fdf4faba0