### PR TITLE
Ensure images are created in main thread

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2548,9 +2548,9 @@ class CardEditorApp:
                             if img is None:
                                 return
                             img = _resize_to_width(img, thumb_size)
-                            photo = _create_image(img)
 
-                            def _update() -> None:
+                            def _update(img=img) -> None:
+                                photo = _create_image(img)
                                 self.mag_card_images[i] = photo
                                 lbl = self.mag_card_image_labels[i]
                                 if lbl is not None:


### PR DESCRIPTION
## Summary
- Defer PhotoImage/CTkImage creation to the main thread via `root.after`
- Load and resize images in background worker threads only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74ff7daac832faea3258f8b64745b