### PR TITLE
Refactor box preview drawing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -99,6 +99,55 @@ _IMAGE_CACHE: dict[str, Optional[bytes]] = {}
 _THUMB_CACHE: dict[str, Image.Image] = {}
 
 
+def draw_box_usage(canvas: "tk.Canvas", box_num: int, occupancy: dict[int, int]) -> float:
+    """Draw occupancy of a single storage box on ``canvas``.
+
+    The function draws a rectangle for each column, filling it with
+    :data:`OCCUPIED_COLOR` when the column contains any cards.  It returns
+    the percentage of occupied slots within the box so callers can update
+    labels or other UI elements accordingly.
+    """
+
+    box_w = BOX_THUMB_SIZE
+    box_h = BOX_THUMB_SIZE
+    columns = storage.BOX_COLUMNS.get(box_num, 4)
+    counts = [occupancy.get(col, 0) for col in range(1, columns + 1)]
+    total_capacity = storage.BOX_CAPACITY.get(
+        box_num, columns * storage.BOX_COLUMN_CAPACITY
+    )
+    filled = sum(counts)
+    occupied_percent = filled / total_capacity * 100 if total_capacity else 0
+
+    col_w = box_w / columns
+
+    if hasattr(canvas, "find_all"):
+        rects = list(canvas.find_all())
+    else:  # fallback for DummyCanvas used in tests
+        rects = list(getattr(canvas, "items", {}).keys())
+
+    if len(rects) < columns:
+        for col in range(len(rects), columns):
+            x1 = col * col_w
+            x2 = (col + 1) * col_w
+            rid = canvas.create_rectangle(
+                x1, 0, x2, box_h, outline="black", width=1
+            )
+            rects.append(rid)
+    elif len(rects) > columns:
+        for rid in rects[columns:]:
+            canvas.delete(rid)
+        rects = rects[:columns]
+
+    for col, rid in enumerate(rects):
+        x1 = col * col_w
+        x2 = (col + 1) * col_w
+        canvas.coords(rid, x1, 0, x2, box_h)
+        fill = OCCUPIED_COLOR if counts[col] > 0 else ""
+        canvas.itemconfigure(rid, fill=fill)
+
+    return occupied_percent
+
+
 def _load_image(path: str) -> Optional[Image.Image]:
     """Load image from local path or URL with caching.
 
@@ -1458,10 +1507,19 @@ class CardEditorApp:
         self.inventory_value_label.pack(pady=(0, 5))
 
         CardEditorApp.build_box_preview(self, self.start_frame)
-        if hasattr(self, "refresh_magazyn"):
+        # Refresh the initial box preview if possible.  The welcome screen does
+        # not depend on the full warehouse window, therefore it prefers a
+        # lightweight ``refresh_home_preview`` method but falls back to the
+        # legacy ``refresh_magazyn`` if needed.
+        if hasattr(self, "refresh_home_preview"):
+            try:
+                self.refresh_home_preview()
+            except Exception:  # pragma: no cover - defensive logging
+                logger.exception("Failed to refresh magazyn preview")
+        elif hasattr(self, "refresh_magazyn"):
             try:
                 self.refresh_magazyn()
-            except Exception:
+            except Exception:  # pragma: no cover - defensive logging
                 logger.exception("Failed to refresh magazyn preview")
 
         config_btn = self.create_button(
@@ -2535,7 +2593,7 @@ class CardEditorApp:
             self.mag_canvases.append(canvas)
             self.mag_labels.append(lbl)
 
-        self.mag_canvas_items = [[] for _ in self.mag_canvases]
+        # Internal helpers used by the magazyn window; populated lazily.
         self.mag_card_images = []
         self.mag_card_rows = []
         self.mag_card_labels = []
@@ -2952,6 +3010,20 @@ class CardEditorApp:
         storage.repack_column(box, column)
         self.refresh_magazyn()
 
+    def refresh_home_preview(self):
+        """Refresh box preview on the welcome screen."""
+        if not getattr(self, "mag_canvases", None):
+            return
+
+        col_occ = storage.compute_column_occupancy()
+        order = getattr(self, "mag_box_order", None) or []
+
+        for idx, canvas in enumerate(self.mag_canvases):
+            box = order[idx] if idx < len(order) else idx + 1
+            percent = draw_box_usage(canvas, box, col_occ.get(box, {}))
+            if idx < len(self.mag_labels):
+                self.mag_labels[idx].configure(text=f"K{box}: {percent:.0f}%")
+
     def refresh_magazyn(self):
         """Refresh storage view and color occupied columns."""
         if not getattr(self, "mag_canvases", None):
@@ -2962,65 +3034,15 @@ class CardEditorApp:
 
         for idx, canvas in enumerate(self.mag_canvases):
             box = order[idx] if idx < len(order) else idx + 1
-            box_w = BOX_THUMB_SIZE
-            box_h = BOX_THUMB_SIZE
-            columns = storage.BOX_COLUMNS.get(box, 4)
+            percent = draw_box_usage(canvas, box, col_occ.get(box, {}))
+            if idx < len(self.mag_labels):
+                self.mag_labels[idx].configure(text=f"K{box}: {percent:.0f}%")
 
-            counts = [
-                col_occ.get(box, {}).get(col, 0) for col in range(1, columns + 1)
-            ]
-            total_capacity = storage.BOX_CAPACITY.get(
-                box, columns * storage.BOX_COLUMN_CAPACITY
-            )
-            filled = sum(counts)
-            occupied_percent = filled / total_capacity * 100 if total_capacity else 0
-
-            rects = self.mag_canvas_items[idx]
-            col_w = box_w / columns
-
-            if not rects:
-                for col in range(columns):
-                    x1 = col * col_w
-                    x2 = (col + 1) * col_w
-                    fill = OCCUPIED_COLOR if counts[col] > 0 else ""
-                    rect_id = canvas.create_rectangle(
-                        x1,
-                        0,
-                        x2,
-                        box_h,
-                        fill=fill,
-                        outline="black",
-                        width=1,
-                    )
-                    rects.append(rect_id)
-            else:
-                if columns < len(rects):
-                    for rid in rects[columns:]:
-                        canvas.delete(rid)
-                    rects[:] = rects[:columns]
-                elif columns > len(rects):
-                    for col in range(len(rects), columns):
-                        x1 = col * col_w
-                        x2 = (col + 1) * col_w
-                        rect_id = canvas.create_rectangle(
-                            x1,
-                            0,
-                            x2,
-                            box_h,
-                            outline="black",
-                            width=1,
-                        )
-                        rects.append(rect_id)
-                for col, rid in enumerate(rects):
-                    x1 = col * col_w
-                    x2 = (col + 1) * col_w
-                    canvas.coords(rid, x1, 0, x2, box_h)
-                    fill = OCCUPIED_COLOR if counts[col] > 0 else ""
-                    canvas.itemconfigure(rid, fill=fill)
-
-            self.mag_labels[idx].configure(text=f"K{box}: {occupied_percent:.0f}%")
-
-        self.update_inventory_stats()
+        if hasattr(self, "update_inventory_stats"):
+            try:
+                self.update_inventory_stats()
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.exception("Failed to update inventory stats")
 
     def show_card_details(self, row: dict):
         """Display details for a selected warehouse card."""

--- a/tests/test_column_occupancy.py
+++ b/tests/test_column_occupancy.py
@@ -61,6 +61,37 @@ def test_sold_cards_excluded_from_occupancy(tmp_path, monkeypatch):
     assert col_occ[1][1] == 1
 
 
+@pytest.mark.parametrize(
+    "csv_content, expected",
+    [
+        (
+            "name;warehouse_code\nA;K1R1P1\nB;K1R2P1\n",
+            {1: {1: 1, 2: 1, 3: 0, 4: 0}},
+        ),
+        (
+            "name;warehouse_code\nA;K2R3P1\nB;K2R3P2\n",
+            {2: {1: 0, 2: 0, 3: 2, 4: 0}},
+        ),
+        (
+            "name;warehouse_code\nA;K3R1P1\nB;K3R4P1\n",
+            {3: {1: 1, 2: 0, 3: 0, 4: 1}},
+        ),
+    ],
+)
+def test_compute_column_occupancy_various_inputs(
+    tmp_path, monkeypatch, csv_content, expected
+):
+    from kartoteka import csv_utils, storage
+
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(csv_content, encoding="utf-8")
+    monkeypatch.setattr(csv_utils, "INVENTORY_CSV", str(csv_path))
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(csv_path))
+
+    col_occ = storage.compute_column_occupancy()
+    for box, cols in expected.items():
+        assert col_occ[box] == cols
+
 def test_refresh_colors_columns_based_on_occupancy(tmp_path, monkeypatch):
     from kartoteka import csv_utils
 

--- a/tests/test_welcome_screen_box_preview.py
+++ b/tests/test_welcome_screen_box_preview.py
@@ -45,6 +45,7 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
             root=dummy_root,
             create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
             refresh_magazyn=lambda: None,
+            refresh_home_preview=lambda: None,
             open_config_dialog=lambda: None,
             show_location_frame=lambda: None,
             setup_pricing_ui=lambda: None,


### PR DESCRIPTION
## Summary
- extract `draw_box_usage` to render a single storage box
- refresh both welcome and magazyn views via shared drawing logic
- expand column occupancy tests for multiple input scenarios

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6797cbd9c832f9c87d5694e2cd40e