### PR TITLE
Handle magazyn duplicates with differing images

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2587,14 +2587,13 @@ class CardEditorApp:
                 reader = csv.DictReader(f, delimiter=";")
                 groups: dict[tuple[str, ...], list[dict]] = defaultdict(list)
                 for row in reader:
-                    if not (row.get("name") and row.get("image")):
-                        logger.warning("Skipping row with missing name or image: %s", row)
+                    if not row.get("name"):
+                        logger.warning("Skipping row with missing name: %s", row)
                         continue
                     key = (
                         row.get("name"),
                         row.get("number"),
                         row.get("set"),
-                        row.get("image"),
                         row.get("variant") or "common",
                         str(row.get("sold") or ""),
                     )
@@ -2602,6 +2601,11 @@ class CardEditorApp:
 
                 for rows in groups.values():
                     combined = dict(rows[0])
+                    combined["image"] = next(
+                        (r.get("image") for r in rows if r.get("image")),
+                        "",
+                    )
+                    combined["variant"] = combined.get("variant") or "common"
                     codes = [
                         r.get("warehouse_code", "") for r in rows if r.get("warehouse_code")
                     ]

--- a/tests/test_magazyn_badge_display.py
+++ b/tests/test_magazyn_badge_display.py
@@ -20,9 +20,9 @@ def test_badge_display_for_duplicates_only(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
         "name;number;set;warehouse_code;price;image;variant\n"
-        "A;1;S;K1R1P1;1;foo.png;common\n"
-        "A;1;S;K1R1P2;1;foo.png;common\n"
-        "B;2;S;K1R1P3;1;foo.png;common\n",
+        "A;1;S;K1R1P1;1;foo1.png;common\n"
+        "A;1;S;K1R1P2;1;foo2.png;common\n"
+        "B;2;S;K1R1P3;1;foo3.png;common\n",
         encoding="utf-8",
     )
 

--- a/tests/test_magazyn_duplicates.py
+++ b/tests/test_magazyn_duplicates.py
@@ -19,8 +19,8 @@ def test_group_duplicates(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
         "name;number;set;warehouse_code;price;image;variant\n"
-        "A;1;S;K1R1P1;1;foo.png;common\n"
-        "A;1;S;K1R1P2;1;foo.png;common\n",
+        "A;1;S;K1R1P1;1;foo1.png;common\n"
+        "A;1;S;K1R1P2;1;foo2.png;common\n",
         encoding="utf-8",
     )
 
@@ -65,3 +65,4 @@ def test_group_duplicates(tmp_path):
     row = app.mag_card_rows[0]
     assert row["_count"] == 2
     assert row["warehouse_code"] == "K1R1P1;K1R1P2"
+    assert row["image"] == "foo1.png"


### PR DESCRIPTION
## Summary
- group magazyn inventory rows by card fields excluding image so duplicates with different filenames merge
- keep first available image path, merge unique warehouse codes and store duplicate count
- add tests for differing image filenames and badge display for duplicates

## Testing
- `python3 -m pytest tests/test_magazyn_duplicates.py tests/test_magazyn_badge_display.py -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b58b7ae514832f81a67cfebc6968f7