### PR TITLE
Remove warehouse CSV downloads

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -5,15 +5,12 @@ from typing import Optional, Tuple
 from tkinter import filedialog, messagebox, TclError
 
 import logging
-import requests
-from requests import RequestException
 
 from webdav_client import WebDAVClient
 INVENTORY_CSV = os.getenv(
     "INVENTORY_CSV", os.getenv("WAREHOUSE_CSV", "magazyn.csv")
 )
 WAREHOUSE_CSV = os.getenv("WAREHOUSE_CSV", INVENTORY_CSV)
-WAREHOUSE_CSV_URL = os.getenv("WAREHOUSE_CSV_URL", "")
 
 # Track last modification time and cached statistics for the warehouse CSV
 WAREHOUSE_CSV_MTIME: Optional[float] = None
@@ -52,42 +49,6 @@ WAREHOUSE_FIELDNAMES = [
     "variant",
     "sold",
 ]
-
-
-def download_warehouse_csv():
-    """Download the warehouse CSV from HTTP or WebDAV."""
-    try:
-        if WAREHOUSE_CSV_URL:
-            response = requests.get(WAREHOUSE_CSV_URL, timeout=30)
-            response.raise_for_status()
-            with open(WAREHOUSE_CSV, "wb") as fh:
-                fh.write(response.content)
-        else:
-            with WebDAVClient() as client:
-                try:
-                    client.download_file(WAREHOUSE_CSV, WAREHOUSE_CSV)
-                except RuntimeError as exc:
-                    logging.warning("Failed to download warehouse CSV: %s", exc)
-                    try:
-                        retry = messagebox.askretrycancel(
-                            "Download Failed",
-                            "Nie udało się pobrać magazynu. Spróbować ponownie?",
-                        )
-                    except TclError:
-                        retry = False
-                    if retry:
-                        return download_warehouse_csv()
-                    return
-    except RequestException as exc:  # pragma: no cover - network failure
-        logging.warning("Failed to download warehouse CSV: %s", exc)
-    except Exception:
-        raise
-
-
-def ensure_warehouse_csv():
-    """Ensure the warehouse CSV exists, downloading it if necessary."""
-    if not os.path.exists(WAREHOUSE_CSV):
-        download_warehouse_csv()
 
 
 def get_inventory_stats(path: str = WAREHOUSE_CSV, force: bool = False):

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4547,19 +4547,8 @@ class CardEditorApp:
             self.loading_frame.destroy()
         self.shoper_client = None
         self.ensure_shoper_client()
-        try:
-            csv_utils.ensure_warehouse_csv()
-        except Exception as exc:  # pragma: no cover - startup fallback
-            logger.exception("Failed to ensure warehouse CSV: %s", exc)
-            try:
-                messagebox.showerror(
-                    _("Warehouse Error"),
-                    _(
-                        "Failed to prepare the warehouse file. The application will continue in read-only mode."
-                    ),
-                )
-            except Exception:
-                pass
+        # The warehouse CSV is now bundled with the application, so no
+        # network download is required during startup.
         self.setup_welcome_screen()
 
     def ensure_shoper_client(self):

--- a/magazyn.csv
+++ b/magazyn.csv
@@ -1,0 +1,1 @@
+name;number;set;warehouse_code;price;image;variant;sold

--- a/tests/test_download_warehouse_csv.py
+++ b/tests/test_download_warehouse_csv.py
@@ -1,116 +1,16 @@
-import sys
 from pathlib import Path
