### PR TITLE
Adjust magazyn window size based on screen resolution

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2656,7 +2656,12 @@ class CardEditorApp:
             self.location_frame.destroy()
             self.location_frame = None
 
-        self.root.minsize(1200, 800)
+        if all(hasattr(self.root, attr) for attr in ("winfo_screenwidth", "winfo_screenheight", "minsize")):
+            screen_w = self.root.winfo_screenwidth()
+            screen_h = self.root.winfo_screenheight()
+            min_w = int(screen_w * 0.75)
+            min_h = int(screen_h * 0.75)
+            self.root.minsize(min_w, min_h)
         self.magazyn_frame = ctk.CTkFrame(self.root, fg_color=BG_COLOR)
         self.magazyn_frame.pack(expand=True, fill="both", padx=10, pady=10)
 


### PR DESCRIPTION
## Summary
- Set magazyn window minimum size relative to screen dimensions instead of fixed 1200x800
- Skip minsize adjustment when screen size info isn't available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6a2859160832fa92ccf8cea47614b