### PR TITLE
Display parsed warehouse code details in card editor

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3180,25 +3180,86 @@ class CardEditorApp:
                 codes = [c.strip() for c in str(val).split(";") if c.strip()]
                 if codes:
                     selected_default = codes[0]
-                if len(codes) > 1:
+                    pattern = re.compile(r"K(\d+)R(\d+)P(\d+)")
+                    parsed = []
+                    for code in codes:
+                        m = pattern.fullmatch(code)
+                        if m:
+                            parsed.append((code, m.group(1), m.group(2), m.group(3)))
+                        else:  # pragma: no cover - unexpected format
+                            parsed.append((code, "", "", ""))
+
+                    if len(parsed) > 1:
+                        ctk.CTkLabel(
+                            right,
+                            text=_("Kody magazynowe:"),
+                            font=("Inter", 16),
+                        ).grid(row=row_idx, column=0, sticky="w", pady=2)
+                        row_idx += 1
+                        try:
+                            selected_var = tk.StringVar(value=selected_default)
+                        except (tk.TclError, RuntimeError):
+                            selected_var = SimpleNamespace(get=lambda: selected_default)
+
+                        def update_labels(selected: str) -> None:
+                            info = next((p for p in parsed if p[0] == selected), parsed[0])
+                            karton_lbl.configure(text=f"Karton: {info[1]}")
+                            kolumna_lbl.configure(text=f"Kolumna: {info[2]}")
+                            pozycja_lbl.configure(text=f"Pozycja: {info[3]}")
+
+                        ctk.CTkOptionMenu(
+                            right,
+                            values=[p[0] for p in parsed],
+                            variable=selected_var,
+                            command=update_labels,
+                        ).grid(row=row_idx, column=0, sticky="w", pady=2)
+                        row_idx += 1
+
+                        karton_lbl = ctk.CTkLabel(
+                            right,
+                            text=f"Karton: {parsed[0][1]}",
+                            font=("Inter", 16),
+                        )
+                        karton_lbl.grid(row=row_idx, column=0, sticky="w", pady=2)
+                        row_idx += 1
+                        kolumna_lbl = ctk.CTkLabel(
+                            right,
+                            text=f"Kolumna: {parsed[0][2]}",
+                            font=("Inter", 16),
+                        )
+                        kolumna_lbl.grid(row=row_idx, column=0, sticky="w", pady=2)
+                        row_idx += 1
+                        pozycja_lbl = ctk.CTkLabel(
+                            right,
+                            text=f"Pozycja: {parsed[0][3]}",
+                            font=("Inter", 16),
+                        )
+                        pozycja_lbl.grid(row=row_idx, column=0, sticky="w", pady=2)
+                        row_idx += 1
+                        continue
+
+                    # single code
+                    c = parsed[0]
                     ctk.CTkLabel(
                         right,
-                        text=_("Kody magazynowe:"),
+                        text=f"Karton: {c[1]}",
                         font=("Inter", 16),
                     ).grid(row=row_idx, column=0, sticky="w", pady=2)
                     row_idx += 1
