### PR TITLE
Display warehouse codes on separate lines

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3061,23 +3061,40 @@ class CardEditorApp:
             ("price", "Price"),
             ("warehouse_code", "Warehouse Code"),
         ]
-        for i, (key, label) in enumerate(fields):
+        row_idx = 0
+        for key, label in fields:
             val = row.get(key, "")
             if key == "warehouse_code":
                 codes = [c.strip() for c in str(val).split(";") if c.strip()]
-                val = ", ".join(codes)
+                if len(codes) > 1:
+                    ctk.CTkLabel(
+                        right,
+                        text=_("Kody magazynowe:"),
+                        font=("Inter", 16),
+                    ).grid(row=row_idx, column=0, sticky="w", pady=2)
+                    row_idx += 1
+                    for code in codes:
+                        ctk.CTkLabel(
+                            right,
+                            text=code,
+                            font=("Inter", 16),
+                        ).grid(row=row_idx, column=0, sticky="w", pady=2)
+                        row_idx += 1
+                    continue
+                val = "\n".join(codes)
             ctk.CTkLabel(
                 right,
                 text=f"{label}: {val}",
                 font=("Inter", 16),
-            ).grid(row=i, column=0, sticky="w", pady=2)
+            ).grid(row=row_idx, column=0, sticky="w", pady=2)
+            row_idx += 1
 
         # Button to mark the card as sold
         ctk.CTkButton(
             right,
             text="Sprzedano",
             command=lambda: self.mark_as_sold(row, top),
-        ).grid(row=len(fields), column=0, pady=10, sticky="w")
+        ).grid(row=row_idx, column=0, pady=10, sticky="w")
 
     def mark_as_sold(self, row: dict, window=None):
         """Mark the card as sold, update CSV and refresh views."""

--- a/tests/test_show_card_details_warehouse_codes.py
+++ b/tests/test_show_card_details_warehouse_codes.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+from pathlib import Path
+from PIL import Image
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import kartoteka.ui as ui
+from tests.ctk_mocks import DummyCTkFrame, DummyCTkLabel, DummyCTkButton
+
+
+def test_show_card_details_splits_warehouse_codes(monkeypatch):
+    top = SimpleNamespace(
+        title=lambda t: None,
+        geometry=lambda *a, **k: None,
+        minsize=lambda *a, **k: None,
+    )
+    monkeypatch.setattr(ui.ctk, "CTkToplevel", lambda master: top)
+    monkeypatch.setattr(ui.ctk, "CTkFrame", DummyCTkFrame)
+    labels = []
+
+    class CapturingLabel(DummyCTkLabel):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            labels.append(self)
+
+    monkeypatch.setattr(ui.ctk, "CTkLabel", CapturingLabel)
+    monkeypatch.setattr(ui.ctk, "CTkButton", DummyCTkButton)
+    monkeypatch.setattr(ui, "_load_image", lambda path: Image.new("RGB", (1, 1)))
+    monkeypatch.setattr(ui, "_create_image", lambda img: SimpleNamespace())
+
+    app = SimpleNamespace(root=None, mark_as_sold=lambda *a, **k: None)
+    ui.CardEditorApp.show_card_details(app, {"warehouse_code": "K1;K2"})
+
+    texts = [lbl.text for lbl in labels]
+    assert "Kody magazynowe:" in texts
+    assert "K1" in texts
+    assert "K2" in texts


### PR DESCRIPTION
## Summary
- Show warehouse codes on separate lines and add a header when multiple codes exist
- Test that card details split warehouse codes correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58572d020832fa9b21f56e37a7bb9