### PR TITLE
Preserve magazyn thumbnails during search refreshes

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2741,8 +2741,7 @@ class CardEditorApp:
                 self.mag_card_frames = []
                 self.mag_card_labels = []
                 self.mag_sold_labels = []
-                for i in range(len(self.mag_card_image_labels)):
-                    self.mag_card_image_labels[i] = None
+                displayed = set(indices)
 
                 for idx in indices:
                     row = self.mag_card_rows[idx]
@@ -2803,6 +2802,10 @@ class CardEditorApp:
                         self.mag_sold_labels.append(label)
                     else:
                         self.mag_card_labels.append(label)
+
+                for i in range(len(self.mag_card_image_labels)):
+                    if i not in displayed:
+                        self.mag_card_image_labels[i] = None
 
                 _relayout_mag_cards()
 

--- a/tests/test_magazyn_search_filters.py
+++ b/tests/test_magazyn_search_filters.py
@@ -3,6 +3,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
+import time
+from PIL import Image
 
 sys.path.append(str(Path(__file__).resolve().parent))
 from ctk_mocks import (
@@ -95,3 +97,76 @@ def test_search_by_sold_status(tmp_path):
     app.mag_sold_filter_var.set("unsold")
     assert len(app.mag_card_labels) == 1
     assert len(app.mag_sold_labels) == 0
+
+
+def _load_app_with_delay(csv_path, stats):
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+        CTkScrollableFrame=DummyCTkScrollableFrame,
+        CTkEntry=DummyCTkEntry,
+        CTkOptionMenu=DummyCTkOptionMenu,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    placeholder_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
+    photo_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
+    def _photo_side_effect(*a, **k):
+        _photo_side_effect.calls += 1
+        return placeholder_mock if _photo_side_effect.calls == 1 else photo_mock
+    _photo_side_effect.calls = 0
+
+    def slow_load(path):
+        time.sleep(0.1)
+        return Image.new("RGB", (10, 10), "white")
+
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(patch.object(ui, "_load_image", side_effect=slow_load))
+    stack.enter_context(patch.object(ui.ImageTk, "PhotoImage", side_effect=_photo_side_effect))
+    stack.enter_context(patch.object(ui.tk, "Canvas", DummyCanvas))
+    stack.enter_context(patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)))
+    stack.enter_context(patch.object(ui.csv_utils, "get_inventory_stats", return_value=stats))
+
+    dummy_root = SimpleNamespace(
+        minsize=lambda *a, **k: None,
+        title=lambda *a, **k: None,
+    )
+    app = SimpleNamespace(
+        root=dummy_root,
+        start_frame=None,
+        pricing_frame=None,
+        shoper_frame=None,
+        frame=None,
+        magazyn_frame=None,
+        location_frame=None,
+        create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+        refresh_magazyn=lambda: None,
+        back_to_welcome=lambda: None,
+        show_card_details=lambda *a, **k: None,
+    )
+    ui.CardEditorApp.open_magazyn_window(app)
+    return app, photo_mock, stack
+
+
+def test_search_clear_keeps_thumbnails(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image\n"
+        "Card;1;S;K1;1;https://example.com/image.png\n",
+        encoding="utf-8",
+    )
+    app, photo, stack = _load_app_with_delay(csv_path, (1, 1.0, 0, 0))
+    try:
+        app.mag_search_var.set("x")
+        app.mag_search_var.set("")
+        for t in app._image_threads:
+            t.join()
+        assert app.mag_card_image_labels[0] is not None
+        assert app.mag_card_image_labels[0].image is photo
+    finally:
+        stack.close()


### PR DESCRIPTION
## Summary
- Avoid clearing all image label slots before replacement so background threads always have a valid target
- Ensure non-displayed rows clear image labels only after rebuilding
- Add regression test verifying thumbnails remain visible after search query is cleared

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5952e6ecc832f8070f1ae05e028b5