### PR TITLE
Inline magazyn view and update call sites

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1583,7 +1583,7 @@ class CardEditorApp:
         self.create_button(
             button_frame,
             text="\U0001f4e6 Magazyn",
-            command=self.open_magazyn_window,
+            command=self.show_magazyn_view,
             fg_color=MAGAZYN_BUTTON_COLOR,
         ).pack(side="left", padx=10, pady=5)
         self.create_button(
@@ -2614,9 +2614,9 @@ class CardEditorApp:
             except Exception:
                 logger.exception("Failed to update inventory stats")
 
-        if hasattr(self, "open_magazyn_window"):
+        if hasattr(self, "show_magazyn_view"):
             try:
-                self.open_magazyn_window()
+                self.show_magazyn_view()
             except Exception:
                 logger.exception("Failed to refresh magazyn window")
 
@@ -2725,7 +2725,7 @@ class CardEditorApp:
         self.mag_sold_labels = []
         self.mag_card_image_labels: list[Optional[ctk.CTkLabel]] = []
 
-    def _open_magazyn_window_internal(self):
+    def show_magazyn_view(self):
         """Display storage occupancy inside the main window."""
         # Unbind previous resize handlers if they exist before rebuilding the
         # magazine view. This prevents ``_relayout_mag_cards`` from being
@@ -3125,20 +3125,21 @@ class CardEditorApp:
         btn_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
         btn_frame.pack(pady=5)
 
-        def _close_mag_window(top=current_root):
-            """Unbind resize handlers and close the magazine list view."""
+        def _close_mag_window():
+            """Return to the previous screen and remove magazyn bindings."""
             mag_frame = getattr(self, "mag_list_frame", None)
             if mag_frame is not None:
                 unbind = getattr(mag_frame, "unbind", None)
                 if callable(unbind) and getattr(self, "_mag_bind_id", None):
                     unbind("<Configure>", self._mag_bind_id)
             if getattr(self, "_root_mag_bind_id", None):
-                root_unbind = getattr(top, "unbind", None)
+                root_unbind = getattr(current_root, "unbind", None)
                 if callable(root_unbind):
                     root_unbind("<Configure>", self._root_mag_bind_id)
             self._mag_bind_id = None
             self._root_mag_bind_id = None
-            getattr(top, "destroy", lambda: None)()
+            if hasattr(self, "back_to_welcome"):
+                self.back_to_welcome()
 
         self.create_button(
             btn_frame, text="Odśwież", command=self.refresh_magazyn
@@ -3213,54 +3214,13 @@ class CardEditorApp:
                 logger.exception("Failed to update inventory stats")
 
     def open_magazyn_window(self):
-        """Display storage view in a separate window without altering the main UI."""
+        """Legacy wrapper for :meth:`show_magazyn_view`.
 
-        try:
-            top = ctk.CTkToplevel(self.root)
-        except Exception:
-            try:
-                top = tk.Toplevel(self.root)  # type: ignore[attr-defined]
-            except Exception:
-                top = SimpleNamespace()
-        if hasattr(top, "title"):
-            top.title("Podgląd magazynu")
-        self.magazyn_window = top
-
-        # Provide no-op implementations for window methods when running in tests
-        top.title = getattr(top, "title", lambda *a, **k: None)
-        top.winfo_screenwidth = getattr(top, "winfo_screenwidth", lambda: 0)
-        top.winfo_screenheight = getattr(top, "winfo_screenheight", lambda: 0)
-        top.minsize = getattr(top, "minsize", lambda *a, **k: None)
-        top.bind = getattr(top, "bind", lambda *a, **k: None)
-        top.destroy = getattr(top, "destroy", lambda *a, **k: None)
-
-        old_root = self.root
-        old_start = getattr(self, "start_frame", None)
-        old_pricing = getattr(self, "pricing_frame", None)
-        old_shoper = getattr(self, "shoper_frame", None)
-        old_frame = getattr(self, "frame", None)
-        old_location = getattr(self, "location_frame", None)
-        old_mag_frame = getattr(self, "magazyn_frame", None)
-
-        self.root = top
-        self.start_frame = None
-        self.pricing_frame = None
-        self.shoper_frame = None
-        self.frame = None
-        self.magazyn_frame = None
-        self.location_frame = None
-
-        try:
-            CardEditorApp._open_magazyn_window_internal(self)
-        finally:
-            new_mag_frame = self.magazyn_frame
-            self.root = old_root
-            self.start_frame = old_start
-            self.pricing_frame = old_pricing
-            self.shoper_frame = old_shoper
-            self.frame = old_frame
-            self.location_frame = old_location
-            self.magazyn_frame = new_mag_frame
+        Existing callers expecting ``open_magazyn_window`` can still invoke it,
+        but it simply delegates to :meth:`show_magazyn_view` and renders the
+        view inside the main application window.
+        """
+        self.show_magazyn_view()
 
     def compute_box_occupancy(self) -> dict[int, int]:
         """Return dictionary of used slots per storage box."""
@@ -3545,8 +3505,8 @@ class CardEditorApp:
             except Exception:
                 logger.exception("Failed to update inventory stats")
 
-        if hasattr(self, "open_magazyn_window"):
-            self.open_magazyn_window()
+        if hasattr(self, "show_magazyn_view"):
+            self.show_magazyn_view()
 
     def toggle_sold(self, row: dict, window=None):
         """Toggle the sold flag for a warehouse card and update CSV."""
@@ -3590,8 +3550,8 @@ class CardEditorApp:
                 logger.exception("Failed to update inventory stats")
 
         # Refresh main view to reflect the change
-        if hasattr(self, "open_magazyn_window"):
-            self.open_magazyn_window()
+        if hasattr(self, "show_magazyn_view"):
+            self.show_magazyn_view()
 
     def setup_pricing_ui(self):
         """UI for quick card price lookup."""

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -83,7 +83,7 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
             update_inventory_stats=lambda: None,
         )
 
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
         ui.CardEditorApp.build_box_preview(app, app.magazyn_frame)
         ui.CardEditorApp.refresh_magazyn(app)
 

--- a/tests/test_column_occupancy.py
+++ b/tests/test_column_occupancy.py
@@ -134,7 +134,7 @@ def test_refresh_colors_columns_based_on_occupancy(tmp_path, monkeypatch):
             back_to_welcome=lambda: None,
             update_inventory_stats=lambda: None,
         )
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
         ui.CardEditorApp.build_box_preview(app, app.magazyn_frame)
         ui.CardEditorApp.refresh_magazyn(app)
 

