### PR TITLE
Include era in warehouse exports and categories

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -42,6 +42,7 @@ STORE_FIELDNAMES = [
 WAREHOUSE_FIELDNAMES = [
     "name",
     "number",
+    "era",
     "set",
     "warehouse_code",
     "price",
@@ -167,6 +168,7 @@ def format_warehouse_row(row):
     return {
         "name": row.get("nazwa", ""),
         "number": row.get("numer", ""),
+        "era": row.get("era", ""),
         "set": row.get("set", ""),
         "warehouse_code": row.get("warehouse_code", ""),
         "price": row.get("cena") or row.get("price", ""),
@@ -295,7 +297,7 @@ def export_csv(app):
     for row in app.output_data:
         if row is None:
             continue
-        key = f"{row['nazwa']}|{row['numer']}|{row['set']}"
+        key = f"{row['nazwa']}|{row['numer']}|{row['set']}|{row['era']}"
         if key in combined:
             combined[key]["stock"] += 1
         else:

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1082,7 +1082,7 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str]:
             "You must return a JSON object with the Pokémon card's English name, "
             "card number in the form NNN/NNN, English set name, era name, and whether "
             "the set is written as text or shown as a symbol. The response must strictly "
-            "match {\\"name\\":\\"\\", \\"number\\":\\"\\", \\"set_name\\":\\"\\", \\"era_name\\":\\"\\", \\"set_format\\":\\"\\"}."
+            'match {"name":"", "number":"", "set_name":"", "era_name":"", "set_format":""}.'
         )
 
         try:
@@ -1171,11 +1171,11 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str]:
             mapped = get_set_name(set_code)
             if mapped:
                 set_name = mapped
-          era_name = data.era_name or ""
-          return name, number, total, set_name, set_code, set_format, era_name
-      except openai.OpenAIError as e:
-          logger.warning("extract_card_info_openai failed: %s", e)
-          return "", "", "", "", "", "", ""
+        era_name = data.era_name or ""
+        return name, number, total, set_name, set_code, set_format, era_name
+    except openai.OpenAIError as e:
+        logger.warning("extract_card_info_openai failed: %s", e)
+        return "", "", "", "", "", "", ""
 
 # ZMIANA: Całkowicie nowa, hierarchiczna logika analizy obrazu
 def analyze_card_image(
@@ -4351,6 +4351,7 @@ class CardEditorApp:
                 0, sanitize_number(str(inv_entry.get("numer", "")))
             )
             self.entries["set"].set(inv_entry.get("set", ""))
+            self.entries["era"].set(inv_entry.get("era", ""))
             self.update_set_options()
             skip_analysis = True
             logger.info(
@@ -5455,10 +5456,10 @@ class CardEditorApp:
                 fp = None
             self.current_fingerprint = fp
         if fp is not None and getattr(self, "hash_db", None):
-        meta = {
-            k: data.get(k, "")
-            for k in ("nazwa", "numer", "set", "era", "język", "stan", "typ")
-        }
+            meta = {
+                k: data.get(k, "")
+                for k in ("nazwa", "numer", "set", "era", "język", "stan", "typ")
+            }
             card_id = f"{meta['set']} {meta['numer']}".strip()
             try:
                 self.hash_db.add_card_from_fp(fp, meta, card_id=card_id)
@@ -5486,7 +5487,7 @@ class CardEditorApp:
         self.next_product_code += 1
         storage.save_last_product_code(self.next_product_code - 1)
         data["unit"] = "szt."
-        data["category"] = f"Karty Pokémon > {data['set']}"
+        data["category"] = f"Karty Pokémon > {data['era']} > {data['set']}"
         data["producer"] = "Pokémon"
         data["producer_code"] = data["numer"]
         data["currency"] = "PLN"

--- a/magazyn.csv
+++ b/magazyn.csv
@@ -1,1 +1,1 @@
-name;number;set;warehouse_code;price;image;variant;sold
+name;number;era;set;warehouse_code;price;image;variant;sold

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -684,7 +684,7 @@ def test_analyze_and_fill_runs_full_pipeline_for_non_matching_card(tmp_path):
 def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        f"name;numer;set\nPikachu;001;{SV01_NAME}\n",
+        f"name;numer;set;era\nPikachu;001;{SV01_NAME};{ui.get_set_era(SV01_CODE)}\n",
         encoding="utf-8",
     )
     monkeypatch.setenv("WAREHOUSE_CSV", str(csv_path))
@@ -716,7 +716,7 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
         entries={"nazwa": name_entry, "numer": num_entry, "set": set_var, "era": MagicMock()},
         type_vars={},
         card_cache={},
-        file_to_key={img.name: f"Pikachu|001|{SV01_NAME}"},
+        file_to_key={img.name: f"Pikachu|001|{SV01_NAME}|{ui.get_set_era(SV01_CODE)}"},
         _guess_key_from_filename=lambda *a, **k: None,
         update_set_options=lambda *a, **k: None,
     )

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -19,9 +19,10 @@ def test_export_includes_new_fields(tmp_path):
             "nazwa": "Pikachu",
             "numer": "1",
             "set": "Base",
