### PR TITLE
Handle destroyed entries when saving card data

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5169,8 +5169,18 @@ class CardEditorApp:
     def save_current_data(self):
         """Store the data for the currently displayed card without changing
         the index."""
-        data = {k: v.get() for k, v in self.entries.items()}
+        data: dict[str, str] = {}
+        for k, v in self.entries.items():
+            try:
+                if hasattr(v, "winfo_exists") and not v.winfo_exists():
+                    continue
+                data[k] = v.get()
+            except tk.TclError:
+                continue
         data.setdefault("psa10_price", "")
+        data.setdefault("nazwa", "")
+        data.setdefault("numer", "")
+        data.setdefault("set", "")
         name = data.get("nazwa")
         number = data.get("numer")
         set_name = data.get("set")

--- a/tests/test_save_and_next_destroyed_widgets.py
+++ b/tests/test_save_and_next_destroyed_widgets.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+import tkinter as tk
+
+# Provide dummy customtkinter before importing UI module
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parent))
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui  # noqa: E402
+
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
+class DestroyedVar:
+    def winfo_exists(self):
+        return False
+
+    def get(self):
+        raise tk.TclError("bad window path name")
+
+
+def make_dummy():
+    dummy = SimpleNamespace(
+        entries={
+            "nazwa": DestroyedVar(),
+            "numer": DummyVar("4"),
+            "set": DummyVar("Base Set"),
+            "język": DummyVar("ENG"),
+            "stan": DummyVar("NM"),
+            "cena": DummyVar(""),
+            "psa10_price": DummyVar(""),
+        },
+        type_vars={"Reverse": DummyVar(False), "Holo": DummyVar(False)},
+        card_cache={},
+        cards=["card1.jpg", "card2.jpg"],
+        index=0,
+        folder_name="folder",
+        file_to_key={},
+        product_code_map={},
+        next_product_code=1,
+        next_free_location=lambda: "K1R1P1",
+        generate_location=lambda idx: "K1R1P1",
+        output_data=[None, None],
+        get_price_from_db=lambda *a: None,
+        fetch_card_price=lambda *a: None,
+        fetch_psa10_price=lambda *a: None,
+        show_card=MagicMock(),
+    )
+    dummy.save_current_data = ui.CardEditorApp.save_current_data.__get__(dummy)
+    return dummy
+
+
+def test_save_and_next_with_destroyed_entries():
+    dummy = make_dummy()
+    with patch.object(ui.storage, "save_last_product_code"), \
+        patch.object(ui.messagebox, "showinfo"), \
+        patch.object(ui.messagebox, "showwarning"):
+        ui.CardEditorApp.save_and_next(dummy)
+    assert dummy.output_data[0]["numer"] == "4"
+    assert dummy.output_data[0]["nazwa"] == ""
+    assert dummy.index == 1
+    dummy.show_card.assert_called_once()


### PR DESCRIPTION
## Summary
- skip destroyed entry widgets when collecting current card data
- add regression test for `save_and_next` with removed widgets

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b58d6b1780832fb8b327faff0b0ce2