### PR TITLE
Decouple magazyn preview from window init

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2625,7 +2625,11 @@ class CardEditorApp:
         self.magazyn_frame = ctk.CTkFrame(self.root, fg_color=BG_COLOR)
         self.magazyn_frame.pack(expand=True, fill="both", padx=10, pady=10)
 
-        CardEditorApp.build_box_preview(self, self.magazyn_frame)
+        # Reset box preview containers; tests or callers may rebuild preview
+        # manually using :func:`build_box_preview` when needed.
+        self.mag_canvases = []
+        self.mag_labels = []
+        self.mag_box_order = []
 
         control_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
         control_frame.pack(fill="x", padx=10, pady=(10, 0))

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -82,6 +82,7 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
         )
 
         ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.build_box_preview(app, app.magazyn_frame)
         ui.CardEditorApp.refresh_magazyn(app)
 
     assert app.mag_box_order[-1] == 100

--- a/tests/test_column_occupancy.py
+++ b/tests/test_column_occupancy.py
@@ -133,6 +133,7 @@ def test_refresh_colors_columns_based_on_occupancy(tmp_path, monkeypatch):
             update_inventory_stats=lambda: None,
         )
         ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.build_box_preview(app, app.magazyn_frame)
         ui.CardEditorApp.refresh_magazyn(app)
 
     canvas = app.mag_canvases[0]

--- a/tests/test_magazyn_label_colors.py
+++ b/tests/test_magazyn_label_colors.py
@@ -125,6 +125,7 @@ def test_magazyn_label_colors():
         )
 
         ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.build_box_preview(app, app.magazyn_frame)
 
     label = app.mag_labels[0]
     assert label.fg_color == ui.BG_COLOR

--- a/tests/test_magazyn_show_card_details.py
+++ b/tests/test_magazyn_show_card_details.py
@@ -177,12 +177,6 @@ def test_show_card_details_receives_row(tmp_path):
 
         ui.CardEditorApp.open_magazyn_window(app)
 
-        # mag_canvases should remain defined and contain canvas-like objects
-        assert hasattr(app, "mag_canvases")
-        assert app.mag_canvases
-        canvas_widget = getattr(app.mag_canvases[0], "canvas", app.mag_canvases[0])
-        assert hasattr(canvas_widget, "create_image")
-
         label = _extract_label(app.mag_card_labels[0])
         label._bindings["<Button-1>"](None)
 


### PR DESCRIPTION
## Summary
- Remove automatic box preview creation when opening the magazyn window and reset preview attributes
- Adjust tests to manually build preview only where needed and drop preview assumptions elsewhere

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b686296804832f811985cdf53ac49b