-import logging
+import importlib
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
-from requests import RequestException
-
-from kartoteka import csv_utils
+from kartoteka import csv_utils as _csv_utils
 
 
-def test_download_warehouse_csv(monkeypatch, tmp_path):
-    called = {}
-
-    class DummyWebDAVClient:
-        def __init__(self, base_url=None, user=None, password=None):
-            called["init"] = (base_url, user, password)
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-        def download_file(self, remote_path, local_path=None):
-            called["args"] = (remote_path, local_path)
-
-    monkeypatch.setattr(csv_utils, "WebDAVClient", DummyWebDAVClient)
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV_URL", "")
-    path = tmp_path / "mag.csv"
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
-
-    csv_utils.download_warehouse_csv()
-
-    assert called["init"] == (None, None, None)
-    assert called["args"] == (str(path), str(path))
+def test_local_warehouse_csv_exists():
+    csv_utils = importlib.reload(_csv_utils)
+    path = Path(csv_utils.WAREHOUSE_CSV)
+    assert path.exists()
+    header = path.read_text(encoding="utf-8").splitlines()[0]
+    assert header == ";".join(csv_utils.WAREHOUSE_FIELDNAMES)
 
 
-def test_download_warehouse_csv_http(monkeypatch, tmp_path):
-    data = b"name;price\n"
-    called = {}
-
-    class DummyResponse:
-        def __init__(self, content):
-            self.content = content
-
-        def raise_for_status(self):
-            pass
-
-    def dummy_get(url, timeout=30):
-        called["url"] = url
-        return DummyResponse(data)
-
-    class FailingWebDAVClient:
-        def __init__(self, *a, **kw):
-            raise AssertionError("WebDAV should not be used when URL is provided")
-
-    monkeypatch.setattr(csv_utils, "WebDAVClient", FailingWebDAVClient)
-    monkeypatch.setattr(csv_utils.requests, "get", dummy_get)
-    url = "http://example.com/mag.csv"
-    monkeypatch.setenv("WAREHOUSE_CSV_URL", url)
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV_URL", url)
-    path = tmp_path / "mag.csv"
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
-
-    csv_utils.download_warehouse_csv()
-
-    assert called["url"] == url
-    assert path.read_bytes() == data
-
-
-def test_download_warehouse_csv_http_error_logs(monkeypatch, tmp_path, caplog):
-    def failing_get(url, timeout=30):
-        raise RequestException("network down")
-
-    monkeypatch.setattr(csv_utils.requests, "get", failing_get)
-    url = "http://example.com/mag.csv"
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV_URL", url)
-    path = tmp_path / "mag.csv"
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
-
-    with caplog.at_level(logging.WARNING):
-        csv_utils.download_warehouse_csv()
-
-    assert "Failed to download warehouse CSV" in caplog.text
-
-
-def test_download_warehouse_csv_webdav_error(monkeypatch, tmp_path, caplog):
-    class FailingWebDAVClient:
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-        def download_file(self, remote_path, local_path=None):
-            raise RuntimeError("connection failed")
-
-    monkeypatch.setattr(csv_utils, "WebDAVClient", FailingWebDAVClient)
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV_URL", "")
-    path = tmp_path / "mag.csv"
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
-
-    called = {}
-
-    def dummy_retry(title, message):
-        called["asked"] = True
-        return False
-
-    monkeypatch.setattr(csv_utils.messagebox, "askretrycancel", dummy_retry)
-
-    with caplog.at_level(logging.WARNING):
-        csv_utils.download_warehouse_csv()
-
-    assert "Failed to download warehouse CSV" in caplog.text
-    assert called["asked"]
+def test_download_function_removed():
+    assert not hasattr(_csv_utils, "download_warehouse_csv")

--- a/tests/test_ensure_warehouse_csv.py
+++ b/tests/test_ensure_warehouse_csv.py
@@ -1,28 +1,4 @@
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).resolve().parents[1]))
-
 from kartoteka import csv_utils
 
-
-def test_ensure_warehouse_csv_downloads_once(monkeypatch, tmp_path):
-    data = b"name;price\n"
-    path = tmp_path / "magazyn.csv"
-    called = {"count": 0}
-
-    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
-
-    def dummy_download():
-        called["count"] += 1
-        path.write_bytes(data)
-
-    monkeypatch.setattr(csv_utils, "download_warehouse_csv", dummy_download)
-
-    assert not path.exists()
-    csv_utils.ensure_warehouse_csv()
-    assert path.read_bytes() == data
-    assert called["count"] == 1
-
-    csv_utils.ensure_warehouse_csv()
-    assert called["count"] == 1
+def test_ensure_function_removed():
+    assert not hasattr(csv_utils, "ensure_warehouse_csv")


### PR DESCRIPTION
## Summary
- Drop network CSV download helpers and startup call
- Ensure tests rely on local warehouse CSV and remove download expectations
- Include empty `magazyn.csv` with header for local use

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b68059d490832f9b3379901a661121