### PR TITLE
Handle marking individual warehouse codes as sold

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -23,6 +23,7 @@ import html
 import difflib
 import sys
 from typing import Iterable, Optional
+from types import SimpleNamespace
 from pydantic import BaseModel
 import pytesseract
 from pathlib import Path
@@ -3100,10 +3101,14 @@ class CardEditorApp:
             ("warehouse_code", "Warehouse Code"),
         ]
         row_idx = 0
+        selected_var = None
+        selected_default = ""
         for key, label in fields:
             val = row.get(key, "")
             if key == "warehouse_code":
                 codes = [c.strip() for c in str(val).split(";") if c.strip()]
+                if codes:
+                    selected_default = codes[0]
                 if len(codes) > 1:
                     ctk.CTkLabel(
                         right,
@@ -3111,13 +3116,16 @@ class CardEditorApp:
                         font=("Inter", 16),
                     ).grid(row=row_idx, column=0, sticky="w", pady=2)
                     row_idx += 1
-                    for code in codes:
-                        ctk.CTkLabel(
-                            right,
-                            text=code,
-                            font=("Inter", 16),
-                        ).grid(row=row_idx, column=0, sticky="w", pady=2)
-                        row_idx += 1
+                    try:
+                        selected_var = tk.StringVar(value=selected_default)
+                    except (tk.TclError, RuntimeError):
+                        selected_var = SimpleNamespace(get=lambda: selected_default)
+                    ctk.CTkOptionMenu(
+                        right,
+                        values=codes,
+                        variable=selected_var,
+                    ).grid(row=row_idx, column=0, sticky="w", pady=2)
+                    row_idx += 1
                     continue
                 val = "\n".join(codes)
             ctk.CTkLabel(
@@ -3131,7 +3139,11 @@ class CardEditorApp:
         ctk.CTkButton(
             right,
             text="Sprzedano",
-            command=lambda: self.mark_as_sold(row, top),
+            command=lambda: self.mark_as_sold(
+                row,
+                top,
+                selected_var.get() if selected_var is not None else selected_default,
+            ),
         ).grid(row=row_idx, column=0, pady=10, sticky="w")
         row_idx += 1
 
@@ -3142,7 +3154,12 @@ class CardEditorApp:
             command=close_details,
         ).grid(row=row_idx, column=0, pady=10, sticky="w")
 
-    def mark_as_sold(self, row: dict, window=None):
+    def mark_as_sold(
+        self,
+        row: dict,
+        window=None,
+        warehouse_code: Optional[str] = None,
+    ):
         """Mark the card as sold, update CSV and refresh views."""
 
         csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
@@ -3157,17 +3174,31 @@ class CardEditorApp:
         if "sold" not in fieldnames:
             fieldnames.append("sold")
 
-        target = str(row.get("warehouse_code", ""))
+        codes = [
+            c.strip()
+            for c in str(row.get("warehouse_code", "")).split(";")
+            if c.strip()
+        ]
+        target = warehouse_code or (codes[0] if codes else "")
         for r in rows:
             if r.get("warehouse_code") == target:
                 r["sold"] = "1"
-                row["sold"] = "1"
                 break
 
         with open(csv_path, "w", newline="", encoding="utf-8") as f:
             writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
             writer.writeheader()
             writer.writerows(rows)
+
+        if target in codes:
+            codes.remove(target)
+            row["warehouse_code"] = ";".join(codes)
+        if "_count" in row:
+            try:
+                row["_count"] = max(int(row.get("_count", 1)) - 1, 0)
+            except Exception:
+                row["_count"] = max(len(codes), 0)
+        row["sold"] = "1" if not codes else ""
 
         if window is not None:
             try:
@@ -3178,7 +3209,7 @@ class CardEditorApp:
         if hasattr(self, "update_inventory_stats"):
             try:
                 self.update_inventory_stats()
-            except Exception as exc:
+            except Exception:
                 logger.exception("Failed to update inventory stats")
 
         if hasattr(self, "open_magazyn_window"):

