### PR TITLE
feat: allow downloading warehouse CSV from HTTP

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -3,11 +3,15 @@ import re
 import csv
 from typing import Optional, Tuple
 from tkinter import filedialog, messagebox, TclError
+
+import requests
+
 from webdav_client import WebDAVClient
 INVENTORY_CSV = os.getenv(
     "INVENTORY_CSV", os.getenv("WAREHOUSE_CSV", "magazyn.csv")
 )
 WAREHOUSE_CSV = os.getenv("WAREHOUSE_CSV", INVENTORY_CSV)
+WAREHOUSE_CSV_URL = os.getenv("WAREHOUSE_CSV_URL", "")
 
 # Track last modification time and cached statistics for the warehouse CSV
 WAREHOUSE_CSV_MTIME: Optional[float] = None
@@ -49,10 +53,16 @@ WAREHOUSE_FIELDNAMES = [
 
 
 def download_warehouse_csv():
-    """Download the warehouse CSV from the WebDAV server."""
+    """Download the warehouse CSV from HTTP or WebDAV."""
     try:
-        with WebDAVClient() as client:
-            client.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
+        if WAREHOUSE_CSV_URL:
+            response = requests.get(WAREHOUSE_CSV_URL, timeout=30)
+            response.raise_for_status()
+            with open(WAREHOUSE_CSV, "wb") as fh:
+                fh.write(response.content)
+        else:
+            with WebDAVClient() as client:
+                client.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
     except Exception:  # pragma: no cover - network failure
         pass
 

--- a/tests/test_download_warehouse_csv.py
+++ b/tests/test_download_warehouse_csv.py
@@ -23,9 +23,7 @@ def test_download_warehouse_csv(monkeypatch, tmp_path):
             called["args"] = (remote_path, local_path)
 
     monkeypatch.setattr(csv_utils, "WebDAVClient", DummyWebDAVClient)
-    monkeypatch.setenv("WEBDAV_URL", "h")
-    monkeypatch.setenv("WEBDAV_USER", "u")
-    monkeypatch.setenv("WEBDAV_PASSWORD", "p")
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV_URL", "")
     path = tmp_path / "mag.csv"
     monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
 
@@ -33,3 +31,36 @@ def test_download_warehouse_csv(monkeypatch, tmp_path):
 
     assert called["init"] == (None, None, None)
     assert called["args"] == (str(path), str(path))
+
+
+def test_download_warehouse_csv_http(monkeypatch, tmp_path):
+    data = b"name;price\n"
+    called = {}
+
+    class DummyResponse:
+        def __init__(self, content):
+            self.content = content
+
+        def raise_for_status(self):
+            pass
+
+    def dummy_get(url, timeout=30):
+        called["url"] = url
+        return DummyResponse(data)
+
+    class FailingWebDAVClient:
+        def __init__(self, *a, **kw):
+            raise AssertionError("WebDAV should not be used when URL is provided")
+
+    monkeypatch.setattr(csv_utils, "WebDAVClient", FailingWebDAVClient)
+    monkeypatch.setattr(csv_utils.requests, "get", dummy_get)
+    url = "http://example.com/mag.csv"
+    monkeypatch.setenv("WAREHOUSE_CSV_URL", url)
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV_URL", url)
+    path = tmp_path / "mag.csv"
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
+
+    csv_utils.download_warehouse_csv()
+
+    assert called["url"] == url
+    assert path.read_bytes() == data


### PR DESCRIPTION
## Summary
- allow specifying `WAREHOUSE_CSV_URL` env var for remote download
- download warehouse CSV from HTTP when URL configured, fallback to WebDAV
- add tests for HTTP download path

## Testing
- `pytest tests/test_download_warehouse_csv.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b55ed0a1fc832f83f6798811d7ff3a