### PR TITLE
Handle only exact fingerprint matches

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -70,7 +70,7 @@ PRICE_MULTIPLIER = 1.23
 HOLO_REVERSE_MULTIPLIER = 3.5
 SET_LOGO_DIR = "set_logos"
 HASH_DIFF_THRESHOLD = 20  # hash difference threshold for accepting matches
-HASH_MATCH_THRESHOLD = 100  # maximum allowed fingerprint distance
+HASH_MATCH_THRESHOLD = 0  # maximum allowed fingerprint distance
 HASH_SIZE = (32, 32)
 PSA_ICON_URL = "https://www.pngkey.com/png/full/231-2310791_psa-grading-standards-professional-sports-authenticator.png"
 
@@ -4047,15 +4047,18 @@ class CardEditorApp:
                 with Image.open(image_path) as img_fp:
                     fp = compute_fingerprint(img_fp)
                 self.current_fingerprint = fp
-                fp_match = self.hash_db.best_match(fp, max_distance=HASH_MATCH_THRESHOLD)
+                fp_match = self.hash_db.best_match(
+                    fp, max_distance=HASH_MATCH_THRESHOLD
+                )
             except (OSError, UnidentifiedImageError, ValueError) as exc:
                 logger.warning("Fingerprint lookup failed for %s: %s", image_path, exc)
                 fp_match = None
-
-            if fp_match:
+            if fp_match and fp_match.distance == 0:
                 meta = fp_match.meta
                 name = meta.get("nazwa", meta.get("name", ""))
-                number = sanitize_number(str(meta.get("numer", meta.get("number", ""))))
+                number = sanitize_number(
+                    str(meta.get("numer", meta.get("number", "")))
+                )
                 set_name = meta.get("set", meta.get("set_name", ""))
                 self.entries["nazwa"].insert(0, name)
                 self.entries["numer"].insert(0, number)
@@ -4075,24 +4078,23 @@ class CardEditorApp:
                 if progress_cb:
                     progress_cb(1.0, hide=True)
 
-        if not fp_match:
+        if not skip_analysis:
             if progress_cb:
                 progress_cb(0, hide=True)
-            if not skip_analysis:
-                thread = threading.Thread(
-                    target=self._analyze_and_fill,
-                    args=(image_path, self.index),
-                    daemon=True,
-                )
-                self.current_analysis_thread = thread
-                for btn_name in ("save_button", "next_button"):
-                    btn = getattr(self, btn_name, None)
-                    if btn is not None:
-                        try:
-                            btn.configure(state=tk.DISABLED)
-                        except Exception:
-                            pass
-                thread.start()
+            thread = threading.Thread(
+                target=self._analyze_and_fill,
+                args=(image_path, self.index),
+                daemon=True,
+            )
+            self.current_analysis_thread = thread
+            for btn_name in ("save_button", "next_button"):
+                btn = getattr(self, btn_name, None)
+                if btn is not None:
+                    try:
+                        btn.configure(state=tk.DISABLED)
+                    except Exception:
+                        pass
+            thread.start()
 
         if getattr(self, "current_analysis_thread", None) is None:
             for btn_name in ("save_button", "next_button"):
@@ -4184,14 +4186,16 @@ class CardEditorApp:
                 with Image.open(path) as img:
                     fp = compute_fingerprint(img)
                 self.current_fingerprint = fp
-                fp_match = self.hash_db.best_match(fp, max_distance=HASH_MATCH_THRESHOLD)
+                fp_match = self.hash_db.best_match(
+                    fp, max_distance=HASH_MATCH_THRESHOLD
+                )
             except (OSError, UnidentifiedImageError, ValueError) as exc:
                 logger.warning("Fingerprint lookup failed for %s: %s", path, exc)
                 fp_match = None
         if update_progress:
             self.root.after(0, lambda: update_progress(0.5))
 
-        if fp_match:
+        if fp_match and fp_match.distance == 0:
             meta = fp_match.meta
             result = {
                 "name": meta.get("nazwa", meta.get("name", "")),

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -6,7 +6,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, call
 import tkinter as tk
-from PIL import Image
+from PIL import Image, ImageDraw
 
 sys.modules["customtkinter"] = SimpleNamespace(
     CTkEntry=tk.Entry,
@@ -15,6 +15,7 @@ sys.modules["customtkinter"] = SimpleNamespace(
     CTkToplevel=MagicMock,
 )
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+from hash_db import HashDB
 import kartoteka.ui as ui
 importlib.reload(ui)
 
@@ -596,6 +597,71 @@ def test_analyze_and_fill_uses_hash_db(monkeypatch):
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "1")
     set_var.set.assert_called_with(SV01_NAME)
+
+
+def test_analyze_and_fill_runs_full_pipeline_for_non_matching_card(tmp_path):
+    """Ensure analysis is run when fingerprint distance is non-zero."""
+    # create and store first card fingerprint
+    db = HashDB(str(tmp_path / "hashes.sqlite"))
+
+    def _create_image(path, variant=False):
+        img = Image.new("RGB", (64, 64), "white")
+        draw = ImageDraw.Draw(img)
+        if variant:
+            draw.rectangle([0, 0, 20, 20], fill="black")
+        else:
+            draw.rectangle([16, 16, 48, 48], fill="black")
+        img.save(path)
+        return img
+
+    first = tmp_path / "first.png"
+    _create_image(first)
+    db.add_card_from_image(str(first), meta={"name": "First"})
+
+    second = tmp_path / "second.png"
+    _create_image(second, variant=True)
+
+    name_entry = MagicMock()
+    num_entry = MagicMock()
+    set_var = MagicMock()
+    name_entry.delete = MagicMock()
+    name_entry.insert = MagicMock()
+    num_entry.delete = MagicMock()
+    num_entry.insert = MagicMock()
+    set_var.set = MagicMock()
+
+    dummy = SimpleNamespace(
+        root=SimpleNamespace(after=lambda delay, func: func()),
+        lang_var=None,
+        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var},
+        index=0,
+        update_set_options=lambda: None,
+        update_set_area_preview=lambda *a, **k: None,
+        hash_db=db,
+        auto_lookup=True,
+        current_fingerprint=None,
+    )
+    dummy._apply_analysis_result = ui.CardEditorApp._apply_analysis_result.__get__(
+        dummy, ui.CardEditorApp
+    )
+
+    with patch.object(
+        ui,
+        "analyze_card_image",
+        return_value={
+            "name": "Second",
+            "number": "002",
+            "total": "",
+            "set": "",
+            "set_code": "",
+            "orientation": 0,
+            "set_format": "",
+        },
+    ) as mock_analyze:
+        ui.CardEditorApp._analyze_and_fill(dummy, str(second), 0)
+
+    mock_analyze.assert_called_once()
+    name_entry.insert.assert_called_with(0, "Second")
 
 
 def test_show_card_fills_from_inventory(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- require exact fingerprint match (`distance == 0`) before using metadata
- always run full analysis when match is absent or non-zero distance
- add regression test ensuring non-matching cards trigger analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5700c225c832f80d79f6144e8774d