### PR TITLE
Improve warehouse code and tooltip tests

### DIFF
--- a/tests/test_show_card_details_sprzedano_button.py
+++ b/tests/test_show_card_details_sprzedano_button.py
@@ -20,6 +20,9 @@ def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
     class DummyButton:
         def __init__(self, master=None, **kwargs):
             created.append(kwargs)
+        
+        def pack(self, *a, **k):
+            return self
 
         def grid(self, *a, **k):
             return self

--- a/tests/test_show_card_details_warehouse_codes.py
+++ b/tests/test_show_card_details_warehouse_codes.py
@@ -99,7 +99,12 @@ def test_show_card_details_updates_labels_for_multiple_codes(monkeypatch):
     ui.CardEditorApp.show_card_details(app, {"warehouse_code": "K1R1P1;K2R2P2"})
 
     texts = [lbl.text for lbl in labels]
+    # initial labels correspond to the first code
     assert "Kody magazynowe:" in texts
+    assert "Karton: 1" in texts
+    assert "Kolumna: 1" in texts
+    assert "Pozycja: 1" in texts
+    # option menu should expose raw codes for backend usage
     assert option_menus[0].values == ["K1R1P1", "K2R2P2"]
 
     option_menus[0].set("K2R2P2")

--- a/tests/test_tooltip_overrideredirect.py
+++ b/tests/test_tooltip_overrideredirect.py
@@ -1,0 +1,49 @@
+import sys
+from types import SimpleNamespace
+
+
+def test_tooltip_overrideredirect_called():
+    called = {
+        "flag": False
+    }
+
+    class DummyTop:
+        def wm_overrideredirect(self, value):
+            called["flag"] = value
+
+        def wm_geometry(self, *a, **k):
+            pass
+
+    top = DummyTop()
+
+    class DummyLabel:
+        def __init__(self, master=None, text=""):
+            pass
+
+        def pack(self, *a, **k):
+            return self
+
+    def fake_toplevel(parent):
+        return top
+
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkToplevel=fake_toplevel,
+        CTkLabel=DummyLabel,
+    )
+
+    import importlib
+    import tooltip
+    importlib.reload(tooltip)
+    Tooltip = tooltip.Tooltip
+
+    widget = SimpleNamespace(
+        bind=lambda *a, **k: None,
+        winfo_rootx=lambda: 0,
+        winfo_rooty=lambda: 0,
+        winfo_height=lambda: 0,
+    )
+
+    t = Tooltip(widget, "tip")
+    t.show()
+
+    assert called["flag"] is True


### PR DESCRIPTION
## Summary
- ensure warehouse code labels appear and update with selection
- allow dummy test buttons to `pack`
- verify tooltip uses `overrideredirect` for frameless windows

## Testing
- `pytest tests/test_show_card_details_warehouse_codes.py tests/test_show_card_details_sprzedano_button.py tests/test_tooltip_overrideredirect.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5a588b434832fa591cb48e926391b