### PR TITLE
Replace FTP with WebDAV for CSV and image transfers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,8 +4,8 @@ SHOPER_API_URL=https://your-store.shop/webapi/rest
 SHOPER_API_TOKEN=your-token
 # API key for OpenAI (required for card text recognition via Vision)
 OPENAI_API_KEY=
-FTP_HOST=example.com
-FTP_USER=username
-FTP_PASSWORD=secret
+WEBDAV_URL=https://example.com/webdav
+WEBDAV_USER=username
+WEBDAV_PASSWORD=secret
 INVENTORY_CSV=magazyn.csv
 HASH_DB_FILE=hashes.sqlite

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pytest tests/test_fingerprint_db.py
 ```
 
 ## Configuration (.env variables)
-Create a `.env` file with API credentials and optional FTP settings:
+Create a `.env` file with API credentials and optional WebDAV settings:
 
 ```bash
 RAPIDAPI_KEY=your-key-here
@@ -122,9 +122,9 @@ RAPIDAPI_HOST=pokemon-tcg-api.p.rapidapi.com
 SHOPER_API_URL=https://your-store.shop/webapi/rest
 SHOPER_API_TOKEN=your-token
 OPENAI_API_KEY=sk-...
-FTP_HOST=example.com
-FTP_USER=username
-FTP_PASSWORD=secret
+WEBDAV_URL=https://example.com/webdav
+WEBDAV_USER=username
+WEBDAV_PASSWORD=secret
 WAREHOUSE_CSV=magazyn.csv
 BASE_IMAGE_URL=https://your-store.shop/upload/images
 HASH_DB_FILE=hashes.sqlite
@@ -137,7 +137,7 @@ HASH_DB_FILE=hashes.sqlite
 **Warning:** This file may contain private API keys and tokens. It is excluded
 from version control via `.gitignore` and should never be shared publicly.
 
-The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `FTP_HOST`, `FTP_USER` and `FTP_PASSWORD` configure optional FTP uploads. `OPENAI_API_KEY` supplies the key for OpenAI Vision to recognise card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
+The `RAPIDAPI_*` variables are used when a card price is not found in the local database. `SHOPER_API_URL` and `SHOPER_API_TOKEN` configure access to your Shoper store for the **Porządkuj** window. The application expects the `/webapi/rest` endpoint and will append it automatically if it is missing. `WEBDAV_URL`, `WEBDAV_USER` and `WEBDAV_PASSWORD` configure optional WebDAV uploads. `OPENAI_API_KEY` supplies the key for OpenAI Vision to recognise card details from scans. `BASE_IMAGE_URL` should point to the public directory where scans are uploaded so OpenAI can fetch them during analysis and the exported CSV contains correct links. Leading or trailing spaces in `SHOPER_API_URL` and `SHOPER_API_TOKEN` are ignored.
 `WAREHOUSE_CSV` controls where the local warehouse CSV is written.
 
 ## Warehouse Layout
@@ -254,7 +254,7 @@ empty. Missing bidding step and duration values default to `1` and `60` seconds
 respectively.
 
 ### CSV and image upload
-After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to FTP using the credentials from `.env`. A copy of every row is also appended to the file specified in `WAREHOUSE_CSV` so the full stock list remains in one place. Use the **FTP Obrazy** button on the welcome screen to upload a folder of images to the configured FTP server.
+After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to WebDAV using the credentials from `.env`. A copy of every row is also appended to the file specified in `WAREHOUSE_CSV` so the full stock list remains in one place. Use the **WebDAV Obrazy** button on the welcome screen to upload a folder of images to the configured WebDAV server.
 
 ## License
 This project is licensed under the terms of the [MIT License](LICENSE).

--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -3,11 +3,7 @@ import re
 import csv
 from typing import Optional, Tuple
 from tkinter import filedialog, messagebox, TclError
-from ftp_client import FTPClient
-
-FTP_HOST = os.getenv("FTP_HOST")
-FTP_USER = os.getenv("FTP_USER")
-FTP_PASSWORD = os.getenv("FTP_PASSWORD")
+from webdav_client import WebDAVClient
 INVENTORY_CSV = os.getenv(
     "INVENTORY_CSV", os.getenv("WAREHOUSE_CSV", "magazyn.csv")
 )
