### PR TITLE
Use progress bars for warehouse box preview

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1431,7 +1431,9 @@ class CardEditorApp:
         self.magazyn_frame = None
         self.location_frame = None
         self.auction_frame = None
-        self.mag_canvases = []
+        self.mag_progressbars: dict[tuple[int, int], ctk.CTkProgressBar] = {}
+        self.mag_percent_labels: dict[tuple[int, int], ctk.CTkLabel] = {}
+        self.mag_labels: list[ctk.CTkLabel] = []
         self.log_widget = None
         self.cheat_frame = None
         self.set_logos = {}
@@ -2568,40 +2570,46 @@ class CardEditorApp:
         return storage.location_from_code(code)
 
     def build_box_preview(self, parent):
-        """Create frames and canvases previewing warehouse boxes."""
-        box_w = BOX_THUMB_SIZE
-        box_h = BOX_THUMB_SIZE
+        """Create frames and progress bars previewing warehouse boxes."""
 
         container = ctk.CTkFrame(parent, fg_color=BG_COLOR)
         container.pack(padx=10, pady=10)
 
         self.mag_box_order = list(range(1, BOX_COUNT + 1)) + [SPECIAL_BOX_NUMBER]
-        self.mag_canvases = []
+        self.mag_progressbars = {}
+        self.mag_percent_labels = {}
         self.mag_labels = []
         for i, box_num in enumerate(self.mag_box_order):
             frame = ctk.CTkFrame(container, fg_color=BG_COLOR)
             lbl = ctk.CTkLabel(
                 frame,
-                text="",
+                text=f"K{box_num}",
                 fg_color=BG_COLOR,
                 text_color=TEXT_COLOR,
             )
-            canvas = tk.Canvas(
-                frame,
-                width=box_w,
-                height=box_h,
-                highlightthickness=0,
-            )
-            canvas.config(bg=BG_COLOR)
-            canvas.pack()
-            lbl.pack()
-            row, col = divmod(i, WAREHOUSE_GRID_COLUMNS)
+            lbl.pack(anchor="w")
+            self.mag_labels.append(lbl)
+            for col in range(1, storage.BOX_COLUMNS.get(box_num, 4) + 1):
+                row_frame = ctk.CTkFrame(frame, fg_color=BG_COLOR)
+                row_frame.pack(fill="x", padx=2, pady=2)
+                bar = ctk.CTkProgressBar(row_frame, orientation="horizontal")
+                bar.set(0)
+                bar.pack(side="left", fill="x", expand=True)
+                pct_label = ctk.CTkLabel(
+                    row_frame,
+                    text="0%",
+                    width=40,
+                    fg_color=BG_COLOR,
+                    text_color=TEXT_COLOR,
+                )
+                pct_label.pack(side="left", padx=(5, 0))
+                self.mag_progressbars[(box_num, col)] = bar
+                self.mag_percent_labels[(box_num, col)] = pct_label
+            row, col_idx = divmod(i, WAREHOUSE_GRID_COLUMNS)
             if box_num == SPECIAL_BOX_NUMBER:
                 row = 0
-                col = WAREHOUSE_GRID_COLUMNS
-            frame.grid(row=row, column=col, padx=5, pady=5)
-            self.mag_canvases.append(canvas)
-            self.mag_labels.append(lbl)
+                col_idx = WAREHOUSE_GRID_COLUMNS
+            frame.grid(row=row, column=col_idx, padx=5, pady=5)
 
         # Internal helpers used by the magazyn window; populated lazily.
         self.mag_card_images = []
@@ -2637,7 +2645,8 @@ class CardEditorApp:
 
         # Reset box preview containers; tests or callers may rebuild preview
         # manually using :func:`build_box_preview` when needed.
-        self.mag_canvases = []
+        self.mag_progressbars = {}
+        self.mag_percent_labels = {}
         self.mag_labels = []
         self.mag_box_order = []
 
@@ -3026,31 +3035,43 @@ class CardEditorApp:
 
     def refresh_home_preview(self):
         """Refresh box preview on the welcome screen."""
-        if not getattr(self, "mag_canvases", None):
+        if not getattr(self, "mag_progressbars", None):
             return
 
         col_occ = storage.compute_column_occupancy()
-        order = getattr(self, "mag_box_order", None) or []
 
