### PR TITLE
Log RequestException during warehouse CSV download

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -4,7 +4,9 @@ import csv
 from typing import Optional, Tuple
 from tkinter import filedialog, messagebox, TclError
 
+import logging
 import requests
+from requests import RequestException
 
 from webdav_client import WebDAVClient
 INVENTORY_CSV = os.getenv(
@@ -63,8 +65,10 @@ def download_warehouse_csv():
         else:
             with WebDAVClient() as client:
                 client.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
-    except Exception:  # pragma: no cover - network failure
-        pass
+    except RequestException as exc:  # pragma: no cover - network failure
+        logging.warning("Failed to download warehouse CSV: %s", exc)
+    except Exception:
+        raise
 
 
 def get_inventory_stats(path: str = WAREHOUSE_CSV, force: bool = False):

--- a/tests/test_download_warehouse_csv.py
+++ b/tests/test_download_warehouse_csv.py
@@ -1,7 +1,10 @@
 import sys
 from pathlib import Path
+import logging
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from requests import RequestException
 
 from kartoteka import csv_utils
 
@@ -64,3 +67,19 @@ def test_download_warehouse_csv_http(monkeypatch, tmp_path):
 
     assert called["url"] == url
     assert path.read_bytes() == data
+
+
+def test_download_warehouse_csv_http_error_logs(monkeypatch, tmp_path, caplog):
+    def failing_get(url, timeout=30):
+        raise RequestException("network down")
+
+    monkeypatch.setattr(csv_utils.requests, "get", failing_get)
+    url = "http://example.com/mag.csv"
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV_URL", url)
+    path = tmp_path / "mag.csv"
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
+
+    with caplog.at_level(logging.WARNING):
+        csv_utils.download_warehouse_csv()
+
+    assert "Failed to download warehouse CSV" in caplog.text


### PR DESCRIPTION
## Summary
- Log a warning when HTTP download of warehouse CSV fails and re-raise unexpected exceptions
- Test that failed downloads emit a warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5630a20a4832f8a9965bec3abe633