### PR TITLE
Check magazyn.csv for duplicates on hash match

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -52,6 +52,62 @@ WAREHOUSE_FIELDNAMES = [
 ]
 
 
+def _sanitize_number(value: str) -> str:
+    """Return ``value`` without leading zeros.
+
+    Parameters
+    ----------
+    value:
+        Raw number string.
+
+    Returns
+    -------
+    str
+        Normalised number or ``"0"`` if the result is empty.
+    """
+
+    return value.lstrip("0") or "0"
+
+
+def find_duplicates(name: str, number: str, set_name: str, variant: str = "common"):
+    """Return rows from ``WAREHOUSE_CSV`` matching the given card details.
+
+    Parameters
+    ----------
+    name, number, set_name:
+        Card attributes to match against ``WAREHOUSE_CSV`` entries.
+    variant:
+        Card variant, defaults to ``"common"``.
+
+    Returns
+    -------
+    list[dict[str, str]]
+        List of matching rows including warehouse codes.
+    """
+
+    matches = []
+    number = _sanitize_number(str(number))
+    if not os.path.exists(WAREHOUSE_CSV):
+        return matches
+
+    try:
+        with open(WAREHOUSE_CSV, encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter=";")
+            for row in reader:
+                row_number = _sanitize_number(str(row.get("number", "")))
+                if (
+                    row.get("name") == name
+                    and row_number == number
+                    and row.get("set") == set_name
+                    and (row.get("variant") or "common") == variant
+                ):
+                    matches.append(row)
+    except OSError:
+        pass
+
+    return matches
+
+
 def get_inventory_stats(path: str = WAREHOUSE_CSV, force: bool = False):
     """Return statistics for both unsold and sold items in the warehouse CSV.
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4529,6 +4529,21 @@ class CardEditorApp:
                     str(meta.get("numer", meta.get("number", "")))
                 )
                 set_name = meta.get("set", meta.get("set_name", ""))
+                duplicates = csv_utils.find_duplicates(name, number, set_name)
+                if duplicates:
+                    codes = ", ".join(
+                        [row.get("warehouse_code", "") for row in duplicates if row.get("warehouse_code")]
+                    )
+                    msg = _(
+                        "Card already exists in magazyn: {codes}. Add anyway?"
+                    ).format(codes=codes)
+                    if not messagebox.askyesno(_("Duplicate"), msg):
+                        logger.info(
+                            "Skipping duplicate card %s #%s in set %s", name, number, set_name
+                        )
+                        if progress_cb:
+                            progress_cb(1.0, hide=True)
+                        return
                 self.entries["nazwa"].delete(0, tk.END)
                 self.entries["numer"].delete(0, tk.END)
                 self.entries["nazwa"].insert(0, name)

--- a/tests/test_magazyn_duplicates.py
+++ b/tests/test_magazyn_duplicates.py
@@ -41,7 +41,11 @@ def test_group_duplicates(tmp_path):
 
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
          patch.object(ui.tk, "Canvas", DummyCanvas), \
-         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)), \
+         patch.object(ui.messagebox, "showinfo", lambda *a, **k: None):
+        duplicates = ui.csv_utils.find_duplicates("A", "1", "S")
+        assert {row["warehouse_code"] for row in duplicates} == {"K1R1P1", "K1R1P2"}
+
         dummy_root = SimpleNamespace(
             minsize=lambda *a, **k: None,
             title=lambda *a, **k: None,

--- a/tests/test_show_card_duplicate_entries.py
+++ b/tests/test_show_card_duplicate_entries.py
@@ -9,7 +9,7 @@ import kartoteka.ui as ui
 from tests.ctk_mocks import DummyCTkEntry
 
 
-def test_show_card_clears_entries_for_duplicate(tmp_path, monkeypatch):
+def test_show_card_warns_on_magazyn_duplicate(tmp_path, monkeypatch):
     img = tmp_path / "card.jpg"
     img.write_bytes(b"data")
 
@@ -82,9 +82,16 @@ def test_show_card_clears_entries_for_duplicate(tmp_path, monkeypatch):
     monkeypatch.setattr(ui, "load_rgba_image", lambda path: DummyImage())
     monkeypatch.setattr(ui.ctk, "CTkEntry", DummyCTkEntry, raising=False)
 
+    dup_rows = [{"warehouse_code": "K1"}]
+    find_mock = MagicMock(return_value=dup_rows)
+    monkeypatch.setattr(ui.csv_utils, "find_duplicates", find_mock)
+    ask_mock = MagicMock(return_value=False)
+    monkeypatch.setattr(ui.messagebox, "askyesno", ask_mock)
+
     with patch.object(ui.Image, "open", return_value=DummyImage()):
         ui.CardEditorApp.show_card(dummy)
-        ui.CardEditorApp.show_card(dummy)
 
-    assert name_entry.get() == "Pika"
-    assert num_entry.get() == "1"
+    find_mock.assert_called_once_with("Pika", "1", "Set X")
+    assert ask_mock.called
+    assert name_entry.get() == ""
+    assert num_entry.get() == ""


### PR DESCRIPTION
## Summary
- add `find_duplicates` helper in `csv_utils` to scan `magazyn.csv`
- warn users when a hash match already exists in `magazyn.csv` and skip unless confirmed
- test duplicate handling against existing warehouse entries

## Testing
- `pytest tests/test_magazyn_duplicates.py tests/test_show_card_duplicate_entries.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d6f25e08832fab1e9910e83e1638