@@ -53,10 +49,10 @@ WAREHOUSE_FIELDNAMES = [
 
 
 def download_warehouse_csv():
-    """Download the warehouse CSV from the FTP server."""
+    """Download the warehouse CSV from the WebDAV server."""
     try:
-        with FTPClient(FTP_HOST, FTP_USER, FTP_PASSWORD) as ftp:
-            ftp.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
+        with WebDAVClient() as client:
+            client.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
     except Exception:  # pragma: no cover - network failure
         pass
 
@@ -348,7 +344,7 @@ def append_warehouse_csv(app, path: str = WAREHOUSE_CSV):
 
 
 def send_csv_to_shoper(app, file_path: str):
-    """Send a CSV file using the Shoper API or FTP fallback."""
+    """Send a CSV file using the Shoper API or WebDAV fallback."""
     try:
         if getattr(app, "shoper_client", None):
             result = app.shoper_client.import_csv(file_path)
@@ -361,8 +357,12 @@ def send_csv_to_shoper(app, file_path: str):
             else:
                 messagebox.showinfo("Sukces", f"Import zakończony: {status}")
         else:
-            with FTPClient(app.FTP_HOST, app.FTP_USER, app.FTP_PASSWORD) as ftp:
-                ftp.upload_file(file_path)
+            with WebDAVClient(
+                getattr(app, "WEBDAV_URL", None),
+                getattr(app, "WEBDAV_USER", None),
+                getattr(app, "WEBDAV_PASSWORD", None),
+            ) as client:
+                client.upload_file(file_path)
             messagebox.showinfo("Sukces", "Plik CSV został wysłany.")
     except Exception as exc:  # pragma: no cover - network failure
         messagebox.showerror("Błąd", f"Nie udało się wysłać pliku: {exc}")

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -28,7 +28,7 @@ import pytesseract
 from pathlib import Path
 
 from shoper_client import ShoperClient
-from ftp_client import FTPClient
+from webdav_client import WebDAVClient
 from . import csv_utils, storage
 import threading
 from urllib.parse import urlencode, urlparse
@@ -56,9 +56,9 @@ RAPIDAPI_HOST = os.getenv("RAPIDAPI_HOST")
 
 SHOPER_API_URL = os.getenv("SHOPER_API_URL", "").strip()
 SHOPER_API_TOKEN = os.getenv("SHOPER_API_TOKEN", "").strip()
-FTP_HOST = os.getenv("FTP_HOST")
-FTP_USER = os.getenv("FTP_USER")
-FTP_PASSWORD = os.getenv("FTP_PASSWORD")
+WEBDAV_URL = os.getenv("WEBDAV_URL")
+WEBDAV_USER = os.getenv("WEBDAV_USER")
+WEBDAV_PASSWORD = os.getenv("WEBDAV_PASSWORD")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 if OPENAI_API_KEY:
     openai.api_key = OPENAI_API_KEY
@@ -1445,7 +1445,7 @@ class CardEditorApp:
         ).pack(side="left", padx=10, pady=5)
         self.create_button(
             button_frame,
-            text="\U0001f4f7 FTP Obrazy",
+            text="\U0001f4f7 WebDAV Obrazy",
             command=self.upload_images_dialog,
             fg_color="#474747",
         ).pack(side="left", padx=10, pady=5)
@@ -5206,25 +5206,27 @@ class CardEditorApp:
         self.root.wait_window(top)
 
     def upload_images_dialog(self):
-        """Upload images from a selected directory via FTP."""
+        """Upload images from a selected directory via WebDAV."""
         directory = filedialog.askdirectory()
         if not directory:
             return
-        host = simpledialog.askstring("FTP", "Serwer", initialvalue=FTP_HOST or "")
-        user = simpledialog.askstring("FTP", "Użytkownik", initialvalue=FTP_USER or "")
-        password = simpledialog.askstring("FTP", "Hasło", show="*", initialvalue=FTP_PASSWORD or "")
-        if not host or not user or not password:
+        url = simpledialog.askstring("WebDAV", "URL", initialvalue=WEBDAV_URL or "")
+        user = simpledialog.askstring("WebDAV", "Użytkownik", initialvalue=WEBDAV_USER or "")
+        password = simpledialog.askstring(
+            "WebDAV", "Hasło", show="*", initialvalue=WEBDAV_PASSWORD or ""
+        )
+        if not url or not user or not password:
             messagebox.showerror("Błąd", "Nie podano pełnych danych logowania")
             return
         try:
-            with FTPClient(host, user, password) as ftp:
-                ftp.upload_directory(directory)
-            messagebox.showinfo("Sukces", "Obrazy zostały wysłane na serwer FTP")
+            with WebDAVClient(url, user, password) as client:
+                client.upload_directory(directory)
+            messagebox.showinfo("Sukces", "Obrazy zostały wysłane na serwer WebDAV")
         except Exception as exc:
             messagebox.showerror("Błąd", f"Nie udało się wysłać obrazów: {exc}")
 
     def send_csv_to_shoper(self, file_path: str):
-        """Send a CSV file using the Shoper API or FTP fallback."""
+        """Send a CSV file using the Shoper API or WebDAV fallback."""
         csv_utils.send_csv_to_shoper(self, file_path)
 
 

--- a/tests/test_download_warehouse_csv.py
+++ b/tests/test_download_warehouse_csv.py
@@ -1,12 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 from kartoteka import csv_utils
 
 
 def test_download_warehouse_csv(monkeypatch, tmp_path):
     called = {}
 
-    class DummyFTPClient:
-        def __init__(self, host, user, password):
-            called["init"] = (host, user, password)
+    class DummyWebDAVClient:
+        def __init__(self, base_url=None, user=None, password=None):
+            called["init"] = (base_url, user, password)
 
         def __enter__(self):
             return self
@@ -17,14 +22,14 @@ def test_download_warehouse_csv(monkeypatch, tmp_path):
         def download_file(self, remote_path, local_path=None):
             called["args"] = (remote_path, local_path)
 
