### PR TITLE
Handle image orientation via EXIF

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1091,15 +1091,15 @@ def analyze_card_image(
     if local_path and os.path.exists(local_path):
         try:
             with Image.open(local_path) as im:
+                exif_orientation = im.getexif().get(0x0112, 1)
+                im = ImageOps.exif_transpose(im)
                 w, h = im.size
-                orientation = 90 if w > h else 0
-                if orientation == 90:
-                    im = im.rotate(90, expand=True)
+                orientation = 90 if exif_orientation in (6, 8) else 0
+                if exif_orientation != 1:
                     rotated_path = local_path + ".rot.jpg"
                     im.save(rotated_path)
                     local_path = rotated_path
                     path = rotated_path
-                    w, h = im.size
                 rects = get_symbol_rects(w, h)
                 if rects:
                     rect = rects[0]

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -429,7 +429,7 @@ def test_analyze_card_image_debug_rect(tmp_path, monkeypatch):
     monkeypatch.setattr(ui, "extract_set_code_ocr", lambda *a, **k: [])
     monkeypatch.setattr(ui, "identify_set_by_hash", lambda *a, **k: [])
     result = ui.analyze_card_image(str(img_path), debug=True)
-    assert result["orientation"] == 90
+    assert result["orientation"] == 0
     rect = result.get("rect")
     assert isinstance(rect, tuple) and len(rect) == 4
 
@@ -445,7 +445,7 @@ def test_analyze_card_image_orientation(tmp_path, monkeypatch):
          patch.object(ui, "lookup_sets_from_api", return_value=[]):
         result = ui.analyze_card_image(str(img_path))
 
-    assert result["orientation"] == 90
+    assert result["orientation"] == 0
 
 
 def test_preview_callback_called(tmp_path, monkeypatch):
@@ -479,7 +479,7 @@ def test_analyze_card_image_horizontal_scan(tmp_path, monkeypatch):
     img_path = tmp_path / "horizontal.png"
     Image.new("RGB", (400, 200), color="white").save(img_path)
 
-    expected_rect = ui.get_symbol_rects(200, 400)[0]
+    expected_rect = ui.get_symbol_rects(400, 200)[0]
 
     def fake_hash(path, rect):
         assert rect == expected_rect
@@ -494,7 +494,7 @@ def test_analyze_card_image_horizontal_scan(tmp_path, monkeypatch):
 
     assert result["set"] == SV01_NAME
     assert result["set_code"] == SV01_CODE
-    assert result["orientation"] == 90
+    assert result["orientation"] == 0
 
 
 def test_analyze_and_fill_translates_for_jp(monkeypatch):


### PR DESCRIPTION
## Summary
- Use `ImageOps.exif_transpose` in `analyze_card_image` to respect image orientation from EXIF metadata
- Simplify orientation handling and save corrected copy when EXIF indicates rotation
- Update tests for new orientation logic

## Testing
- `pytest tests/test_get_symbol_rect.py -q`
- `pytest tests/test_analyze_card_image.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b533a2ea30832f98afa31451ce7d00