### PR TITLE
Handle last card in save and next

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5244,7 +5244,13 @@ class CardEditorApp:
                 pass
             return
         self.save_current_data()
-        self.index += 1
+        if self.index < len(self.cards) - 1:
+            self.index += 1
+        else:
+            try:
+                messagebox.showinfo("Info", "To jest ostatnia karta.")
+            except tk.TclError:
+                pass
         self.show_card()
 
     def previous_card(self):

--- a/tests/test_save_and_next_last_card.py
+++ b/tests/test_save_and_next_last_card.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+# Provide dummy customtkinter before importing UI module
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parent))
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui  # noqa: E402
+
+
+def test_save_and_next_on_last_card():
+    app = SimpleNamespace(
+        current_analysis_thread=None,
+        save_current_data=lambda: None,
+        index=0,
+        cards=[1],
+        show_card=lambda: None,
+    )
+    with patch.object(ui.messagebox, "showinfo") as mock_info:
+        ui.CardEditorApp.save_and_next(app)
+    assert app.index == 0
+    mock_info.assert_called_once()


### PR DESCRIPTION
## Summary
- prevent `save_and_next` from incrementing past final card and show info message
- add regression test for pressing Save/Next on the last card

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b54dc30fd4832fb7eec024f69bd250