### PR TITLE
Add magazyn pagination with grid layout

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2779,6 +2779,11 @@ class CardEditorApp:
         self.mag_labels = []
         self.mag_box_order = []
 
+        # Pagination settings for magazyn card list
+        self.mag_page_size = getattr(self, "mag_page_size", 20)
+        self.mag_page = 0
+        self.mag_total_pages = 1
+
         control_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
         control_frame.pack(fill="x", padx=10, pady=(10, 0))
 
@@ -3008,18 +3013,28 @@ class CardEditorApp:
 
                     indices.sort(key=_price)
 
+                total = len(indices)
+                self.mag_total_pages = max(1, (total + self.mag_page_size - 1) // self.mag_page_size)
+                self.mag_page = max(0, min(self.mag_page, self.mag_total_pages - 1))
+                start = self.mag_page * self.mag_page_size
+                end = start + self.mag_page_size
+                page_indices = indices[start:end]
+
                 for frame in getattr(self, "mag_card_frames", []):
                     frame.destroy()
                 self.mag_card_frames = []
                 self.mag_card_labels = []
                 self.mag_sold_labels = []
-                displayed = set(indices)
+                displayed = set(page_indices)
 
-                for idx in indices:
+                cols = 4
+                for pos, idx in enumerate(page_indices):
                     row = self.mag_card_rows[idx]
                     photo = self.mag_card_images[idx]
                     frame = ctk.CTkFrame(list_frame, fg_color=BG_COLOR)
-                    frame.pack(fill="x", padx=5, pady=5)
+                    r = pos // cols
+                    c = pos % cols
+                    frame.grid(row=r, column=c, padx=5, pady=5, sticky="n")
                     is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
                     text = row.get("name", "")
                     color = TEXT_COLOR
@@ -3080,6 +3095,17 @@ class CardEditorApp:
                     if i not in displayed:
                         self.mag_card_image_labels[i] = None
 
+                prev_btn = getattr(self, "mag_prev_button", None)
+                if prev_btn is not None and hasattr(prev_btn, "configure"):
+                    prev_state = "normal" if self.mag_page > 0 else "disabled"
+                    prev_btn.configure(state=prev_state)
+                next_btn = getattr(self, "mag_next_button", None)
+                if next_btn is not None and hasattr(next_btn, "configure"):
+                    next_state = (
+                        "normal" if self.mag_page < self.mag_total_pages - 1 else "disabled"
+                    )
+                    next_btn.configure(state=next_state)
+
                 canvas = getattr(list_frame, "_parent_canvas", None)
                 if canvas is not None:
                     def _update_scroll_region():
@@ -3109,6 +3135,23 @@ class CardEditorApp:
                 self._root_mag_bind_id = root_bind("<Configure>", _relayout_mag_cards)
             else:
                 self._root_mag_bind_id = None
+
+            def _prev_page():
+                if self.mag_page > 0:
+                    self.mag_page -= 1
+                    _update_mag_list()
+
+            def _next_page():
+                if self.mag_page < self.mag_total_pages - 1:
+                    self.mag_page += 1
+                    _update_mag_list()
+
+            nav_frame = ctk.CTkFrame(self.magazyn_frame, fg_color=BG_COLOR)
+            nav_frame.pack(pady=5)
+            self.mag_prev_button = self.create_button(nav_frame, text="Previous", command=_prev_page)
+            self.mag_prev_button.pack(side="left", padx=5)
+            self.mag_next_button = self.create_button(nav_frame, text="Next", command=_next_page)
+            self.mag_next_button.pack(side="left", padx=5)
 
             self.mag_search_var.trace_add("write", _update_mag_list)
             self.mag_sold_filter_var.trace_add("write", _update_mag_list)

--- a/tests/test_magazyn_pagination_grid.py
+++ b/tests/test_magazyn_pagination_grid.py
@@ -1,0 +1,135 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parent))
+from ctk_mocks import (
+    DummyCTkButton,
+    DummyCTkEntry,
+    DummyCTkFrame,
+    DummyCTkLabel,
+    DummyCTkOptionMenu,
+    DummyCTkScrollableFrame,
+    DummyCanvas,
+)
+
+
+def _load_app(csv_path, stats):
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=DummyCTkFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+        CTkScrollableFrame=DummyCTkScrollableFrame,
+        CTkEntry=DummyCTkEntry,
+        CTkOptionMenu=DummyCTkOptionMenu,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
+         patch.object(ui.tk, "Canvas", DummyCanvas), \
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)), \
+         patch.object(ui.csv_utils, "get_inventory_stats", return_value=stats):
+        dummy_root = SimpleNamespace(
+            minsize=lambda *a, **k: None,
+            title=lambda *a, **k: None,
+        )
+        app = SimpleNamespace(
+            root=dummy_root,
+            start_frame=None,
+            pricing_frame=None,
+            shoper_frame=None,
+            frame=None,
+            magazyn_frame=None,
+            location_frame=None,
+            create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+            refresh_magazyn=lambda: None,
+            back_to_welcome=lambda: None,
+        )
+        ui.CardEditorApp.show_magazyn_view(app)
+        return app
+
+
+def test_magazyn_page_navigation(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    header = "name;number;era;set;warehouse_code;price;image;variant\n"
+    rows = [
+        f"Card{i:02d};{i};E;S;K{i};1;img{i}.png;common\n" for i in range(25)
+    ]
+    csv_path.write_text(header + "".join(rows), encoding="utf-8")
+
+    app = _load_app(csv_path, (25, 25.0, 0, 0))
+
+    assert app.mag_page == 0
+    assert len(app.mag_card_labels) == 20
+
+    app.mag_next_button.kwargs["command"]()
+    assert app.mag_page == 1
+    assert len(app.mag_card_labels) == 5
+    assert app.mag_card_labels[0].text == "Card20"
+
+    app.mag_prev_button.kwargs["command"]()
+    assert app.mag_page == 0
+    assert len(app.mag_card_labels) == 20
+
+
+def test_magazyn_grid_positions(tmp_path):
+    class RecordingFrame(DummyCTkFrame):
+        def grid(self, **kwargs):
+            self.grid_kwargs = kwargs
+            return self
+
+    sys.modules["customtkinter"] = SimpleNamespace(
+        CTkFrame=RecordingFrame,
+        CTkLabel=DummyCTkLabel,
+        CTkButton=DummyCTkButton,
+        CTkScrollableFrame=DummyCTkScrollableFrame,
+        CTkEntry=DummyCTkEntry,
+        CTkOptionMenu=DummyCTkOptionMenu,
+    )
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;era;set;warehouse_code;price;image;variant\n"
+        "A;1;E;S;K1;1;foo1.png;common\n"
+        "B;2;E;S;K2;1;foo2.png;common\n"
+        "C;3;E;S;K3;1;foo3.png;common\n",
+        encoding="utf-8",
+    )
+
+    photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
+    with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
+         patch.object(ui.tk, "Canvas", DummyCanvas), \
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)), \
+         patch.object(ui.csv_utils, "get_inventory_stats", return_value=(3, 3.0, 0, 0)):
+        dummy_root = SimpleNamespace(
+            minsize=lambda *a, **k: None,
+            title=lambda *a, **k: None,
+        )
+        app = SimpleNamespace(
+            root=dummy_root,
+            start_frame=None,
+            pricing_frame=None,
+            shoper_frame=None,
+            frame=None,
+            magazyn_frame=None,
+            location_frame=None,
+            create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+            refresh_magazyn=lambda: None,
+            back_to_welcome=lambda: None,
+        )
+        ui.CardEditorApp.show_magazyn_view(app)
+
+    frames = app.mag_card_frames
+    assert frames[0].grid_kwargs["row"] == 0
+    assert frames[0].grid_kwargs["column"] == 0
+    assert frames[1].grid_kwargs["row"] == 0
+    assert frames[1].grid_kwargs["column"] == 1
+


### PR DESCRIPTION
## Summary
- paginate magazyn cards with `mag_page` and `mag_page_size`
- lay out magazyn thumbnails in a grid and add prev/next controls
- test page navigation and grid positioning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e5d70db8832f8c0132cac6dc8fee