-                    try:
-                        selected_var = tk.StringVar(value=selected_default)
-                    except (tk.TclError, RuntimeError):
-                        selected_var = SimpleNamespace(get=lambda: selected_default)
-                    ctk.CTkOptionMenu(
+                    ctk.CTkLabel(
                         right,
-                        values=codes,
-                        variable=selected_var,
+                        text=f"Kolumna: {c[2]}",
+                        font=("Inter", 16),
+                    ).grid(row=row_idx, column=0, sticky="w", pady=2)
+                    row_idx += 1
+                    ctk.CTkLabel(
+                        right,
+                        text=f"Pozycja: {c[3]}",
+                        font=("Inter", 16),
                     ).grid(row=row_idx, column=0, sticky="w", pady=2)
                     row_idx += 1
                     continue
-                val = "\n".join(codes)
+
             ctk.CTkLabel(
                 right,
                 text=f"{label}: {val}",

--- a/tests/test_show_card_details_warehouse_codes.py
+++ b/tests/test_show_card_details_warehouse_codes.py
@@ -13,43 +13,101 @@ from tests.ctk_mocks import (
 )
 
 
-def test_show_card_details_splits_warehouse_codes(monkeypatch):
+labels: list = []
+option_menus: list = []
+buttons: list = []
+
+
+class CapturingLabel(DummyCTkLabel):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        labels.append(self)
+
+
+class CapturingOptionMenu(DummyCTkOptionMenu):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        option_menus.append(self)
+
+
+class CapturingButton(DummyCTkButton):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        buttons.append(k)
+
+
+def setup_ctk():
     top = SimpleNamespace(
         title=lambda t: None,
         geometry=lambda *a, **k: None,
         minsize=lambda *a, **k: None,
     )
-    labels = []
-    option_menus = []
-
-    class CapturingLabel(DummyCTkLabel):
-        def __init__(self, *a, **k):
-            super().__init__(*a, **k)
-            labels.append(self)
-
-    class CapturingOptionMenu(DummyCTkOptionMenu):
-        def __init__(self, *a, **k):
-            super().__init__(*a, **k)
-            option_menus.append(self)
-
     sys.modules["customtkinter"] = SimpleNamespace(
         CTkToplevel=lambda master: top,
         CTkFrame=DummyCTkFrame,
         CTkLabel=CapturingLabel,
-        CTkButton=DummyCTkButton,
+        CTkButton=CapturingButton,
         CTkOptionMenu=CapturingOptionMenu,
     )
+    return top
 
+
+def reload_ui(monkeypatch):
     import importlib
     import kartoteka.ui as ui
     importlib.reload(ui)
-
     monkeypatch.setattr(ui, "_load_image", lambda path: Image.new("RGB", (1, 1)))
     monkeypatch.setattr(ui, "_create_image", lambda img: SimpleNamespace())
+    return ui
+
+
+def test_show_card_details_displays_single_code_fields(monkeypatch):
+    global labels, option_menus, buttons
+    labels, option_menus, buttons = [], [], []
+    setup_ctk()
+    ui = reload_ui(monkeypatch)
 
     app = SimpleNamespace(root=None, mark_as_sold=lambda *a, **k: None)
-    ui.CardEditorApp.show_card_details(app, {"warehouse_code": "K1;K2"})
+    ui.CardEditorApp.show_card_details(app, {"warehouse_code": "K1R2P3"})
+
+    texts = [lbl.text for lbl in labels]
+    assert "Karton: 1" in texts
+    assert "Kolumna: 2" in texts
+    assert "Pozycja: 3" in texts
+
+
+def test_show_card_details_updates_labels_for_multiple_codes(monkeypatch):
+    global labels, option_menus, buttons
+    labels, option_menus, buttons = [], [], []
+    setup_ctk()
+    ui = reload_ui(monkeypatch)
+
+    captured = []
+    app = SimpleNamespace(root=None, mark_as_sold=lambda r, w=None, c=None: captured.append(c))
+
+    class DummyVar:
+        def __init__(self, value=""):
+            self._v = value
+
+        def get(self):
+            return self._v
+
+        def set(self, v):
+            self._v = v
+
+    monkeypatch.setattr(ui.tk, "StringVar", DummyVar)
+    ui.CardEditorApp.show_card_details(app, {"warehouse_code": "K1R1P1;K2R2P2"})
 
     texts = [lbl.text for lbl in labels]
     assert "Kody magazynowe:" in texts
-    assert option_menus[0].values == ["K1", "K2"]
+    assert option_menus[0].values == ["K1R1P1", "K2R2P2"]
+
+    option_menus[0].set("K2R2P2")
+    texts = [lbl.text for lbl in labels]
+    assert "Karton: 2" in texts
+    assert "Kolumna: 2" in texts
+    assert "Pozycja: 2" in texts
+
+    sprzedano_btn = next(b for b in buttons if b.get("text") == "Sprzedano")
+    sprzedano_btn["command"]()
+    assert captured == ["K2R2P2"]


### PR DESCRIPTION
## Summary
- parse warehouse codes into Karton/Kolumna/Pozycja details
- add option menu for selecting among multiple codes and update labels accordingly
- extend tests for single and multiple warehouse codes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a3ffbd78832fa67c97a22a50d177