### PR TITLE
Add distance threshold for fingerprint matches

### DIFF
--- a/hash_db.py
+++ b/hash_db.py
@@ -250,11 +250,25 @@ class HashDB:
         results.sort(key=lambda c: c.distance)
         return results[:limit]
 
-    def best_match(self, source) -> Optional[Candidate]:
-        """Return the single best match for ``source`` or ``None``."""
+    def best_match(self, source, max_distance: Optional[int] = None) -> Optional[Candidate]:
+        """Return the single best match for ``source`` or ``None``.
+
+        Parameters
+        ----------
+        source:
+            Fingerprint mapping or image path used for the lookup.
+        max_distance:
+            Optional maximum allowed distance for a match.  If the best
+            candidate exceeds this distance, ``None`` is returned instead.
+        """
 
         candidates = self.candidates(source, limit=1)
-        return candidates[0] if candidates else None
+        if not candidates:
+            return None
+        best = candidates[0]
+        if max_distance is not None and best.distance > max_distance:
+            return None
+        return best
 
 
 __all__ = ["HashDB", "Candidate"]

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -70,6 +70,7 @@ PRICE_MULTIPLIER = 1.23
 HOLO_REVERSE_MULTIPLIER = 3.5
 SET_LOGO_DIR = "set_logos"
 HASH_DIFF_THRESHOLD = 20  # hash difference threshold for accepting matches
+HASH_MATCH_THRESHOLD = 400  # maximum allowed fingerprint distance
 HASH_SIZE = (32, 32)
 PSA_ICON_URL = "https://www.pngkey.com/png/full/231-2310791_psa-grading-standards-professional-sports-authenticator.png"
 
@@ -4039,7 +4040,7 @@ class CardEditorApp:
                 with Image.open(image_path) as img_fp:
                     fp = compute_fingerprint(img_fp)
                 self.current_fingerprint = fp
-                fp_match = self.hash_db.best_match(fp)
+                fp_match = self.hash_db.best_match(fp, max_distance=HASH_MATCH_THRESHOLD)
             except (OSError, UnidentifiedImageError, ValueError) as exc:
                 logger.warning("Fingerprint lookup failed for %s: %s", image_path, exc)
                 fp_match = None
@@ -4153,7 +4154,7 @@ class CardEditorApp:
                 with Image.open(path) as img:
                     fp = compute_fingerprint(img)
                 self.current_fingerprint = fp
-                fp_match = self.hash_db.best_match(fp)
+                fp_match = self.hash_db.best_match(fp, max_distance=HASH_MATCH_THRESHOLD)
             except (OSError, UnidentifiedImageError, ValueError) as exc:
                 logger.warning("Fingerprint lookup failed for %s: %s", path, exc)
                 fp_match = None


### PR DESCRIPTION
## Summary
- extend `HashDB.best_match` with optional `max_distance` check
- use new `HASH_MATCH_THRESHOLD` constant in UI to validate hash matches
- run full card analysis when no match within threshold

## Testing
- `pytest tests/test_fingerprint_db.py tests/test_hash_db_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5400b8c08832fb1a3b9593fba6a56