-    monkeypatch.setattr(csv_utils, "FTPClient", DummyFTPClient)
-    monkeypatch.setattr(csv_utils, "FTP_HOST", "h")
-    monkeypatch.setattr(csv_utils, "FTP_USER", "u")
-    monkeypatch.setattr(csv_utils, "FTP_PASSWORD", "p")
+    monkeypatch.setattr(csv_utils, "WebDAVClient", DummyWebDAVClient)
+    monkeypatch.setenv("WEBDAV_URL", "h")
+    monkeypatch.setenv("WEBDAV_USER", "u")
+    monkeypatch.setenv("WEBDAV_PASSWORD", "p")
     path = tmp_path / "mag.csv"
     monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
 
     csv_utils.download_warehouse_csv()
 
-    assert called["init"] == ("h", "u", "p")
+    assert called["init"] == (None, None, None)
     assert called["args"] == (str(path), str(path))

--- a/tests/test_send_csv_to_shoper.py
+++ b/tests/test_send_csv_to_shoper.py
@@ -34,3 +34,29 @@ def test_send_csv_shows_errors_and_warnings(tmp_path):
         msg = error.call_args[0][1]
         assert "warn" in msg and "err" in msg
 
+
+def test_send_csv_uses_webdav(monkeypatch, tmp_path):
+    called = {}
+
+    class DummyClient:
+        def __init__(self, base_url=None, user=None, password=None):
+            called['init'] = (base_url, user, password)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def upload_file(self, path, remote_name=None):
+            called['path'] = path
+
+    monkeypatch.setattr('kartoteka.csv_utils.WebDAVClient', DummyClient)
+    app = SimpleNamespace(shoper_client=None, WEBDAV_URL='h', WEBDAV_USER='u', WEBDAV_PASSWORD='p')
+    with patch('tkinter.messagebox.showinfo') as info, patch('tkinter.messagebox.showerror') as error:
+        send_csv_to_shoper(app, str(tmp_path / 'file.csv'))
+        info.assert_called_once()
+        error.assert_not_called()
+    assert called['init'] == ('h', 'u', 'p')
+    assert called['path'].endswith('file.csv')
+

--- a/tests/test_webdav_client.py
+++ b/tests/test_webdav_client.py
@@ -1,0 +1,50 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import requests
+from webdav_client import WebDAVClient
+
+
+def test_download_file(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_get(url, auth):
+        called['url'] = url
+        called['auth'] = auth
+        return types.SimpleNamespace(status_code=200, content=b'data', text='')
+
+    monkeypatch.setattr(requests, 'get', fake_get)
+    monkeypatch.setenv('WEBDAV_URL', 'http://example.com')
+    monkeypatch.setenv('WEBDAV_USER', 'u')
+    monkeypatch.setenv('WEBDAV_PASSWORD', 'p')
+    dest = tmp_path / 'file.txt'
+    client = WebDAVClient()
+    client.download_file('remote.txt', str(dest))
+    assert dest.read_bytes() == b'data'
+    assert called['url'] == 'http://example.com/remote.txt'
+    assert called['auth'] == ('u', 'p')
+
+
+def test_upload_file(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_put(url, data, auth):
+        called['url'] = url
+        called['auth'] = auth
+        called['data'] = data.read()
+        return types.SimpleNamespace(status_code=201, text='')
+
+    monkeypatch.setattr(requests, 'put', fake_put)
+    monkeypatch.setenv('WEBDAV_URL', 'http://example.com')
+    monkeypatch.setenv('WEBDAV_USER', 'u')
+    monkeypatch.setenv('WEBDAV_PASSWORD', 'p')
+    src = tmp_path / 'local.txt'
+    src.write_text('hello')
+    client = WebDAVClient()
+    client.upload_file(str(src), 'remote.txt')
+    assert called['url'] == 'http://example.com/remote.txt'
+    assert called['auth'] == ('u', 'p')
+    assert called['data'] == b'hello'

--- a/webdav_client.py
+++ b/webdav_client.py
@@ -47,6 +47,15 @@ class WebDAVClient:
         except RequestException as exc:  # pragma: no cover - network failure
             raise RuntimeError(f"WebDAV download failed: {exc}") from exc
 
+    def upload_directory(self, directory: str, remote_dir: str = ".") -> None:
+        """Upload all files from ``directory`` to ``remote_dir``."""
+        for entry in os.listdir(directory):
+            path = os.path.join(directory, entry)
+            if not os.path.isfile(path):
+                continue
+            dest = f"{remote_dir.rstrip('/')}/{entry}" if remote_dir not in {"", "."} else entry
+            self.upload_file(path, dest)
+
     def __enter__(self):
         return self
 


### PR DESCRIPTION
## Summary
- switch CSV utilities and UI upload dialog from FTP to WebDAV
- document new `WEBDAV_URL/USER/PASSWORD` environment variables
- add WebDAV client directory upload and tests for download/upload and CSV sending

## Testing
- `pytest tests/test_webdav_client.py tests/test_download_warehouse_csv.py tests/test_send_csv_to_shoper.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2c8beea50832f870a96ea8350d68b