### PR TITLE
Handle last card in save_and_next

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5247,12 +5247,12 @@ class CardEditorApp:
         self.save_current_data()
         if self.index < len(self.cards) - 1:
             self.index += 1
+            self.show_card()
         else:
             try:
                 messagebox.showinfo("Info", "To jest ostatnia karta.")
             except tk.TclError:
                 pass
-        self.show_card()
 
     def previous_card(self):
         """Save current data and display the previous scan."""

--- a/tests/test_save_and_next_last_card.py
+++ b/tests/test_save_and_next_last_card.py
@@ -11,14 +11,16 @@ import kartoteka.ui as ui  # noqa: E402
 
 
 def test_save_and_next_on_last_card():
+    show_card_mock = MagicMock()
     app = SimpleNamespace(
         current_analysis_thread=None,
         save_current_data=lambda: None,
         index=0,
         cards=[1],
-        show_card=lambda: None,
+        show_card=show_card_mock,
     )
     with patch.object(ui.messagebox, "showinfo") as mock_info:
         ui.CardEditorApp.save_and_next(app)
     assert app.index == 0
-    mock_info.assert_called_once()
+    mock_info.assert_called_once_with("Info", "To jest ostatnia karta.")
+    show_card_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- Only advance to the next card when one exists in `save_and_next` and show an info message on the last card
- Add unit test verifying the method does not advance or show a new card on the final entry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b556a03998832fb118cce8b793b936