--- a/tests/test_confirm_order_updates_sold_flags.py
+++ b/tests/test_confirm_order_updates_sold_flags.py
@@ -26,7 +26,7 @@ def test_confirm_order_updates_csv(tmp_path, monkeypatch):
     refresh_called = []
     app = SimpleNamespace(
         update_inventory_stats=lambda: stats_called.append(True),
-        open_magazyn_window=lambda: refresh_called.append(True),
+        show_magazyn_view=lambda: refresh_called.append(True),
         pending_orders=[{"products": [{"warehouse_code": "K1;K2"}]}],
     )
     app.complete_order = lambda order: ui.CardEditorApp.complete_order(app, order)

--- a/tests/test_magazyn_badge_display.py
+++ b/tests/test_magazyn_badge_display.py
@@ -74,7 +74,7 @@ def test_badge_display_for_duplicates_only(tmp_path):
             back_to_welcome=lambda: None,
         )
 
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
 
     badges = [lbl for lbl in created_labels if lbl.kwargs.get("width") == 20]
     assert len(badges) == 1

--- a/tests/test_magazyn_duplicates.py
+++ b/tests/test_magazyn_duplicates.py
@@ -63,7 +63,7 @@ def test_group_duplicates(tmp_path):
             back_to_welcome=lambda: None,
         )
 
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
 
     assert len(app.mag_card_rows) == 1
     row = app.mag_card_rows[0]

--- a/tests/test_magazyn_inventory_stats_view.py
+++ b/tests/test_magazyn_inventory_stats_view.py
@@ -64,7 +64,7 @@ def test_inventory_stats_display_and_update(tmp_path, monkeypatch):
             back_to_welcome=lambda: None,
         )
 
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
 
     assert app.mag_inventory_count_label.text == f"📊 Łączna liczba kart: {first_stats[0]}"
     assert (

--- a/tests/test_magazyn_label_colors.py
+++ b/tests/test_magazyn_label_colors.py
@@ -157,7 +157,7 @@ def test_magazyn_label_colors():
             back_to_welcome=lambda: None,
         )
 
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
         ui.CardEditorApp.build_box_preview(app, app.magazyn_frame)
 
     label = app.mag_labels[0]

--- a/tests/test_magazyn_search_filters.py
+++ b/tests/test_magazyn_search_filters.py
@@ -52,7 +52,7 @@ def _load_app(csv_path, stats):
             refresh_magazyn=lambda: None,
             back_to_welcome=lambda: None,
         )
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
         return app
 
 
@@ -149,7 +149,7 @@ def _load_app_with_delay(csv_path, stats):
         back_to_welcome=lambda: None,
         show_card_details=lambda *a, **k: None,
     )
-    ui.CardEditorApp.open_magazyn_window(app)
+    ui.CardEditorApp.show_magazyn_view(app)
     return app, photo_mock, stack
 
 

