### PR TITLE
Use in-place magazyn refresh

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3542,14 +3542,19 @@ class CardEditorApp:
             except tk.TclError:
                 pass
 
-        if hasattr(self, "update_inventory_stats"):
+        # Refresh the magazyn view in-place rather than reopening the window.
+        if hasattr(self, "refresh_magazyn"):
             try:
-                self.update_inventory_stats()
+                self.refresh_magazyn()
             except Exception:
-                logger.exception("Failed to update inventory stats")
-
-        if hasattr(self, "show_magazyn_view"):
-            self.show_magazyn_view()
+                logger.exception("Failed to refresh magazyn view")
+        elif hasattr(self, "show_magazyn_view"):
+            # Fallback for environments where the magazyn view was not yet
+            # initialised; rebuild it inside the main window.
+            try:
+                self.show_magazyn_view()
+            except Exception:
+                logger.exception("Failed to display magazyn view")
 
     def toggle_sold(self, row: dict, window=None):
         """Toggle the sold flag for a warehouse card and update CSV."""
@@ -3585,16 +3590,17 @@ class CardEditorApp:
             except tk.TclError:
                 pass
 
-        # Update inventory statistics after toggling the sold flag
-        if hasattr(self, "update_inventory_stats"):
+        # Refresh main view to reflect the change without recreating the root
+        if hasattr(self, "refresh_magazyn"):
             try:
-                self.update_inventory_stats()
-            except Exception as exc:
-                logger.exception("Failed to update inventory stats")
-
-        # Refresh main view to reflect the change
-        if hasattr(self, "show_magazyn_view"):
-            self.show_magazyn_view()
+                self.refresh_magazyn()
+            except Exception:
+                logger.exception("Failed to refresh magazyn view")
+        elif hasattr(self, "show_magazyn_view"):
+            try:
+                self.show_magazyn_view()
+            except Exception:
+                logger.exception("Failed to display magazyn view")
 
     def setup_pricing_ui(self):
         """UI for quick card price lookup."""

--- a/tests/test_mark_as_sold_multiple_codes.py
+++ b/tests/test_mark_as_sold_multiple_codes.py
@@ -2,6 +2,7 @@ import csv
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
@@ -13,6 +14,32 @@ def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
     )
 
     sys.path.append(str(Path(__file__).resolve().parents[1]))
