### PR TITLE
Use CTkFrame for box previews and color-code occupancy

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -336,6 +336,15 @@ SPECIAL_BOX_CAPACITY = 500  # slots in the special box
 BOX_CAPACITY = GRID_COLUMNS * BOX_COLUMN_CAPACITY  # slots in a standard box
 
 
+def _occupancy_color(value: float) -> str:
+    """Return a color representing occupancy level."""
+    if value < 0.5:
+        return "#4caf50"  # green
+    if value < 0.8:
+        return "#ffeb3b"  # yellow
+    return "#f44336"  # red
+
+
 
 def normalize(text: str, keep_spaces: bool = False) -> str:
     """Normalize text for comparisons and API queries."""
@@ -2627,7 +2636,7 @@ class CardEditorApp:
     def build_home_box_preview(self, parent):
         """Create a minimal box preview showing only overall fill percentages."""
 
-        container = ctk.CTkScrollableFrame(parent, fg_color=BG_COLOR)
+        container = ctk.CTkFrame(parent, fg_color=BG_COLOR)
         container.pack(expand=True, fill="both", padx=10, pady=10)
 
         self.mag_box_order = list(range(1, BOX_COUNT + 1)) + [SPECIAL_BOX_NUMBER]
@@ -2640,6 +2649,7 @@ class CardEditorApp:
                 text=f"K{box_num}",
                 fg_color=BG_COLOR,
                 text_color=TEXT_COLOR,
+                font=("Segoe UI", 24, "bold"),
             )
             lbl.pack(side="left")
             self.mag_labels.append(lbl)
@@ -2648,7 +2658,8 @@ class CardEditorApp:
                 text="0%",
                 width=40,
                 fg_color=BG_COLOR,
-                text_color=TEXT_COLOR,
+                text_color=_occupancy_color(0),
+                font=("Segoe UI", 24, "bold"),
             )
             pct_label.pack(side="left", padx=(5, 0))
             self.home_percent_labels[box_num] = pct_label
@@ -2661,7 +2672,7 @@ class CardEditorApp:
     def build_box_preview(self, parent):
         """Create a scrollable grid of frames and progress bars for boxes."""
 
-        container = ctk.CTkScrollableFrame(parent, fg_color=BG_COLOR)
+        container = ctk.CTkFrame(parent, fg_color=BG_COLOR)
         container.pack(expand=True, fill="both", padx=10, pady=10)
 
         self.mag_box_order = list(range(1, BOX_COUNT + 1)) + [SPECIAL_BOX_NUMBER]
@@ -2675,13 +2686,19 @@ class CardEditorApp:
                 text=f"K{box_num}",
                 fg_color=BG_COLOR,
                 text_color=TEXT_COLOR,
+                font=("Segoe UI", 24, "bold"),
             )
             lbl.pack(anchor="w")
             self.mag_labels.append(lbl)
             for col in range(1, storage.BOX_COLUMNS.get(box_num, 4) + 1):
                 row_frame = ctk.CTkFrame(frame, fg_color=BG_COLOR)
                 row_frame.pack(fill="x", padx=2, pady=2)
-                bar = ctk.CTkProgressBar(row_frame, orientation="horizontal")
+                bar = ctk.CTkProgressBar(
+                    row_frame,
+                    orientation="horizontal",
+                    fg_color=FREE_COLOR,
+                    progress_color=OCCUPIED_COLOR,
+                )
                 bar.set(0)
                 bar.pack(side="left", fill="x", expand=True)
                 pct_label = ctk.CTkLabel(
@@ -2689,7 +2706,8 @@ class CardEditorApp:
                     text="0%",
                     width=40,
                     fg_color=BG_COLOR,
-                    text_color=TEXT_COLOR,
+                    text_color=_occupancy_color(0),
+                    font=("Segoe UI", 24, "bold"),
                 )
                 pct_label.pack(side="left", padx=(5, 0))
                 self.mag_progressbars[(box_num, col)] = bar
@@ -3244,7 +3262,7 @@ class CardEditorApp:
                 box, columns * storage.BOX_COLUMN_CAPACITY
             )
             value = box_occ.get(box, 0) / total_capacity if total_capacity else 0
-            lbl.configure(text=f"{value * 100:.0f}%")
+            lbl.configure(text=f"{value * 100:.0f}%", text_color=_occupancy_color(value))
 
     def refresh_magazyn(self):
         """Refresh storage view and update column usage bars."""
