### PR TITLE
Add request timeouts to WebDAV client

### DIFF
--- a/tests/test_webdav_client.py
+++ b/tests/test_webdav_client.py
@@ -11,7 +11,7 @@ from webdav_client import WebDAVClient
 def test_download_file(monkeypatch, tmp_path):
     called = {}
 
-    def fake_get(url, auth):
+    def fake_get(url, auth, timeout=None):
         called['url'] = url
         called['auth'] = auth
         return types.SimpleNamespace(status_code=200, content=b'data', text='')
@@ -31,7 +31,7 @@ def test_download_file(monkeypatch, tmp_path):
 def test_upload_file(monkeypatch, tmp_path):
     called = {}
 
-    def fake_put(url, data, auth):
+    def fake_put(url, data, auth, timeout=None):
         called['url'] = url
         called['auth'] = auth
         called['data'] = data.read()

--- a/webdav_client.py
+++ b/webdav_client.py
@@ -24,7 +24,9 @@ class WebDAVClient:
         url = self._make_url(remote_name)
         try:
             with open(local_path, "rb") as fh:
-                response = requests.put(url, data=fh, auth=(self.user, self.password))
+                response = requests.put(
+                    url, data=fh, auth=(self.user, self.password), timeout=30
+                )
             if response.status_code not in (200, 201):
                 raise RuntimeError(
                     f"WebDAV upload failed: {response.status_code} {response.text}"
@@ -37,7 +39,9 @@ class WebDAVClient:
         local_path = local_path or os.path.basename(remote_name)
         url = self._make_url(remote_name)
         try:
-            response = requests.get(url, auth=(self.user, self.password))
+            response = requests.get(
+                url, auth=(self.user, self.password), timeout=30
+            )
             if response.status_code != 200:
                 raise RuntimeError(
                     f"WebDAV download failed: {response.status_code} {response.text}"


### PR DESCRIPTION
## Summary
- set 30-second timeouts on WebDAV `requests.put` and `requests.get` calls
- adjust WebDAV client tests for new timeout argument

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56b96cea4832f939f18c52c48380c