--- a/tests/test_mark_as_sold_multiple_codes.py
+++ b/tests/test_mark_as_sold_multiple_codes.py
@@ -1,0 +1,84 @@
+import csv
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;sold\n"
+        "A;1;S;K1;1;;\n"
+        "A;1;S;K2;1;;\n",
+        encoding="utf-8",
+    )
+
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    from tests.ctk_mocks import (
+        DummyCTkButton,
+        DummyCTkEntry,
+        DummyCTkFrame,
+        DummyCTkLabel,
+        DummyCTkOptionMenu,
+        DummyCTkScrollableFrame,
+        DummyCanvas,
+    )
+
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+        CTkScrollableFrame=DummyCTkScrollableFrame,
+        CTkEntry=DummyCTkEntry,
+        CTkOptionMenu=DummyCTkOptionMenu,
+    )
+
+    import kartoteka.ui as ui
+    import importlib
+
+    importlib.reload(ui)
+
+    photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
+    monkeypatch.setattr(ui.ImageTk, "PhotoImage", lambda *a, **k: photo_mock)
+    monkeypatch.setattr(ui.tk, "Canvas", DummyCanvas)
+    monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
+    monkeypatch.setattr(ui, "_load_image", lambda path: None)
+
+    dummy_root = SimpleNamespace(minsize=lambda *a, **k: None, title=lambda *a, **k: None)
+    app = SimpleNamespace(
+        root=dummy_root,
+        start_frame=None,
+        pricing_frame=None,
+        shoper_frame=None,
+        frame=None,
+        magazyn_frame=None,
+        location_frame=None,
+        create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+        refresh_magazyn=lambda: None,
+        back_to_welcome=lambda: None,
+    )
+
+    ui.CardEditorApp.open_magazyn_window(app)
+
+    row = app.mag_card_rows[0]
+    assert row["warehouse_code"] == "K1;K2"
+    assert row["_count"] == 2
+
+    app.update_inventory_stats = lambda: None
+    app.open_magazyn_window = lambda: ui.CardEditorApp.open_magazyn_window(app)
+
+    ui.CardEditorApp.mark_as_sold(app, row, warehouse_code="K1")
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f, delimiter=";"))
+
+    assert any(r["warehouse_code"] == "K1" and r.get("sold") == "1" for r in rows)
+    assert any(r["warehouse_code"] == "K2" and not r.get("sold") for r in rows)
+
+    assert row["warehouse_code"] == "K2"
+    assert row["_count"] == 1
+
+    assert len(app.mag_card_rows) == 2
+    unsold = next(r for r in app.mag_card_rows if not r.get("sold"))
+    assert unsold["warehouse_code"] == "K2"
+    assert unsold["_count"] == 1
+

--- a/tests/test_show_card_details_sprzedano_button.py
+++ b/tests/test_show_card_details_sprzedano_button.py
@@ -73,7 +73,9 @@ def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
         open_magazyn_window=open_mock,
         update_inventory_stats=stats_mock,
     )
-    app.mark_as_sold = lambda r, w=None: ui.CardEditorApp.mark_as_sold(app, r, w)
+    app.mark_as_sold = lambda r, w=None, c=None: ui.CardEditorApp.mark_as_sold(
+        app, r, w, c
+    )
 
     row = {
         "name": "A",

--- a/tests/test_show_card_details_warehouse_codes.py
+++ b/tests/test_show_card_details_warehouse_codes.py
@@ -5,8 +5,12 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-import kartoteka.ui as ui
-from tests.ctk_mocks import DummyCTkFrame, DummyCTkLabel, DummyCTkButton
+from tests.ctk_mocks import (
+    DummyCTkFrame,
+    DummyCTkLabel,
+    DummyCTkButton,
+    DummyCTkOptionMenu,
+)
 
 
 def test_show_card_details_splits_warehouse_codes(monkeypatch):
@@ -15,17 +19,31 @@ def test_show_card_details_splits_warehouse_codes(monkeypatch):
         geometry=lambda *a, **k: None,
         minsize=lambda *a, **k: None,
     )
-    monkeypatch.setattr(ui.ctk, "CTkToplevel", lambda master: top)
-    monkeypatch.setattr(ui.ctk, "CTkFrame", DummyCTkFrame)
     labels = []
+    option_menus = []
 
     class CapturingLabel(DummyCTkLabel):
         def __init__(self, *a, **k):
             super().__init__(*a, **k)
             labels.append(self)
 
-    monkeypatch.setattr(ui.ctk, "CTkLabel", CapturingLabel)
-    monkeypatch.setattr(ui.ctk, "CTkButton", DummyCTkButton)
+    class CapturingOptionMenu(DummyCTkOptionMenu):
+        def __init__(self, *a, **k):
+            super().__init__(*a, **k)
+            option_menus.append(self)
+
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkToplevel=lambda master: top,
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=CapturingLabel,
+        CTkButton=DummyCTkButton,
+        CTkOptionMenu=CapturingOptionMenu,
+    )
+
+    import importlib
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
     monkeypatch.setattr(ui, "_load_image", lambda path: Image.new("RGB", (1, 1)))
     monkeypatch.setattr(ui, "_create_image", lambda img: SimpleNamespace())
 
@@ -34,5 +52,4 @@ def test_show_card_details_splits_warehouse_codes(monkeypatch):
 
     texts = [lbl.text for lbl in labels]
     assert "Kody magazynowe:" in texts
-    assert "K1" in texts
-    assert "K2" in texts
+    assert option_menus[0].values == ["K1", "K2"]


### PR DESCRIPTION
## Summary
- let users choose which warehouse code was shipped when a card has duplicates
- update `mark_as_sold` to only flag the selected code and adjust group counts
- refresh inventory after sale and add regression tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b598f80bfc832fb00881c1516241e1