### PR TITLE
Handle WebDAV CSV download failures gracefully

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -64,7 +64,20 @@ def download_warehouse_csv():
                 fh.write(response.content)
         else:
             with WebDAVClient() as client:
-                client.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
+                try:
+                    client.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
+                except RuntimeError as exc:
+                    logging.warning("Failed to download warehouse CSV: %s", exc)
+                    try:
+                        retry = messagebox.askretrycancel(
+                            "Download Failed",
+                            "Nie udało się pobrać magazynu. Spróbować ponownie?",
+                        )
+                    except TclError:
+                        retry = False
+                    if retry:
+                        return download_warehouse_csv()
+                    return
     except RequestException as exc:  # pragma: no cover - network failure
         logging.warning("Failed to download warehouse CSV: %s", exc)
     except Exception:

--- a/tests/test_download_warehouse_csv.py
+++ b/tests/test_download_warehouse_csv.py
@@ -83,3 +83,34 @@ def test_download_warehouse_csv_http_error_logs(monkeypatch, tmp_path, caplog):
         csv_utils.download_warehouse_csv()
 
     assert "Failed to download warehouse CSV" in caplog.text
+
+
+def test_download_warehouse_csv_webdav_error(monkeypatch, tmp_path, caplog):
+    class FailingWebDAVClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def download_file(self, remote_path, local_path=None):
+            raise RuntimeError("connection failed")
+
+    monkeypatch.setattr(csv_utils, "WebDAVClient", FailingWebDAVClient)
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV_URL", "")
+    path = tmp_path / "mag.csv"
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
+
+    called = {}
+
+    def dummy_retry(title, message):
+        called["asked"] = True
+        return False
+
+    monkeypatch.setattr(csv_utils.messagebox, "askretrycancel", dummy_retry)
+
+    with caplog.at_level(logging.WARNING):
+        csv_utils.download_warehouse_csv()
+
+    assert "Failed to download warehouse CSV" in caplog.text
+    assert called["asked"]


### PR DESCRIPTION
## Summary
- Handle `RuntimeError` from WebDAV downloads without crashing
- Prompt user to retry or continue offline when warehouse CSV download fails
- Test WebDAV download failure logging and user prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b568af6dcc832fb43f1d43cb26e67f