### PR TITLE
Validate era handling in OpenAI parsing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1044,10 +1044,10 @@ class CardInfo(BaseModel):
 
 
 # ZMIANA: Funkcja prosi OpenAI o wszystkie dane naraz, w tym o zestaw
-def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str]:
+def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str, str]:
     """Recognize card name, number, set, and its format using OpenAI Vision.
 
-    Returns a tuple ``(name, number, total, set_name, set_code, set_format, era_name)``.
+    Returns a tuple ``(name, number, total, era_name, set_name, set_code, set_format)``.
     The ``set_name`` value is normalised to the canonical display name whenever
     a matching ``set_code`` can be resolved. ``set_format`` is ``"text"`` or
     ``"symbol"`` depending on how the set was detected.
@@ -1116,8 +1116,8 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str]:
             try:
                 data_dict = json.loads(raw)
             except json.JSONDecodeError:
-                  logger.error("OpenAI returned non-JSON: %r", raw)
-                  return "", "", "", "", "", "", ""
+                logger.error("OpenAI returned non-JSON: %r", raw)
+                return "", "", "", "", "", "", ""
         except TypeError:
             resp = client.responses.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-4o"),
@@ -1148,8 +1148,8 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str]:
             try:
                 data_dict = json.loads(raw)
             except json.JSONDecodeError:
-                  logger.error("OpenAI returned non-JSON: %r", raw)
-                  return "", "", "", "", "", "", ""
+                logger.error("OpenAI returned non-JSON: %r", raw)
+                return "", "", "", "", "", "", ""
 
         data = CardInfo(**data_dict)
 
@@ -1172,7 +1172,7 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str]:
             if mapped:
                 set_name = mapped
         era_name = data.era_name or ""
-        return name, number, total, set_name, set_code, set_format, era_name
+        return name, number, total, era_name, set_name, set_code, set_format
     except openai.OpenAIError as e:
         logger.warning("extract_card_info_openai failed: %s", e)
         return "", "", "", "", "", "", ""
@@ -1271,7 +1271,7 @@ def analyze_card_image(
         if api_key:
             print("[INFO] Step 2: Analyzing with OpenAI Vision...")
             try:
-                name, number, total, set_name, set_code, set_format, era_name = extract_card_info_openai(path)
+                name, number, total, era_name, set_name, set_code, set_format = extract_card_info_openai(path)
 
                 if translate_name and name and not name.isascii():
                     name = translate_to_english(name)
@@ -2398,10 +2398,10 @@ class CardEditorApp:
 
     def lookup_inventory_entry(self, key):
         """Return first row from ``WAREHOUSE_CSV`` matching ``key``."""
-        try:
-            name, number, set_name = key.split("|", 2)
-        except ValueError:
+        parts = key.split("|")
+        if len(parts) < 3:
             return None
+        name, number, set_name = parts[:3]
 
         try:
             with open(csv_utils.WAREHOUSE_CSV, newline="", encoding="utf-8") as f:

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -23,6 +23,17 @@ SV01_CODE = "sv01"
 SV01_NAME = ui.get_set_name(SV01_CODE)
 
 
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
 def test_extract_card_info_openai_maps_set(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
 
@@ -43,12 +54,18 @@ def test_extract_card_info_openai_maps_set(monkeypatch, tmp_path):
             self.responses = SimpleNamespace(create=lambda *a, **k: resp)
 
     monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
-    name, number, total, set_name, set_code, set_format, era_name = ui.extract_card_info_openai(str(img))
-    assert (name, number, total) == ("Pikachu", "037", "198")
+    name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(
+        str(img)
+    )
+    assert (name, number, total, era_name) == (
+        "Pikachu",
+        "037",
+        "198",
+        ui.get_set_era(SV01_CODE),
+    )
     assert set_code == SV01_CODE
     assert set_name == SV01_NAME
     assert set_format == "text"
-    assert era_name == ui.get_set_era(SV01_CODE)
 
 
 def test_show_card_uses_analyzer(tmp_path):
@@ -164,6 +181,32 @@ def test_analyze_card_image_api_multiple_sets(monkeypatch):
         "set_format": "",
         "era": "",
     }
+    mock_hash.assert_called_once()
+
+
+def test_analyze_card_image_propagates_openai_era(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    with patch.object(
+        ui,
+        "extract_card_info_openai",
+        return_value=("Pikachu", "037", "", "Test Era", "", "", ""),
+    ) as mock_extract, patch.object(
+        ui,
+        "lookup_sets_from_api",
+        return_value=[],
+    ), patch.object(
+        ui,
+        "identify_set_by_hash",
+        return_value=[],
+    ) as mock_hash, patch.object(
+        ui,
+        "extract_set_code_ocr",
+        return_value=[],
+    ):
+        result = ui.analyze_card_image("/tmp/img.jpg")
+
+    assert result["era"] == "Test Era"
+    mock_extract.assert_called_once()
     mock_hash.assert_called_once()
 
 
@@ -526,12 +569,6 @@ def test_analyze_and_fill_translates_for_jp(monkeypatch):
     num_entry.insert = MagicMock()
     set_var.set = MagicMock()
 
-    class DummyVar:
-        def __init__(self, value):
-            self.value = value
-        def get(self):
-            return self.value
-
     dummy = SimpleNamespace(
         root=SimpleNamespace(after=lambda delay, func: func()),
         lang_var=DummyVar("JP"),
@@ -691,7 +728,6 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     import importlib
     import kartoteka.csv_utils as csv_utils
     importlib.reload(csv_utils)
-    import kartoteka.ui as ui
     importlib.reload(ui)
 
     img = tmp_path / "card.jpg"
@@ -720,6 +756,7 @@ def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
         _guess_key_from_filename=lambda *a, **k: None,
         update_set_options=lambda *a, **k: None,
     )
+    dummy._analyze_and_fill = MagicMock()
 
     dummy.lookup_inventory_entry = ui.CardEditorApp.lookup_inventory_entry.__get__(dummy, ui.CardEditorApp)
 

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -30,6 +30,7 @@ def test_parse_code_fence(monkeypatch, tmp_path):
         "name": "Pikachu",
         "number": "037/198",
         "set_name": SV01_CODE,
+        "era_name": ui.get_set_era(SV01_CODE),
         "set_format": "text",
     }
     resp = SimpleNamespace(output_text=f"```json\n{json.dumps(payload)}\n```")
@@ -39,8 +40,13 @@ def test_parse_code_fence(monkeypatch, tmp_path):
             self.responses = SimpleNamespace(create=lambda *a, **k: resp)
 
     monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
-    name, number, total, set_name, set_code, set_format = ui.extract_card_info_openai(str(img))
-    assert (name, number, total) == ("Pikachu", "037", "198")
+    name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(str(img))
+    assert (name, number, total, era_name) == (
+        "Pikachu",
+        "037",
+        "198",
+        ui.get_set_era(SV01_CODE),
+    )
     assert set_code == SV01_CODE
     assert set_name == SV01_NAME
     assert set_format == "text"


### PR DESCRIPTION
## Summary
- Ensure `extract_card_info_openai` returns era before set info
- Test OpenAI response parsing including `era_name`
- Verify `analyze_card_image` propagates era to results

## Testing
- `pytest tests/test_openai_parsing.py`
- `pytest tests/test_analyze_card_image.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c19630dc832fbce55b4a1bd32c95