### PR TITLE
Handle closing of card details window

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3021,8 +3021,14 @@ class CardEditorApp:
             top.lift()
         if hasattr(top, "focus_force"):
             top.focus_force()
-        if hasattr(top, "protocol") and hasattr(top, "grab_release"):
-            top.protocol("WM_DELETE_WINDOW", top.grab_release)
+
+        def close_details():
+            if hasattr(top, "grab_release"):
+                top.grab_release()
+            top.destroy()
+
+        if hasattr(top, "protocol"):
+            top.protocol("WM_DELETE_WINDOW", close_details)
         top.title(row.get("name", _("Karta")))
         # ensure enough space for side-by-side layout
         if hasattr(top, "geometry"):
@@ -3094,6 +3100,14 @@ class CardEditorApp:
             right,
             text="Sprzedano",
             command=lambda: self.mark_as_sold(row, top),
+        ).grid(row=row_idx, column=0, pady=10, sticky="w")
+        row_idx += 1
+
+        # Explicit close button
+        ctk.CTkButton(
+            right,
+            text="Zamknij",
+            command=close_details,
         ).grid(row=row_idx, column=0, pady=10, sticky="w")
 
     def mark_as_sold(self, row: dict, window=None):

--- a/tests/test_show_card_details_sprzedano_button.py
+++ b/tests/test_show_card_details_sprzedano_button.py
@@ -15,11 +15,11 @@ def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
         encoding="utf-8",
     )
 
-    created = {}
+    created = []
 
     class DummyButton:
         def __init__(self, master=None, **kwargs):
-            created["kwargs"] = kwargs
+            created.append(kwargs)
 
         def grid(self, *a, **k):
             return self
@@ -86,10 +86,10 @@ def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
 
     ui.CardEditorApp.show_card_details(app, row)
 
-    assert created["kwargs"]["text"] == "Sprzedano"
+    sprzedano_btn = next(b for b in created if b["text"] == "Sprzedano")
 
     # Simulate button press
-    created["kwargs"]["command"]()
+    sprzedano_btn["command"]()
 
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")


### PR DESCRIPTION
## Summary
- Add `close_details` helper to release grab and destroy card detail window
- Wire window close protocol and new `Zamknij` button to `close_details`
- Update tests to handle multiple buttons in card details dialog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5886dfc7c832f97a1b00de44fa20a