### PR TITLE
Enable scrolling for box preview container

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2587,10 +2587,10 @@ class CardEditorApp:
         return storage.location_from_code(code)
 
     def build_box_preview(self, parent):
-        """Create frames and progress bars previewing warehouse boxes."""
+        """Create a scrollable grid of frames and progress bars for boxes."""
 
-        container = ctk.CTkFrame(parent, fg_color=BG_COLOR)
-        container.pack(padx=10, pady=10)
+        container = ctk.CTkScrollableFrame(parent, fg_color=BG_COLOR)
+        container.pack(expand=True, fill="both", padx=10, pady=10)
 
         self.mag_box_order = list(range(1, BOX_COUNT + 1)) + [SPECIAL_BOX_NUMBER]
         self.mag_progressbars = {}


### PR DESCRIPTION
## Summary
- Replace static box preview frame with `CTkScrollableFrame`
- Ensure container fills available space for overflowed thumbnails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6a541e074832fa12967bb8880e8bb