+    class _TkMock(SimpleNamespace):
+        class TclError(Exception):
+            pass
+
+        @staticmethod
+        def StringVar(*args, **kwargs):
+            raise RuntimeError("tkinter unavailable")
+
+    tk_mod = _TkMock()
+    tk_mod.filedialog = SimpleNamespace()
+    tk_mod.messagebox = SimpleNamespace()
+    tk_mod.simpledialog = SimpleNamespace()
+    tk_mod.ttk = SimpleNamespace()
+    tk_mod.Canvas = SimpleNamespace()
+    sys.modules["tkinter"] = tk_mod
+    sys.modules["tkinter.ttk"] = tk_mod.ttk
+    sys.modules["tkinter.filedialog"] = tk_mod.filedialog
+    sys.modules["tkinter.messagebox"] = tk_mod.messagebox
+    sys.modules["tkinter.simpledialog"] = tk_mod.simpledialog
+    sys.modules["imagehash"] = MagicMock()
+    sys.modules["openai"] = MagicMock()
+    sys.modules["requests"] = MagicMock()
+    sys.modules["pydantic"] = MagicMock()
+    sys.modules["pytesseract"] = MagicMock()
+    sys.modules["dotenv"] = MagicMock()
+    sys.modules["numpy"] = MagicMock()
     from tests.ctk_mocks import (
         DummyCTkButton,
         DummyCTkEntry,
@@ -42,6 +69,7 @@ def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
     monkeypatch.setattr(ui.tk, "Canvas", DummyCanvas)
     monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
     monkeypatch.setattr(ui, "_load_image", lambda path: None)
+    refresh_called: list[bool] = []
 
     dummy_root = SimpleNamespace(minsize=lambda *a, **k: None, title=lambda *a, **k: None)
     app = SimpleNamespace(
@@ -53,7 +81,7 @@ def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
         magazyn_frame=None,
         location_frame=None,
         create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
-        refresh_magazyn=lambda: None,
+        refresh_magazyn=lambda: refresh_called.append(True),
         back_to_welcome=lambda: None,
     )
 
@@ -77,8 +105,10 @@ def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
     assert row["warehouse_code"] == "K2"
     assert row["_count"] == 1
 
-    assert len(app.mag_card_rows) == 2
-    unsold = next(r for r in app.mag_card_rows if not r.get("sold"))
+    assert refresh_called
+    assert len(app.mag_card_rows) == 1
+    unsold = app.mag_card_rows[0]
+    assert not unsold.get("sold")
     assert unsold["warehouse_code"] == "K2"
     assert unsold["_count"] == 1
 

--- a/tests/test_show_card_details_sprzedano_button.py
+++ b/tests/test_show_card_details_sprzedano_button.py
@@ -51,6 +51,15 @@ def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
         def destroy(self):
             pass
 
+    sys.modules["tkinter"] = MagicMock()
+    sys.modules["tkinter.ttk"] = MagicMock()
+    sys.modules["imagehash"] = MagicMock()
+    sys.modules["openai"] = MagicMock()
+    sys.modules["requests"] = MagicMock()
+    sys.modules["pydantic"] = MagicMock()
+    sys.modules["pytesseract"] = MagicMock()
+    sys.modules["dotenv"] = MagicMock()
+    sys.modules["numpy"] = MagicMock()
     sys.modules["customtkinter"] = SimpleNamespace(
         CTkToplevel=DummyToplevel,
         CTkFrame=DummyFrame,
@@ -66,12 +75,11 @@ def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
     monkeypatch.setattr(ui, "_create_image", lambda img: SimpleNamespace())
     monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
 
-    open_mock = MagicMock()
+    refresh_mock = MagicMock()
     stats_mock = MagicMock()
     app = SimpleNamespace(
         root=SimpleNamespace(),
-        show_magazyn_view=open_mock,
-        update_inventory_stats=stats_mock,
+        refresh_magazyn=lambda: (refresh_mock(), stats_mock()),
     )
     app.mark_as_sold = lambda r, w=None, c=None: ui.CardEditorApp.mark_as_sold(
         app, r, w, c
@@ -98,6 +106,6 @@ def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
         rows = list(reader)
         assert rows[0]["sold"] == "1"
 
-    open_mock.assert_called_once()
+    refresh_mock.assert_called_once()
     stats_mock.assert_called_once()
 

--- a/tests/test_toggle_sold.py
+++ b/tests/test_toggle_sold.py
@@ -6,6 +6,18 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 sys.modules.setdefault("customtkinter", MagicMock())
+sys.modules.setdefault("tkinter", MagicMock())
+sys.modules.setdefault("tkinter.ttk", MagicMock())
+sys.modules.setdefault("PIL", MagicMock())
+sys.modules.setdefault("PIL.Image", MagicMock())
+sys.modules.setdefault("PIL.ImageTk", MagicMock())
+sys.modules.setdefault("imagehash", MagicMock())
+sys.modules.setdefault("openai", MagicMock())
+sys.modules.setdefault("requests", MagicMock())
+sys.modules.setdefault("pydantic", MagicMock())
+sys.modules.setdefault("pytesseract", MagicMock())
+sys.modules.setdefault("dotenv", MagicMock())
+sys.modules.setdefault("numpy", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import kartoteka.ui as ui
@@ -19,20 +31,19 @@ def test_toggle_sold_updates_csv(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
     row = {"name": "A", "warehouse_code": "K1R1P1", "sold": ""}
-    app = SimpleNamespace(
-        show_magazyn_view=lambda: None, update_inventory_stats=MagicMock()
-    )
+    refresh_called = MagicMock()
+    app = SimpleNamespace(refresh_magazyn=refresh_called)
 
     ui.CardEditorApp.toggle_sold(app, row)
-    app.update_inventory_stats.assert_called_once()
+    refresh_called.assert_called_once()
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
         assert rows[0]["sold"] == "1"
 
-    app.update_inventory_stats.reset_mock()
+    refresh_called.reset_mock()
     ui.CardEditorApp.toggle_sold(app, row)
-    app.update_inventory_stats.assert_called_once()
+    refresh_called.assert_called_once()
     with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)


### PR DESCRIPTION
## Summary
- refresh magazyn view in place when marking or toggling sold cards
- update tests to verify refresh_magazyn is used instead of reopening window

## Testing
- `python -m pytest tests/test_toggle_sold.py tests/test_show_card_details_sprzedano_button.py tests/test_mark_as_sold_multiple_codes.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6e7da7c68832fb38dec5c21b50e94