-        for idx, canvas in enumerate(self.mag_canvases):
-            box = order[idx] if idx < len(order) else idx + 1
-            percent = draw_box_usage(canvas, box, col_occ.get(box, {}))
-            if idx < len(self.mag_labels):
-                self.mag_labels[idx].configure(text=f"K{box}: {percent:.0f}%")
+        for (box, col), bar in self.mag_progressbars.items():
+            filled = col_occ.get(box, {}).get(col, 0)
+            columns = storage.BOX_COLUMNS.get(box, 4)
+            total_capacity = storage.BOX_CAPACITY.get(
+                box, columns * storage.BOX_COLUMN_CAPACITY
+            )
+            col_capacity = total_capacity / columns if columns else storage.BOX_COLUMN_CAPACITY
+            value = filled / col_capacity if col_capacity else 0
+            bar.set(value)
+            lbl = self.mag_percent_labels.get((box, col))
+            if lbl:
+                lbl.configure(text=f"{value * 100:.0f}%")
 
     def refresh_magazyn(self):
-        """Refresh storage view and color occupied columns."""
-        if not getattr(self, "mag_canvases", None):
+        """Refresh storage view and update column usage bars."""
+        if not getattr(self, "mag_progressbars", None):
             return
 
         col_occ = storage.compute_column_occupancy()
-        order = getattr(self, "mag_box_order", None) or []
 
-        for idx, canvas in enumerate(self.mag_canvases):
-            box = order[idx] if idx < len(order) else idx + 1
-            percent = draw_box_usage(canvas, box, col_occ.get(box, {}))
-            if idx < len(self.mag_labels):
-                self.mag_labels[idx].configure(text=f"K{box}: {percent:.0f}%")
+        for (box, col), bar in self.mag_progressbars.items():
+            filled = col_occ.get(box, {}).get(col, 0)
+            columns = storage.BOX_COLUMNS.get(box, 4)
+            total_capacity = storage.BOX_CAPACITY.get(
+                box, columns * storage.BOX_COLUMN_CAPACITY
+            )
+            col_capacity = total_capacity / columns if columns else storage.BOX_COLUMN_CAPACITY
+            value = filled / col_capacity if col_capacity else 0
+            bar.set(value)
+            lbl = self.mag_percent_labels.get((box, col))
+            if lbl:
+                lbl.configure(text=f"{value * 100:.0f}%")
 
         if hasattr(self, "update_inventory_stats"):
             try:

--- a/tests/ctk_mocks.py
+++ b/tests/ctk_mocks.py
@@ -82,6 +82,19 @@ class DummyCTkOptionMenu(_Widget):
             self.command(value)
 
 
+class DummyCTkProgressBar(_Widget):
+    def __init__(self, master=None, orientation="horizontal", **kwargs):
+        self.master = master
+        self.orientation = orientation
+        self.value = 0
+
+    def set(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+
 class DummyCanvas(_Widget):
     def __init__(self, master=None, width=0, height=0, highlightthickness=0):
         self.master = master

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -14,6 +14,7 @@ from ctk_mocks import (  # noqa: E402
     DummyCTkOptionMenu,
     DummyCTkScrollableFrame,
     DummyCanvas,
+    DummyCTkProgressBar,
 )
 
 import pytest
@@ -49,6 +50,7 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
         CTkScrollableFrame=DummyCTkScrollableFrame,
         CTkEntry=DummyCTkEntry,
         CTkOptionMenu=DummyCTkOptionMenu,
+        CTkProgressBar=DummyCTkProgressBar,
     )
     sys.path.append(str(Path(__file__).resolve().parents[1]))
     import kartoteka.ui as ui
