### PR TITLE
Aggregate box occupancy and adjust UI display

### DIFF
--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -109,20 +109,17 @@ def next_free_location(app):
     return generate_location(idx)
 
 
-def compute_column_occupancy():
-    """Return count of used slots per box column.
+def compute_box_occupancy() -> dict[int, int]:
+    """Return count of used slots per storage box.
 
-    The result is a nested dictionary mapping ``box -> column -> used
-    slots``.  The set of boxes and the number of columns per box are
-    derived from :data:`BOX_COLUMNS` so changes in storage layout only
-    require updating that mapping.
+    The returned mapping contains an entry for each box defined in
+    :data:`BOX_CAPACITY`.  Cards marked as sold are ignored.  This is a
+    simplified variant of the previous :func:`compute_column_occupancy`
+    helper which aggregated usage per column – callers now only care
+    about the total number of used slots in every box.
     """
 
-    occ: dict[int, dict[int, int]] = {}
-    for box in BOX_CAPACITY:
-        occ[box] = {
-            c: 0 for c in range(1, BOX_COLUMNS.get(box, 4) + 1)
-        }
+    occ: dict[int, int] = {box: 0 for box in BOX_CAPACITY}
     try:
         with open(csv_utils.INVENTORY_CSV, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f, delimiter=";")
@@ -139,9 +136,8 @@ def compute_column_occupancy():
                     if not m:
                         continue
                     box = int(m.group(1))
-                    c = int(m.group(2))
-                    if box in occ and c in occ[box]:
-                        occ[box][c] += 1
+                    if box in occ:
+                        occ[box] += 1
     except FileNotFoundError:
         pass
     return occ

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2447,12 +2447,12 @@ class CardEditorApp:
             self.mag_canvases.append(canvas)
             self.mag_labels.append(lbl)
 
-        # Canvas item IDs per column for incremental redraws
-        self.mag_canvas_items: list[dict[int, dict[str, object]]] = [
+        # Canvas item IDs for incremental redraws per box
+        self.mag_canvas_items: list[dict[str, object]] = [
             {} for _ in self.mag_canvases
         ]
-        # Previous occupancy values per column
-        self._mag_prev_occupancy: dict[int, dict[int, dict[str, int]]] = {}
+        # Previous occupancy values per box
+        self._mag_prev_occupancy: dict[int, dict[str, int]] = {}
 
         # List of cards currently in the warehouse
         self.mag_card_images = []
@@ -2807,9 +2807,9 @@ class CardEditorApp:
             except Exception:
                 pass
 
-    def compute_column_occupancy(self):
-        """Return dictionary of used slots per box column."""
-        return storage.compute_column_occupancy()
+    def compute_box_occupancy(self) -> dict[int, int]:
+        """Return dictionary of used slots per storage box."""
+        return storage.compute_box_occupancy()
 
     def repack_column(self, box: int, column: int):
         """Renumber codes in the given column so there are no gaps."""
@@ -2827,7 +2827,7 @@ class CardEditorApp:
         if not getattr(self, "mag_canvases", None):
             return
 
-        occ = self.compute_column_occupancy()
+        occ = self.compute_box_occupancy()
 
         base_dir = os.path.dirname(__file__)
         if getattr(self, "mag_box_photo", None) is None:
@@ -2857,101 +2857,95 @@ class CardEditorApp:
 
             box_w = int(canvas.cget("width"))
             box_h = int(canvas.cget("height"))
-            columns = storage.BOX_COLUMNS.get(box, 4)
             total_capacity = storage.BOX_CAPACITY.get(
-                box, columns * storage.BOX_COLUMN_CAPACITY
+                box,
+                storage.BOX_COLUMNS.get(box, 4) * storage.BOX_COLUMN_CAPACITY,
             )
-            col_capacity = total_capacity // columns
-            col_w = box_w / columns
 
-            prev_box = self._mag_prev_occupancy.setdefault(box, {})
+            filled = occ.get(box, 0)
+            segment_capacity = storage.BOX_COLUMN_CAPACITY // 10
+            seg_count = max(1, total_capacity // segment_capacity)
+            filled_sections = min(seg_count, filled // segment_capacity)
+
+            prev_stats = self._mag_prev_occupancy.get(box)
             canvas_items = self.mag_canvas_items[idx]
-            label_texts: list[str] = []
+            if (
+                prev_stats
+                and prev_stats.get("filled") == filled
+                and prev_stats.get("seg_count") == seg_count
+                and canvas_items
+            ):
+                occupied_percent = filled / total_capacity * 100
+                self.mag_labels[idx].configure(
+                    text=f"K{box}: {occupied_percent:.0f}%"
+                )
+                continue
 
-            for c in range(1, columns + 1):
-                filled = occ.get(box, {}).get(c, 0)
-                segment_capacity = storage.BOX_COLUMN_CAPACITY // 10
-                seg_count = max(1, col_capacity // segment_capacity)
-                filled_sections = min(seg_count, filled // segment_capacity)
+            self._mag_prev_occupancy[box] = {
+                "filled": filled,
+                "seg_count": seg_count,
+            }
 
-                prev_stats = prev_box.get(c)
-                if (
-                    prev_stats
-                    and prev_stats.get("filled") == filled
-                    and prev_stats.get("seg_count") == seg_count
-                    and c in canvas_items
-                ):
-                    occupied_percent = filled / col_capacity * 100
-                    label_texts.append(f"C{c}: {occupied_percent:.0f}%")
-                    continue
+            x1 = 0
+            x2 = box_w
+            occupied_percent = filled / total_capacity * 100
+            free_percent = 100 - occupied_percent
+            bg_fill = FREE_COLOR if free_percent >= 30 else ""
 
-                prev_box[c] = {"filled": filled, "seg_count": seg_count}
-
-                x1 = (c - 1) * col_w
-                x2 = x1 + col_w
-                occupied_percent = filled / col_capacity * 100
-                free_percent = 100 - occupied_percent
-                bg_fill = FREE_COLOR if free_percent >= 30 else ""
-
-                items = canvas_items.get(c)
-                seg_h = box_h / seg_count
-                if not items:
-                    bg_id = canvas.create_rectangle(
-                        x1, 0, x2, box_h, fill=bg_fill, width=0
+            seg_h = box_h / seg_count
+            if not canvas_items:
+                bg_id = canvas.create_rectangle(x1, 0, x2, box_h, fill=bg_fill, width=0)
+                segments = []
+                for i in range(seg_count):
+                    y1 = box_h - seg_h * (i + 1)
+                    y2 = box_h - seg_h * i
+                    color = OCCUPIED_COLOR if i < filled_sections else ""
+                    seg_id = canvas.create_rectangle(
+                        x1,
+                        y1,
+                        x2,
+                        y2,
+                        fill=color,
+                        outline="black",
+                        width=1,
                     )
-                    segments = []
-                    for i in range(seg_count):
-                        y1 = box_h - seg_h * (i + 1)
-                        y2 = box_h - seg_h * i
-                        color = OCCUPIED_COLOR if i < filled_sections else ""
+                    segments.append(seg_id)
+                self.mag_canvas_items[idx] = {
+                    "bg": bg_id,
+                    "segments": segments,
+                    "seg_count": seg_count,
+                }
+            else:
+                bg_id = canvas_items["bg"]
+                canvas.coords(bg_id, x1, 0, x2, box_h)
+                canvas.itemconfigure(bg_id, fill=bg_fill)
+
+                segments = canvas_items["segments"]
+                if seg_count < len(segments):
+                    for seg_id in segments[seg_count:]:
+                        canvas.delete(seg_id)
+                    segments = segments[:seg_count]
+                elif seg_count > len(segments):
+                    for i in range(len(segments), seg_count):
                         seg_id = canvas.create_rectangle(
                             x1,
-                            y1,
+                            box_h - seg_h * (i + 1),
                             x2,
-                            y2,
-                            fill=color,
+                            box_h - seg_h * i,
                             outline="black",
                             width=1,
                         )
                         segments.append(seg_id)
-                    canvas_items[c] = {
-                        "bg": bg_id,
-                        "segments": segments,
-                        "seg_count": seg_count,
-                    }
-                else:
-                    bg_id = items["bg"]
-                    canvas.coords(bg_id, x1, 0, x2, box_h)
-                    canvas.itemconfigure(bg_id, fill=bg_fill)
+                for i, seg_id in enumerate(segments):
+                    y1 = box_h - seg_h * (i + 1)
+                    y2 = box_h - seg_h * i
+                    canvas.coords(seg_id, x1, y1, x2, y2)
+                    color = OCCUPIED_COLOR if i < filled_sections else ""
+                    canvas.itemconfigure(seg_id, fill=color)
+                canvas_items["segments"] = segments
+                canvas_items["seg_count"] = seg_count
 
-                    segments = items["segments"]
-                    if seg_count < len(segments):
-                        for seg_id in segments[seg_count:]:
-                            canvas.delete(seg_id)
-                        segments = segments[:seg_count]
-                    elif seg_count > len(segments):
-                        for i in range(len(segments), seg_count):
-                            seg_id = canvas.create_rectangle(
-                                x1,
-                                box_h - seg_h * (i + 1),
-                                x2,
-                                box_h - seg_h * i,
-                                outline="black",
-                                width=1,
-                            )
-                            segments.append(seg_id)
-                    for i, seg_id in enumerate(segments):
-                        y1 = box_h - seg_h * (i + 1)
-                        y2 = box_h - seg_h * i
-                        canvas.coords(seg_id, x1, y1, x2, y2)
-                        color = OCCUPIED_COLOR if i < filled_sections else ""
-                        canvas.itemconfigure(seg_id, fill=color)
-                    items["segments"] = segments
-                    items["seg_count"] = seg_count
-
-                label_texts.append(f"C{c}: {occupied_percent:.0f}%")
-
-            self.mag_labels[idx].configure(text=" | ".join(label_texts))
+            self.mag_labels[idx].configure(text=f"K{box}: {occupied_percent:.0f}%")
         self.update_inventory_stats()
 
     def show_card_details(self, row: dict):

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -16,15 +16,19 @@ from ctk_mocks import (  # noqa: E402
     DummyCanvas,
 )
 
+import pytest
 
-def test_compute_column_occupancy_box100(tmp_path, monkeypatch):
+
+def test_compute_box_occupancy_box100(tmp_path, monkeypatch):
     from kartoteka import csv_utils, storage
 
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text("name;warehouse_code\nA;K100R1P0001\n", encoding="utf-8")
     monkeypatch.setattr(csv_utils, "INVENTORY_CSV", str(csv_path))
-    occ = storage.compute_column_occupancy()
-    assert occ[100][1] == 1
+    occ = storage.compute_box_occupancy()
+    assert occ[100] == 1
+    percent = occ[100] / storage.BOX_CAPACITY[100] * 100
+    assert percent == pytest.approx(0.2)
 
 
 def test_generate_and_next_free_location_box100():
@@ -79,5 +83,9 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
         ui.CardEditorApp.open_magazyn_window(app)
 
     assert app.mag_box_order[-1] == 100
-    occ = ui.CardEditorApp.compute_column_occupancy(app)
-    assert occ[100][1] == 1
+    occ = ui.CardEditorApp.compute_box_occupancy(app)
+    assert occ[100] == 1
+    from kartoteka import storage
+
+    percent = occ[100] / storage.BOX_CAPACITY[100] * 100
+    assert percent == pytest.approx(0.2)

--- a/tests/test_column_occupancy.py
+++ b/tests/test_column_occupancy.py
@@ -4,12 +4,15 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 
 def test_split_codes_counted(tmp_path, monkeypatch):
     from kartoteka import csv_utils
+    from kartoteka import storage
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
         'name;warehouse_code\nA;"K1R1P1;K1R1P2"\n', encoding="utf-8"
@@ -19,12 +22,15 @@ def test_split_codes_counted(tmp_path, monkeypatch):
     import kartoteka.ui as ui
     importlib.reload(ui)
     dummy = SimpleNamespace()
-    occ = ui.CardEditorApp.compute_column_occupancy(dummy)
-    assert occ[1][1] == 2
+    occ = ui.CardEditorApp.compute_box_occupancy(dummy)
+    assert occ[1] == 2
+    percent = occ[1] / storage.BOX_CAPACITY[1] * 100
+    assert percent == pytest.approx(0.05)
 
 
 def test_sold_cards_excluded_from_occupancy(tmp_path, monkeypatch):
     from kartoteka import csv_utils
+    from kartoteka import storage
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
         "name;warehouse_code;sold\nA;K1R1P1;\nB;K1R1P2;1\n", encoding="utf-8"
@@ -35,5 +41,7 @@ def test_sold_cards_excluded_from_occupancy(tmp_path, monkeypatch):
     import importlib
     importlib.reload(ui)
     dummy = SimpleNamespace()
-    occ = ui.CardEditorApp.compute_column_occupancy(dummy)
-    assert occ[1][1] == 1
+    occ = ui.CardEditorApp.compute_box_occupancy(dummy)
+    assert occ[1] == 1
+    percent = occ[1] / storage.BOX_CAPACITY[1] * 100
+    assert percent == pytest.approx(0.025)


### PR DESCRIPTION
## Summary
- compute_box_occupancy sums card usage per storage box
- Magazyn view now shows one percentage per box (e.g., `K1: 75%`)
- Tests updated for new box-level occupancy and percentage checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b424d13b04832f863bc84f7220edf6