--- a/tests/test_magazyn_show_card_details.py
+++ b/tests/test_magazyn_show_card_details.py
@@ -175,7 +175,7 @@ def test_show_card_details_receives_row(tmp_path):
             show_card_details=fake_show,
         )
 
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
 
         label = _extract_label(app.mag_card_labels[0])
         label._bindings["<Button-1>"](None)

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -75,7 +75,7 @@ def test_sold_cards_styled(tmp_path):
             back_to_welcome=lambda: None,
         )
 
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
 
     assert len(app.mag_card_labels) == 1
     assert len(app.mag_sold_labels) == 1

--- a/tests/test_mark_as_sold_multiple_codes.py
+++ b/tests/test_mark_as_sold_multiple_codes.py
@@ -57,14 +57,14 @@ def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
         back_to_welcome=lambda: None,
     )
 
-    ui.CardEditorApp.open_magazyn_window(app)
+    ui.CardEditorApp.show_magazyn_view(app)
 
     row = app.mag_card_rows[0]
     assert row["warehouse_code"] == "K1;K2"
     assert row["_count"] == 2
 
     app.update_inventory_stats = lambda: None
-    app.open_magazyn_window = lambda: ui.CardEditorApp.open_magazyn_window(app)
+    app.show_magazyn_view = lambda: ui.CardEditorApp.show_magazyn_view(app)
 
     ui.CardEditorApp.mark_as_sold(app, row, warehouse_code="K1")
 

--- a/tests/test_remote_image_loading.py
+++ b/tests/test_remote_image_loading.py
@@ -143,7 +143,7 @@ def _write_csv(path, image_url):
         )
 
 
-def test_open_magazyn_window_remote_thumbnail(tmp_path):
+def test_show_magazyn_view_remote_thumbnail(tmp_path):
     ui = _setup_module(tmp_path)
 
     url = "https://example.com/card.png"
@@ -191,7 +191,7 @@ def test_open_magazyn_window_remote_thumbnail(tmp_path):
          patch.object(ui.requests, "get", return_value=resp) as mock_get, \
          patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)), \
          patch.object(ui.messagebox, "showinfo", lambda *a, **k: None):
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
         for t in app._image_threads:
             t.join()
 
@@ -237,7 +237,7 @@ def test_show_card_details_remote_uses_cache(tmp_path):
          patch.object(ui.requests, "get", return_value=resp) as mock_get, \
          patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)):
         # first load thumbnails
-        ui.CardEditorApp.open_magazyn_window(app)
+        ui.CardEditorApp.show_magazyn_view(app)
         for t in app._image_threads:
             t.join()
         # then show details which should reuse cache and not trigger new request

--- a/tests/test_show_card_details_sprzedano_button.py
+++ b/tests/test_show_card_details_sprzedano_button.py
@@ -70,7 +70,7 @@ def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
     stats_mock = MagicMock()
     app = SimpleNamespace(
         root=SimpleNamespace(),
-        open_magazyn_window=open_mock,
+        show_magazyn_view=open_mock,
         update_inventory_stats=stats_mock,
     )
     app.mark_as_sold = lambda r, w=None, c=None: ui.CardEditorApp.mark_as_sold(

--- a/tests/test_toggle_sold.py
+++ b/tests/test_toggle_sold.py
@@ -20,7 +20,7 @@ def test_toggle_sold_updates_csv(tmp_path, monkeypatch):
     monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
     row = {"name": "A", "warehouse_code": "K1R1P1", "sold": ""}
     app = SimpleNamespace(
-        open_magazyn_window=lambda: None, update_inventory_stats=MagicMock()
+        show_magazyn_view=lambda: None, update_inventory_stats=MagicMock()
     )
 
     ui.CardEditorApp.toggle_sold(app, row)

--- a/tests/test_welcome_screen_box_preview.py
+++ b/tests/test_welcome_screen_box_preview.py
@@ -48,7 +48,7 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
             show_location_frame=lambda: None,
             setup_pricing_ui=lambda: None,
             open_shoper_window=lambda: None,
-            open_magazyn_window=lambda: None,
+            show_magazyn_view=lambda: None,
             open_auctions_window=lambda: None,
         )
         ui.CardEditorApp.setup_welcome_screen(app)


### PR DESCRIPTION
## Summary
- render magazyn view directly in main window via new `show_magazyn_view`
- keep `open_magazyn_window` as a thin wrapper for compatibility
- refresh magazyn in `mark_as_sold`/`toggle_sold` using the new view and fix closing logic
- update tests to reference the in-place magazyn view

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e3e429f8832fa7b2cfd48d34ed0c