@@ -61,8 +63,8 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
 
     photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(
-        ui.tk, "Canvas", DummyCanvas
-    ), patch.object(ui.messagebox, "showinfo", lambda *a, **k: None):
+        ui.messagebox, "showinfo", lambda *a, **k: None
+    ):
         dummy_root = SimpleNamespace(
             minsize=lambda *a, **k: None,
             title=lambda *a, **k: None,
@@ -93,6 +95,5 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
     percent = occ[100] / storage.BOX_CAPACITY[100] * 100
     assert percent == pytest.approx(0.2)
 
-    canvas = app.mag_canvases[-1]
-    rect = list(canvas.items.values())[0]
-    assert rect["fill"] == ui.OCCUPIED_COLOR
+    bar = app.mag_progressbars[(100, 1)]
+    assert bar.get() == pytest.approx(1 / ui.storage.BOX_CAPACITY[100])

--- a/tests/test_column_occupancy.py
+++ b/tests/test_column_occupancy.py
@@ -14,6 +14,7 @@ from ctk_mocks import (
     DummyCTkOptionMenu,
     DummyCTkScrollableFrame,
     DummyCanvas,
+    DummyCTkProgressBar,
 )
 
 sys.modules.setdefault("customtkinter", MagicMock())
@@ -107,14 +108,15 @@ def test_refresh_colors_columns_based_on_occupancy(tmp_path, monkeypatch):
         CTkScrollableFrame=DummyCTkScrollableFrame,
         CTkEntry=DummyCTkEntry,
         CTkOptionMenu=DummyCTkOptionMenu,
+        CTkProgressBar=DummyCTkProgressBar,
     )
     import kartoteka.ui as ui
     importlib.reload(ui)
 
     photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(
-        ui.tk, "Canvas", DummyCanvas
-    ), patch.object(ui.messagebox, "showinfo", lambda *a, **k: None):
+        ui.messagebox, "showinfo", lambda *a, **k: None
+    ):
         dummy_root = SimpleNamespace(
             minsize=lambda *a, **k: None,
             title=lambda *a, **k: None,
@@ -136,7 +138,7 @@ def test_refresh_colors_columns_based_on_occupancy(tmp_path, monkeypatch):
         ui.CardEditorApp.build_box_preview(app, app.magazyn_frame)
         ui.CardEditorApp.refresh_magazyn(app)
 
-    canvas = app.mag_canvases[0]
-    rects = list(canvas.items.values())
-    assert rects[0]["fill"] == ui.OCCUPIED_COLOR
-    assert all(r["fill"] == "" for r in rects[1:])
+    bar = app.mag_progressbars[(1, 1)]
+    assert bar.get() > 0
+    for col in range(2, ui.storage.BOX_COLUMNS[1] + 1):
+        assert app.mag_progressbars[(1, col)].get() == 0

--- a/tests/test_magazyn_label_colors.py
+++ b/tests/test_magazyn_label_colors.py
@@ -90,6 +90,19 @@ class DummyCanvas(_Widget):
     def height(self):
         return self.height_val
 
+
+class DummyCTkProgressBar(_Widget):
+    def __init__(self, master=None, orientation="horizontal", **kwargs):
+        self.master = master
+        self.orientation = orientation
+        self.value = 0
+
+    def set(self, value):
+        self.value = value
+
+    def get(self):
+        return self.value
+
 def test_magazyn_label_colors():
     sys.modules["customtkinter"] = SimpleNamespace(
         CTkFrame=DummyCTkFrame,
@@ -98,6 +111,7 @@ def test_magazyn_label_colors():
         CTkScrollableFrame=DummyCTkScrollableFrame,
         CTkEntry=DummyCTkEntry,
         CTkOptionMenu=DummyCTkOptionMenu,
+        CTkProgressBar=DummyCTkProgressBar,
     )
     sys.path.append(str(Path(__file__).resolve().parents[1]))
     import kartoteka.ui as ui
@@ -105,8 +119,7 @@ def test_magazyn_label_colors():
 
     photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
 
-    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
-         patch.object(ui.tk, "Canvas", DummyCanvas):
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock):
         dummy_root = SimpleNamespace(
             minsize=lambda *a, **k: None,
             title=lambda *a, **k: None,

--- a/tests/test_welcome_screen_box_preview.py
+++ b/tests/test_welcome_screen_box_preview.py
@@ -13,6 +13,7 @@ from ctk_mocks import (
     DummyCTkEntry,
     DummyCTkOptionMenu,
     DummyCanvas,
+    DummyCTkProgressBar,
 )
 
 
@@ -24,6 +25,7 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
         CTkScrollableFrame=DummyCTkScrollableFrame,
         CTkEntry=DummyCTkEntry,
         CTkOptionMenu=DummyCTkOptionMenu,
+        CTkProgressBar=DummyCTkProgressBar,
     )
     sys.path.append(str(Path(__file__).resolve().parents[1]))
     import kartoteka.ui as ui
@@ -33,8 +35,8 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
 
     photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(
-        ui.tk, "Canvas", DummyCanvas
-    ), patch.object(ui.tk, "Frame", DummyCTkFrame), patch.object(
+        ui.tk, "Frame", DummyCTkFrame
+    ), patch.object(ui.tk, "Canvas", DummyCanvas), patch.object(
         ui.messagebox, "showinfo", lambda *a, **k: None
     ):
         dummy_root = SimpleNamespace(
@@ -55,5 +57,5 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
         )
         ui.CardEditorApp.setup_welcome_screen(app)
 
-    assert hasattr(app, "mag_canvases")
-    assert len(app.mag_canvases) == ui.BOX_COUNT + 1
+    assert hasattr(app, "mag_progressbars")
+    assert len(app.mag_progressbars) == sum(ui.storage.BOX_COLUMNS.values())


### PR DESCRIPTION
## Summary
- replace canvas-based box preview with frames containing CTkProgressBar widgets and percentage labels
- update preview refresh logic to compute column occupancy and set progress bars
- adapt tests to new progress bar interface

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b69042b958832fa894f4a69ebc4309