### PR TITLE
Fix magazyn frame resize callback when frame missing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2881,6 +2881,9 @@ class CardEditorApp:
 
             def _relayout_mag_cards(event=None):
                 """Recompute thumbnail size and grid layout on resize."""
+                exists_fn = getattr(self.mag_list_frame, "winfo_exists", lambda: True)
+                if not self.mag_list_frame or not exists_fn():
+                    return
                 global CARD_THUMB_SIZE
                 width_fn = getattr(self.mag_list_frame, "winfo_width", lambda: 0)
                 width = width_fn()


### PR DESCRIPTION
## Summary
- Guard `_relayout_mag_cards` against missing or destroyed `mag_list_frame`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6cac57c08832f93ec741e19348b9d