@@ -3264,7 +3282,7 @@ class CardEditorApp:
             bar.set(value)
             lbl = self.mag_percent_labels.get((box, col))
             if lbl:
-                lbl.configure(text=f"{value * 100:.0f}%")
+                lbl.configure(text=f"{value * 100:.0f}%", text_color=_occupancy_color(value))
 
         if hasattr(self, "update_inventory_stats"):
             try:

--- a/tests/ctk_mocks.py
+++ b/tests/ctk_mocks.py
@@ -83,10 +83,19 @@ class DummyCTkOptionMenu(_Widget):
 
 
 class DummyCTkProgressBar(_Widget):
-    def __init__(self, master=None, orientation="horizontal", **kwargs):
+    def __init__(
+        self,
+        master=None,
+        orientation="horizontal",
+        fg_color=None,
+        progress_color=None,
+        **kwargs,
+    ):
         self.master = master
         self.orientation = orientation
         self.value = 0
+        self.fg_color = fg_color
+        self.progress_color = progress_color
 
     def set(self, value):
         self.value = value

--- a/tests/test_magazyn_label_colors.py
+++ b/tests/test_magazyn_label_colors.py
@@ -23,11 +23,20 @@ class DummyCTkFrame(_Widget):
 
 
 class DummyCTkLabel(_Widget):
-    def __init__(self, master=None, text="", fg_color=None, text_color=None, **kwargs):
+    def __init__(
+        self,
+        master=None,
+        text="",
+        fg_color=None,
+        text_color=None,
+        font=None,
+        **kwargs,
+    ):
         self.master = master
         self.text = text
         self.fg_color = fg_color
         self.text_color = text_color
+        self.font = font
         self._bindings = {}
 
     def bind(self, event, callback):
@@ -92,10 +101,19 @@ class DummyCanvas(_Widget):
 
 
 class DummyCTkProgressBar(_Widget):
-    def __init__(self, master=None, orientation="horizontal", **kwargs):
+    def __init__(
+        self,
+        master=None,
+        orientation="horizontal",
+        fg_color=None,
+        progress_color=None,
+        **kwargs,
+    ):
         self.master = master
         self.orientation = orientation
         self.value = 0
+        self.fg_color = fg_color
+        self.progress_color = progress_color
 
     def set(self, value):
         self.value = value
@@ -145,3 +163,12 @@ def test_magazyn_label_colors():
     label = app.mag_labels[0]
     assert label.fg_color == ui.BG_COLOR
     assert label.text_color == ui.TEXT_COLOR
+    assert label.font == ("Segoe UI", 24, "bold")
+
+    key = (app.mag_box_order[0], 1)
+    bar = app.mag_progressbars[key]
+    assert bar.fg_color == ui.FREE_COLOR
+    assert bar.progress_color == ui.OCCUPIED_COLOR
+    pct = app.mag_percent_labels[key]
+    assert pct.font == ("Segoe UI", 24, "bold")
+    assert pct.text_color == ui._occupancy_color(0)

--- a/tests/test_welcome_screen_box_preview.py
+++ b/tests/test_welcome_screen_box_preview.py
@@ -9,7 +9,6 @@ from ctk_mocks import (
     DummyCTkButton,
     DummyCTkFrame,
     DummyCTkLabel,
-    DummyCTkScrollableFrame,
     DummyCTkEntry,
     DummyCTkOptionMenu,
     DummyCanvas,
@@ -21,7 +20,6 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
         CTkFrame=DummyCTkFrame,
         CTkLabel=DummyCTkLabel,
         CTkButton=DummyCTkButton,
-        CTkScrollableFrame=DummyCTkScrollableFrame,
         CTkEntry=DummyCTkEntry,
         CTkOptionMenu=DummyCTkOptionMenu,
     )
@@ -57,3 +55,6 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
 
     assert hasattr(app, "home_percent_labels")
     assert len(app.home_percent_labels) == len(app.mag_box_order)
+    first = app.home_percent_labels[app.mag_box_order[0]]
+    assert first.font == ("Segoe UI", 24, "bold")
+    assert first.text_color == ui._occupancy_color(0)


### PR DESCRIPTION
## Summary
- Replace scrollable frames with CTkFrame in box preview builders
- Apply bold 24pt fonts, progress bar colors, and occupancy-based label coloring
- Update tests for new widget types and styling

## Testing
- `pytest tests/test_welcome_screen_box_preview.py tests/test_magazyn_label_colors.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d43b96ac832f95accbb1ced0a4ba