### PR TITLE
Add variant and sold filters to Magazyn search

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2565,6 +2565,14 @@ class CardEditorApp:
         )
         sort_menu.pack(side="left", padx=5, pady=5)
 
+        self.mag_sold_filter_var = _safe_var("all")
+        sold_filter_menu = ctk.CTkOptionMenu(
+            control_frame,
+            variable=self.mag_sold_filter_var,
+            values=["all", "sold", "unsold"],
+        )
+        sold_filter_menu.pack(side="left", padx=5, pady=5)
+
         list_frame = ctk.CTkScrollableFrame(self.magazyn_frame, fg_color=LIGHT_BG_COLOR)
         list_frame.pack(expand=True, fill="both", padx=10, pady=10)
         # store reference for resize handling
@@ -2694,16 +2702,28 @@ class CardEditorApp:
             def _update_mag_list(*_):
                 query = self.mag_search_var.get().lower()
                 sort_key = self.mag_sort_var.get()
-                indices = [
-                    i
-                    for i, r in enumerate(self.mag_card_rows)
-                    if (
-                        query in r.get("name", "").lower()
-                        or query in str(r.get("number", "")).lower()
-                        or query in r.get("set", "").lower()
-                        or query in r.get("warehouse_code", "").lower()
+                status_filter = self.mag_sold_filter_var.get()
+
+                def _matches(row: dict) -> bool:
+                    is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
+                    if status_filter == "sold" and not is_sold:
+                        return False
+                    if status_filter == "unsold" and is_sold:
+                        return False
+                    price_str = str(row.get("price", "")).replace(",", ".")
+                    variant = (row.get("variant") or "").lower()
+                    return (
+                        query in row.get("name", "").lower()
+                        or query in str(row.get("number", "")).lower()
+                        or query in row.get("set", "").lower()
+                        or query in row.get("warehouse_code", "").lower()
+                        or query in variant
+                        or query in price_str
+                        or (query == "sold" and is_sold)
+                        or (query == "unsold" and not is_sold)
                     )
-                ]
+
+                indices = [i for i, r in enumerate(self.mag_card_rows) if _matches(r)]
                 if sort_key == "name":
                     indices.sort(key=lambda i: self.mag_card_rows[i].get("name", ""))
                 elif sort_key == "price":
@@ -2791,10 +2811,15 @@ class CardEditorApp:
                 bind("<Configure>", _relayout_mag_cards)
 
             self.mag_search_var.trace_add("write", _update_mag_list)
+            self.mag_sold_filter_var.trace_add("write", _update_mag_list)
             if hasattr(sort_menu, "configure"):
                 sort_menu.configure(command=lambda _: _update_mag_list())
             else:
                 sort_menu.command = lambda _: _update_mag_list()
+            if hasattr(sold_filter_menu, "configure"):
+                sold_filter_menu.configure(command=lambda _: _update_mag_list())
+            else:
+                sold_filter_menu.command = lambda _: _update_mag_list()
             _update_mag_list()
 
         btn_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)

--- a/tests/test_magazyn_search_filters.py
+++ b/tests/test_magazyn_search_filters.py
@@ -1,0 +1,97 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parent))
+from ctk_mocks import (
+    DummyCTkButton,
+    DummyCTkEntry,
+    DummyCTkFrame,
+    DummyCTkLabel,
+    DummyCTkOptionMenu,
+    DummyCTkScrollableFrame,
+    DummyCanvas,
+)
+
+
+def _load_app(csv_path, stats):
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+        CTkScrollableFrame=DummyCTkScrollableFrame,
+        CTkEntry=DummyCTkEntry,
+        CTkOptionMenu=DummyCTkOptionMenu,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
+         patch.object(ui.tk, "Canvas", DummyCanvas), \
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)), \
+         patch.object(ui.csv_utils, "get_inventory_stats", return_value=stats):
+        dummy_root = SimpleNamespace(
+            minsize=lambda *a, **k: None,
+            title=lambda *a, **k: None,
+        )
+        app = SimpleNamespace(
+            root=dummy_root,
+            start_frame=None,
+            pricing_frame=None,
+            shoper_frame=None,
+            frame=None,
+            magazyn_frame=None,
+            location_frame=None,
+            create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+            refresh_magazyn=lambda: None,
+            back_to_welcome=lambda: None,
+        )
+        ui.CardEditorApp.open_magazyn_window(app)
+        return app
+
+
+def test_search_by_variant(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;variant\n"
+        "A;1;S;K1;10;foo.png;holo\n"
+        "B;2;S;K2;5;foo.png;reverse\n",
+        encoding="utf-8",
+    )
+    app = _load_app(csv_path, (2, 15.0, 0, 0))
+
+    app.mag_search_var.set("holo")
+    assert len(app.mag_card_labels) == 1
+    assert app.mag_card_labels[0].text == "A"
+
+
+def test_search_by_sold_status(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;variant;sold\n"
+        "A;1;S;K1;1;foo.png;common;\n"
+        "B;2;S;K2;1;foo.png;common;1\n",
+        encoding="utf-8",
+    )
+    app = _load_app(csv_path, (1, 1.0, 1, 1.0))
+
+    app.mag_search_var.set("sold")
+    assert len(app.mag_sold_labels) == 1
+    assert len(app.mag_card_labels) == 0
+
+    app.mag_search_var.set("unsold")
+    assert len(app.mag_card_labels) == 1
+    assert len(app.mag_sold_labels) == 0
+
+    app.mag_search_var.set("")
+    app.mag_sold_filter_var.set("sold")
+    assert len(app.mag_sold_labels) == 1
+    assert len(app.mag_card_labels) == 0
+
+    app.mag_sold_filter_var.set("unsold")
+    assert len(app.mag_card_labels) == 1
+    assert len(app.mag_sold_labels) == 0


### PR DESCRIPTION
## Summary
- Expand warehouse search to include variant, price, and sold state.
- Add a dropdown for filtering sold vs. unsold cards.
- Test searching by variant and sold status.

## Testing
- `pytest tests/test_magazyn_search_filters.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58c6a81c8832f9d4f257ea1cf012c