### PR TITLE
Add FTP download for warehouse CSV

### DIFF
--- a/ftp_client.py
+++ b/ftp_client.py
@@ -38,6 +38,17 @@ class FTPClient:
         except all_errors as exc:  # pragma: no cover - network failure
             raise RuntimeError(f"FTP upload failed: {exc}") from exc
 
+    def download_file(self, remote_path, local_path=None):
+        """Download a single file from the FTP server."""
+        if self.ftp is None:
+            self.connect()
+        local_path = local_path or os.path.basename(remote_path)
+        try:
+            with open(local_path, "wb") as fh:
+                self.ftp.retrbinary(f"RETR {remote_path}", fh.write)
+        except all_errors as exc:  # pragma: no cover - network failure
+            raise RuntimeError(f"FTP download failed: {exc}") from exc
+
     def upload_directory(self, directory, remote_dir="."):
         """Upload all files from ``directory`` to ``remote_dir``."""
         if self.ftp is None:

--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -52,6 +52,15 @@ WAREHOUSE_FIELDNAMES = [
 ]
 
 
+def download_warehouse_csv():
+    """Download the warehouse CSV from the FTP server."""
+    try:
+        with FTPClient(FTP_HOST, FTP_USER, FTP_PASSWORD) as ftp:
+            ftp.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
+    except Exception:  # pragma: no cover - network failure
+        pass
+
+
 def get_inventory_stats(path: str = WAREHOUSE_CSV, force: bool = False):
     """Return statistics for both unsold and sold items in the warehouse CSV.
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4270,6 +4270,7 @@ class CardEditorApp:
             self.loading_frame.destroy()
         self.shoper_client = None
         self.ensure_shoper_client()
+        csv_utils.download_warehouse_csv()
         self.setup_welcome_screen()
 
     def ensure_shoper_client(self):

--- a/tests/test_download_warehouse_csv.py
+++ b/tests/test_download_warehouse_csv.py
@@ -1,0 +1,30 @@
+from kartoteka import csv_utils
+
+
+def test_download_warehouse_csv(monkeypatch, tmp_path):
+    called = {}
+
+    class DummyFTPClient:
+        def __init__(self, host, user, password):
+            called["init"] = (host, user, password)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def download_file(self, remote_path, local_path=None):
+            called["args"] = (remote_path, local_path)
+
+    monkeypatch.setattr(csv_utils, "FTPClient", DummyFTPClient)
+    monkeypatch.setattr(csv_utils, "FTP_HOST", "h")
+    monkeypatch.setattr(csv_utils, "FTP_USER", "u")
+    monkeypatch.setattr(csv_utils, "FTP_PASSWORD", "p")
+    path = tmp_path / "mag.csv"
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
+
+    csv_utils.download_warehouse_csv()
+
+    assert called["init"] == ("h", "u", "p")
+    assert called["args"] == (str(path), str(path))

--- a/tests/test_ftp_download.py
+++ b/tests/test_ftp_download.py
@@ -1,0 +1,42 @@
+from ftp_client import FTPClient
+
+
+def test_download_file(tmp_path):
+    data = b"hello"
+
+    class DummyFTP:
+        def __init__(self):
+            self.commands = []
+
+        def retrbinary(self, cmd, callback):
+            self.commands.append(cmd)
+            callback(data)
+
+    client = FTPClient("h", "u", "p")
+    client.ftp = DummyFTP()
+    dest = tmp_path / "local.txt"
+    client.download_file("remote.txt", str(dest))
+    assert dest.read_bytes() == data
+    assert client.ftp.commands == ["RETR remote.txt"]
+
+
+def test_download_file_connects(monkeypatch, tmp_path):
+    payload = b"data"
+
+    class DummyFTP:
+        def retrbinary(self, cmd, callback):
+            callback(payload)
+
+    connected = False
+
+    def fake_connect(self):
+        nonlocal connected
+        connected = True
+        self.ftp = DummyFTP()
+
+    monkeypatch.setattr(FTPClient, "connect", fake_connect)
+    client = FTPClient("h", "u", "p")
+    dest = tmp_path / "file.txt"
+    client.download_file("remote.bin", str(dest))
+    assert connected
+    assert dest.read_bytes() == payload


### PR DESCRIPTION
## Summary
- extend FTPClient with `download_file` using `retrbinary`
- implement `download_warehouse_csv` utility and invoke during app startup
- add tests for FTP downloads and warehouse CSV retrieval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2c46634ec832fb66912fadf84e621