### PR TITLE
Ensure images are closed with context managers

### DIFF
--- a/kartoteka/image_utils.py
+++ b/kartoteka/image_utils.py
@@ -1,6 +1,7 @@
 import logging
 from typing import IO, Optional, Union
 from pathlib import Path
+from contextlib import ExitStack
 from PIL import Image, UnidentifiedImageError
 
 logger = logging.getLogger(__name__)
@@ -21,20 +22,20 @@ def load_rgba_image(source: Source) -> Optional[Image.Image]:
         The loaded image in RGBA mode or ``None`` if the image cannot be
         opened or decoded.
     """
-    img = None
     try:
-        img = Image.open(source)
-        rgba = img.convert("RGBA")
-        load = getattr(rgba, "load", None)
-        if callable(load):
-            load()
-        return rgba
+        with ExitStack() as stack:
+            img = Image.open(source)
+            if hasattr(img, "__enter__"):
+                img = stack.enter_context(img)
+            else:
+                close = getattr(img, "close", None)
+                if callable(close):
+                    stack.callback(close)
+            rgba = img.convert("RGBA")
+            load = getattr(rgba, "load", None)
+            if callable(load):
+                load()
+            return rgba
     except (FileNotFoundError, UnidentifiedImageError, OSError) as exc:  # pragma: no cover - logged
         logger.warning("Failed to open image %s: %s", source, exc)
         return None
-    finally:
-        try:
-            if img and hasattr(img, "close"):
-                img.close()
-        except Exception:
-            pass

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4235,16 +4235,15 @@ class CardEditorApp:
         gif_path = os.path.join(os.path.dirname(__file__), "simple_pokeball.gif")
         if os.path.exists(gif_path):
             from PIL import ImageSequence
-
             with Image.open(gif_path) as img:
                 img.convert("RGBA")
-            self.gif_frames = []
-            self.gif_durations = []
-            for frame in ImageSequence.Iterator(Image.open(gif_path)):
-                self.gif_frames.append(
-                    _create_image(frame.convert("RGBA"))
-                )
-                self.gif_durations.append(frame.info.get("duration", 100))
+                self.gif_frames = []
+                self.gif_durations = []
+                for frame in ImageSequence.Iterator(img):
+                    self.gif_frames.append(
+                        _create_image(frame.convert("RGBA"))
+                    )
+                    self.gif_durations.append(frame.info.get("duration", 100))
 
             self.gif_label = ctk.CTkLabel(
                 self.loading_frame, text=""


### PR DESCRIPTION
## Summary
- use `ExitStack` to guarantee `Image.open` resources are closed in `image_utils.load_rgba_image`
- open loading GIF with a single context-managed `Image.open` in `ui` to avoid leaked file handles

## Testing
- `python -m pytest -W error::ResourceWarning`


------
https://chatgpt.com/codex/tasks/task_e_68b432d8c43c832f80a458d10a4595c1