+            "era": "Era1",
             "product_code": 1,
             "cena": "10",
-            "category": "Karty",
+            "category": "Karty Pokémon > Era1 > Base",
             "producer": "Pokemon",
             "short_description": "s",
             "description": "d",
@@ -64,9 +65,10 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
             "nazwa": "Pikachu",
             "numer": "1",
             "set": "Base",
+            "era": "Era1",
             "product_code": 1,
             "cena": "10",
-            "category": "Karty",
+            "category": "Karty Pokémon > Era1 > Base",
             "producer": "Pokemon",
             "short_description": "s",
             "description": "d",
@@ -88,6 +90,7 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
         row = rows[0]
         assert row["name"] == "Pikachu"
         assert row["number"] == "1"
+        assert row["era"] == "Era1"
         assert row["set"] == "Base"
         assert row["warehouse_code"] == "K1R1P1"
         assert row["price"] == "10"

--- a/tests/test_inventory_stats.py
+++ b/tests/test_inventory_stats.py
@@ -10,7 +10,8 @@ from kartoteka import csv_utils
 def test_get_inventory_stats(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10.5;img1\n" "B;2;S2;K2;5,25;img2\n",
+        "name;number;era;set;warehouse_code;price;image\n"
+        "A;1;E1;S1;K1;10.5;img1\n" "B;2;E2;S2;K2;5,25;img2\n",
         encoding="utf-8",
     )
     count_unsold, total_unsold, count_sold, total_sold = csv_utils.get_inventory_stats(
@@ -25,7 +26,8 @@ def test_get_inventory_stats(tmp_path):
 def test_inventory_stats_excludes_sold(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1;10;img1;\n" "B;2;S2;K2;5;img2;1\n",
+        "name;number;era;set;warehouse_code;price;image;sold\n"
+        "A;1;E1;S1;K1;10;img1;\n" "B;2;E2;S2;K2;5;img2;1\n",
         encoding="utf-8",
     )
     count_unsold, total_unsold, count_sold, total_sold = csv_utils.get_inventory_stats(

--- a/tests/test_inventory_stats_cache.py
+++ b/tests/test_inventory_stats_cache.py
@@ -17,7 +17,7 @@ def test_get_inventory_stats_cached(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     _write_csv(
         csv_path,
-        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
+        "name;number;era;set;warehouse_code;price;image\n" "A;1;E1;S1;K1;10;img\n",
     )
 
     first = csv_utils.get_inventory_stats(str(csv_path))
@@ -41,7 +41,7 @@ def test_get_inventory_stats_recomputes_on_change(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     _write_csv(
         csv_path,
-        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
+        "name;number;era;set;warehouse_code;price;image\n" "A;1;E1;S1;K1;10;img\n",
     )
 
     first = csv_utils.get_inventory_stats(str(csv_path))
@@ -49,7 +49,7 @@ def test_get_inventory_stats_recomputes_on_change(tmp_path):
     mtime = os.path.getmtime(csv_path)
     _write_csv(
         csv_path,
-        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n" "B;2;S2;K2;5;img2\n",
+        "name;number;era;set;warehouse_code;price;image\n" "A;1;E1;S1;K1;10;img\n" "B;2;E2;S2;K2;5;img2\n",
     )
     os.utime(csv_path, (mtime + 1, mtime + 1))
 
@@ -62,7 +62,7 @@ def test_get_inventory_stats_force(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     _write_csv(
         csv_path,
-        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
+        "name;number;era;set;warehouse_code;price;image\n" "A;1;E1;S1;K1;10;img\n",
     )
 
     csv_utils.get_inventory_stats(str(csv_path))

--- a/tests/test_magazyn_badge_display.py
+++ b/tests/test_magazyn_badge_display.py
@@ -19,10 +19,10 @@ from ctk_mocks import (
 def test_badge_display_for_duplicates_only(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;variant\n"
-        "A;1;S;K1R1P1;1;foo1.png;common\n"
-        "A;1;S;K1R1P2;1;foo2.png;common\n"
-        "B;2;S;K1R1P3;1;foo3.png;common\n",
+        "name;number;era;set;warehouse_code;price;image;variant\n"
+        "A;1;E;S;K1R1P1;1;foo1.png;common\n"
+        "A;1;E;S;K1R1P2;1;foo2.png;common\n"
+        "B;2;E;S;K1R1P3;1;foo3.png;common\n",
         encoding="utf-8",
     )
 

--- a/tests/test_magazyn_duplicates.py
+++ b/tests/test_magazyn_duplicates.py
@@ -18,9 +18,9 @@ from ctk_mocks import (  # noqa: E402
 def test_group_duplicates(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;variant\n"
-        "A;1;S;K1R1P1;1;foo1.png;common\n"
-        "A;1;S;K1R1P2;1;foo2.png;common\n",
+        "name;number;era;set;warehouse_code;price;image;variant\n"
+        "A;1;E;S;K1R1P1;1;foo1.png;common\n"
+        "A;1;E;S;K1R1P2;1;foo2.png;common\n",
         encoding="utf-8",
     )
 

--- a/tests/test_magazyn_search_filters.py
+++ b/tests/test_magazyn_search_filters.py
@@ -59,9 +59,9 @@ def _load_app(csv_path, stats):
 def test_search_by_variant(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;variant\n"
-        "A;1;S;K1;10;foo.png;holo\n"
-        "B;2;S;K2;5;foo.png;reverse\n",
+        "name;number;era;set;warehouse_code;price;image;variant\n"
+        "A;1;E1;S;K1;10;foo.png;holo\n"
+        "B;2;E2;S;K2;5;foo.png;reverse\n",
         encoding="utf-8",
     )
     app = _load_app(csv_path, (2, 15.0, 0, 0))
@@ -74,9 +74,9 @@ def test_search_by_variant(tmp_path):
 def test_search_by_sold_status(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;variant;sold\n"
-        "A;1;S;K1;1;foo.png;common;\n"
-        "B;2;S;K2;1;foo.png;common;1\n",
+        "name;number;era;set;warehouse_code;price;image;variant;sold\n"
+        "A;1;E1;S;K1;1;foo.png;common;\n"
+        "B;2;E2;S;K2;1;foo.png;common;1\n",
         encoding="utf-8",
     )
     app = _load_app(csv_path, (1, 1.0, 1, 1.0))
@@ -156,8 +156,8 @@ def _load_app_with_delay(csv_path, stats):
 def test_search_clear_keeps_thumbnails(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image\n"
-        "Card;1;S;K1;1;https://example.com/image.png\n",
+        "name;number;era;set;warehouse_code;price;image\n"
+        "Card;1;E1;S;K1;1;https://example.com/image.png\n",
         encoding="utf-8",
     )
     app, photo, stack = _load_app_with_delay(csv_path, (1, 1.0, 0, 0))

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -35,9 +35,9 @@ def _extract_label(widget):
 def test_sold_cards_styled(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;sold\n"
-        "A;1;S1;K1R1P1;1;foo.png;\n"
-        "B;2;S2;K1R1P2;1;foo.png;1\n",
+        "name;number;era;set;warehouse_code;price;image;sold\n"
+        "A;1;E1;S1;K1R1P1;1;foo.png;\n"
+        "B;2;E2;S2;K1R1P2;1;foo.png;1\n",
         encoding="utf-8",
     )
 

--- a/tests/test_mark_as_sold_multiple_codes.py
+++ b/tests/test_mark_as_sold_multiple_codes.py
@@ -6,9 +6,9 @@ from types import SimpleNamespace
 def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;sold\n"
-        "A;1;S;K1;1;;\n"
-        "A;1;S;K2;1;;\n",
+        "name;number;era;set;warehouse_code;price;image;sold\n"
+        "A;1;E;S;K1;1;;\n"
+        "A;1;E;S;K2;1;;\n",
         encoding="utf-8",
     )
 

--- a/tests/test_show_card_details_sprzedano_button.py
+++ b/tests/test_show_card_details_sprzedano_button.py
@@ -11,7 +11,7 @@ from PIL import Image
 def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;10;;\n",
+        "name;number;era;set;warehouse_code;price;image;sold\n" "A;1;E1;S1;K1R1P1;10;;\n",
         encoding="utf-8",
     )
 

--- a/tests/test_toggle_sold.py
+++ b/tests/test_toggle_sold.py
@@ -14,7 +14,7 @@ import kartoteka.ui as ui
 def test_toggle_sold_updates_csv(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;10;;\n",
+        "name;number;era;set;warehouse_code;price;image;sold\n" "A;1;E1;S1;K1R1P1;10;;\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))

--- a/tests/test_variant_flags.py
+++ b/tests/test_variant_flags.py
@@ -87,7 +87,7 @@ def test_save_and_reload_variant_flags(tmp_path):
             assert row["types"] == {"Reverse": True, "Holo": False}
             dummy.type_vars["Reverse"].set(False)
             dummy.type_vars["Holo"].set(False)
-            key = "Charizard|4|Base Set"
+            key = "Charizard|4|Base Set|"
             dummy.file_to_key[os.path.basename(str(img_path))] = key
             ui.CardEditorApp.show_card(dummy)
             assert dummy.type_vars["Reverse"].get() is True


### PR DESCRIPTION
## Summary
- Track card era in warehouse CSV and deduplication keys
- Propagate era in category paths and inventory lookups

## Testing
- `pytest` *(fails: 7 failed, 149 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b5f31194832f9cbb5979d25f1cca