### PR TITLE
Add Shoper order completion support

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1725,6 +1725,12 @@ class CardEditorApp:
         ).grid(row=1, column=0, pady=5)
 
         self.create_button(
+            orders_tab,
+            text="Potwierdź zamówienie",
+            command=self.confirm_order,
+        ).grid(row=2, column=0, pady=5)
+
+        self.create_button(
             self.shoper_frame,
             text="Powrót",
             command=self.back_to_welcome,
@@ -2393,6 +2399,7 @@ class CardEditorApp:
                 return
             orders = self.shoper_client.list_orders({"filters[status]": "new"})
             orders_list = orders.get("list", orders)
+            self.pending_orders = orders_list
             choose_nearest_locations(orders_list, self.output_data)
             widget.delete("1.0", tk.END)
             lines = []
@@ -2418,6 +2425,70 @@ class CardEditorApp:
         except requests.RequestException as e:
             logger.exception("Failed to list orders")
             messagebox.showerror("Błąd", str(e))
+
+    def complete_order(self, order: dict):
+        """Mark warehouse codes from ``order`` as sold.
+
+        After updating the CSV the inventory statistics are recalculated and
+        the warehouse view is refreshed.
+        """
+
+        csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
+        try:
+            with open(csv_path, newline="", encoding="utf-8") as f:
+                reader = csv.DictReader(f, delimiter=";")
+                rows = list(reader)
+                fieldnames = reader.fieldnames or []
+        except FileNotFoundError:
+            return
+
+        if "sold" not in fieldnames:
+            fieldnames.append("sold")
+
+        codes_to_mark = {
+            c.strip()
+            for item in order.get("products", [])
+            for c in str(
+                item.get("warehouse_code")
+                or item.get("product_code")
+                or item.get("code", "")
+            ).split(";")
+            if c.strip()
+        }
+
+        if not codes_to_mark:
+            return
+
+        for r in rows:
+            if r.get("warehouse_code") in codes_to_mark:
+                r["sold"] = "1"
+
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+            writer.writeheader()
+            writer.writerows(rows)
+
+        if hasattr(self, "update_inventory_stats"):
+            try:
+                self.update_inventory_stats()
+            except Exception:
+                logger.exception("Failed to update inventory stats")
+
+        if hasattr(self, "open_magazyn_window"):
+            try:
+                self.open_magazyn_window()
+            except Exception:
+                logger.exception("Failed to refresh magazyn window")
+
+    def confirm_order(self):
+        """Confirm the first pending order and mark codes as sold."""
+
+        orders = getattr(self, "pending_orders", [])
+        if not orders:
+            return
+        order = orders.pop(0)
+        self.complete_order(order)
+
     @staticmethod
     def location_from_code(code: str) -> str:
         return storage.location_from_code(code)

--- a/tests/test_confirm_order_updates_sold_flags.py
+++ b/tests/test_confirm_order_updates_sold_flags.py
@@ -1,0 +1,41 @@
+import csv
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_confirm_order_updates_csv(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;warehouse_code;price;sold\n"
+        "A;K1;1;\n"
+        "B;K2;2;\n",
+        encoding="utf-8",
+    )
+
+    sys.modules.setdefault("customtkinter", MagicMock())
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    import importlib
+    importlib.reload(ui)
+
+    monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
+
+    stats_called = []
+    refresh_called = []
+    app = SimpleNamespace(
+        update_inventory_stats=lambda: stats_called.append(True),
+        open_magazyn_window=lambda: refresh_called.append(True),
+        pending_orders=[{"products": [{"warehouse_code": "K1;K2"}]}],
+    )
+    app.complete_order = lambda order: ui.CardEditorApp.complete_order(app, order)
+
+    ui.CardEditorApp.confirm_order(app)
+
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f, delimiter=";"))
+
+    assert all(r.get("sold") == "1" for r in rows)
+    assert stats_called
+    assert refresh_called


### PR DESCRIPTION
## Summary
- mark warehouse codes as sold when confirming an order
- add confirmation button and refresh inventory after order completion
- test that confirming an order flags used codes as sold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b59afd2128832fb313be1410290021