### PR TITLE
Convert set logos to RGBA for Tkinter compatibility

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4182,6 +4182,7 @@ class CardEditorApp:
                 continue
             try:
                 img = Image.open(path)
+                img = img.convert("RGBA")
                 img.thumbnail((40, 40))
                 self.set_logos[code] = _create_image(img)
             except Exception:


### PR DESCRIPTION
## Summary
- Convert set logo images to RGBA before thumbnailing to ensure proper handling by Tkinter and Pillow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a74ce8b880832fb4dffaa36e1f8f6a