### PR TITLE
Remove WebDAV image upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ empty. Missing bidding step and duration values default to `1` and `60` seconds
 respectively.
 
 ### CSV and image upload
-After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to WebDAV using the credentials from `.env`. A copy of every row is also appended to the file specified in `WAREHOUSE_CSV` so the full stock list remains in one place. Use the **WebDAV Obrazy** button on the welcome screen to upload a folder of images to the configured WebDAV server.
+After exporting a CSV file the application prompts to send it directly to Shoper. When Shoper API credentials are configured the file is uploaded via the REST API. If not, the exporter falls back to WebDAV using the credentials from `.env`. A copy of every row is also appended to the file specified in `WAREHOUSE_CSV` so the full stock list remains in one place.
 
 ## License
 This project is licensed under the terms of the [MIT License](LICENSE).

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1458,12 +1458,6 @@ class CardEditorApp:
         ).pack(side="left", padx=10, pady=5)
         self.create_button(
             button_frame,
-            text="\U0001f4f7 WebDAV Obrazy",
-            command=self.upload_images_dialog,
-            fg_color="#474747",
-        ).pack(side="left", padx=10, pady=5)
-        self.create_button(
-            button_frame,
             text="\u2699\ufe0f Konfiguracja",
             command=self.open_config_dialog,
             fg_color="#404040",
@@ -5211,26 +5205,6 @@ class CardEditorApp:
         save_btn.grid(row=2, column=0, columnspan=2, pady=10)
         top.grid_columnconfigure(1, weight=1)
         self.root.wait_window(top)
-
-    def upload_images_dialog(self):
-        """Upload images from a selected directory via WebDAV."""
-        directory = filedialog.askdirectory()
-        if not directory:
-            return
-        url = simpledialog.askstring("WebDAV", "URL", initialvalue=WEBDAV_URL or "")
-        user = simpledialog.askstring("WebDAV", "Użytkownik", initialvalue=WEBDAV_USER or "")
-        password = simpledialog.askstring(
-            "WebDAV", "Hasło", show="*", initialvalue=WEBDAV_PASSWORD or ""
-        )
-        if not url or not user or not password:
-            messagebox.showerror("Błąd", "Nie podano pełnych danych logowania")
-            return
-        try:
-            with WebDAVClient(url, user, password) as client:
-                client.upload_directory(directory)
-            messagebox.showinfo("Sukces", "Obrazy zostały wysłane na serwer WebDAV")
-        except Exception as exc:
-            messagebox.showerror("Błąd", f"Nie udało się wysłać obrazów: {exc}")
 
     def send_csv_to_shoper(self, file_path: str):
         """Send a CSV file using the Shoper API or WebDAV fallback."""


### PR DESCRIPTION
## Summary
- Drop "📷 WebDAV Obrazy" button from the main UI and delete its dialog handler
- Update documentation to remove references to the WebDAV image upload button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b422114b24832f933573b4e029a7c0