### PR TITLE
Remove era column from warehouse CSV

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -42,7 +42,6 @@ STORE_FIELDNAMES = [
 WAREHOUSE_FIELDNAMES = [
     "name",
     "number",
-    "era",
     "set",
     "warehouse_code",
     "price",
@@ -224,7 +223,6 @@ def format_warehouse_row(row):
     return {
         "name": row.get("nazwa", ""),
         "number": row.get("numer", ""),
-        "era": row.get("era", ""),
         "set": row.get("set", ""),
         "warehouse_code": row.get("warehouse_code", ""),
         "price": row.get("cena") or row.get("price", ""),
@@ -353,7 +351,7 @@ def export_csv(app):
     for row in app.output_data:
         if row is None:
             continue
-        key = f"{row['nazwa']}|{row['numer']}|{row['set']}|{row['era']}"
+        key = f"{row['nazwa']}|{row['numer']}|{row['set']}|{row.get('era', '')}"
         if key in combined:
             combined[key]["stock"] += 1
         else:

--- a/magazyn.csv
+++ b/magazyn.csv
@@ -1,1 +1,1 @@
-name;number;era;set;warehouse_code;price;image;variant;sold
+name;number;set;warehouse_code;price;image;variant;sold

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -721,7 +721,7 @@ def test_analyze_and_fill_runs_full_pipeline_for_non_matching_card(tmp_path):
 def test_show_card_fills_from_inventory(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        f"name;numer;set;era\nPikachu;001;{SV01_NAME};{ui.get_set_era(SV01_CODE)}\n",
+        f"name;numer;set\nPikachu;001;{SV01_NAME}\n",
         encoding="utf-8",
     )
     monkeypatch.setenv("WAREHOUSE_CSV", str(csv_path))

--- a/tests/test_append_warehouse_csv.py
+++ b/tests/test_append_warehouse_csv.py
@@ -31,6 +31,7 @@ def test_append_warehouse_csv_updates_stats(tmp_path):
     with open(path, encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
+        assert reader.fieldnames == csv_utils.WAREHOUSE_FIELDNAMES
         assert rows[0]["warehouse_code"] == "K1"
 
 
@@ -54,4 +55,5 @@ def test_append_warehouse_csv_writes_variant(tmp_path):
     with open(path, encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         row = next(reader)
+        assert reader.fieldnames == csv_utils.WAREHOUSE_FIELDNAMES
         assert row["variant"] == "holo"

--- a/tests/test_download_warehouse_csv.py
+++ b/tests/test_download_warehouse_csv.py
@@ -10,9 +10,16 @@ def test_local_warehouse_csv_exists():
     assert path.exists()
     header = path.read_text(encoding="utf-8").splitlines()[0]
     assert header == ";".join(csv_utils.WAREHOUSE_FIELDNAMES)
-    header_fields = header.split(";")
-    assert "era" in csv_utils.WAREHOUSE_FIELDNAMES
-    assert "era" in header_fields
+    assert csv_utils.WAREHOUSE_FIELDNAMES == [
+        "name",
+        "number",
+        "set",
+        "warehouse_code",
+        "price",
+        "image",
+        "variant",
+        "sold",
+    ]
 
 
 def test_download_function_removed():

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -150,12 +150,12 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
         row = rows[0]
         assert row["name"] == "Pikachu"
         assert row["number"] == "1"
-        assert row["era"] == "Era1"
         assert row["set"] == "Base"
         assert row["warehouse_code"] == "K1R1P1"
         assert row["price"] == "10"
         assert row["image"] == "img.jpg"
         assert row["variant"] == "common"
         assert row.get("sold", "") == ""
+        assert "era" not in row
 
 

--- a/tests/test_inventory_stats.py
+++ b/tests/test_inventory_stats.py
@@ -10,8 +10,8 @@ from kartoteka import csv_utils
 def test_get_inventory_stats(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image\n"
-        "A;1;E1;S1;K1;10.5;img1\n" "B;2;E2;S2;K2;5,25;img2\n",
+        "name;number;set;warehouse_code;price;image\n"
+        "A;1;S1;K1;10.5;img1\n" "B;2;S2;K2;5,25;img2\n",
         encoding="utf-8",
     )
     count_unsold, total_unsold, count_sold, total_sold = csv_utils.get_inventory_stats(
@@ -26,8 +26,8 @@ def test_get_inventory_stats(tmp_path):
 def test_inventory_stats_excludes_sold(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;sold\n"
-        "A;1;E1;S1;K1;10;img1;\n" "B;2;E2;S2;K2;5;img2;1\n",
+        "name;number;set;warehouse_code;price;image;sold\n"
+        "A;1;S1;K1;10;img1;\n" "B;2;S2;K2;5;img2;1\n",
         encoding="utf-8",
     )
     count_unsold, total_unsold, count_sold, total_sold = csv_utils.get_inventory_stats(

--- a/tests/test_inventory_stats_cache.py
+++ b/tests/test_inventory_stats_cache.py
@@ -17,7 +17,7 @@ def test_get_inventory_stats_cached(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     _write_csv(
         csv_path,
-        "name;number;era;set;warehouse_code;price;image\n" "A;1;E1;S1;K1;10;img\n",
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
     )
 
     first = csv_utils.get_inventory_stats(str(csv_path))
@@ -41,7 +41,7 @@ def test_get_inventory_stats_recomputes_on_change(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     _write_csv(
         csv_path,
-        "name;number;era;set;warehouse_code;price;image\n" "A;1;E1;S1;K1;10;img\n",
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
     )
 
     first = csv_utils.get_inventory_stats(str(csv_path))
@@ -49,7 +49,7 @@ def test_get_inventory_stats_recomputes_on_change(tmp_path):
     mtime = os.path.getmtime(csv_path)
     _write_csv(
         csv_path,
-        "name;number;era;set;warehouse_code;price;image\n" "A;1;E1;S1;K1;10;img\n" "B;2;E2;S2;K2;5;img2\n",
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n" "B;2;S2;K2;5;img2\n",
     )
     os.utime(csv_path, (mtime + 1, mtime + 1))
 
@@ -62,7 +62,7 @@ def test_get_inventory_stats_force(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     _write_csv(
         csv_path,
-        "name;number;era;set;warehouse_code;price;image\n" "A;1;E1;S1;K1;10;img\n",
+        "name;number;set;warehouse_code;price;image\n" "A;1;S1;K1;10;img\n",
     )
 
     csv_utils.get_inventory_stats(str(csv_path))

--- a/tests/test_magazyn_badge_display.py
+++ b/tests/test_magazyn_badge_display.py
@@ -19,10 +19,10 @@ from ctk_mocks import (
 def test_badge_display_for_duplicates_only(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;variant\n"
-        "A;1;E;S;K1R1P1;1;foo1.png;common\n"
-        "A;1;E;S;K1R1P2;1;foo2.png;common\n"
-        "B;2;E;S;K1R1P3;1;foo3.png;common\n",
+        "name;number;set;warehouse_code;price;image;variant\n"
+        "A;1;S;K1R1P1;1;foo1.png;common\n"
+        "A;1;S;K1R1P2;1;foo2.png;common\n"
+        "B;2;S;K1R1P3;1;foo3.png;common\n",
         encoding="utf-8",
     )
 

--- a/tests/test_magazyn_duplicates.py
+++ b/tests/test_magazyn_duplicates.py
@@ -18,9 +18,9 @@ from ctk_mocks import (  # noqa: E402
 def test_group_duplicates(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;variant\n"
-        "A;1;E;S;K1R1P1;1;foo1.png;common\n"
-        "A;1;E;S;K1R1P2;1;foo2.png;common\n",
+        "name;number;set;warehouse_code;price;image;variant\n"
+        "A;1;S;K1R1P1;1;foo1.png;common\n"
+        "A;1;S;K1R1P2;1;foo2.png;common\n",
         encoding="utf-8",
     )
 

--- a/tests/test_magazyn_grid_layout.py
+++ b/tests/test_magazyn_grid_layout.py
@@ -98,9 +98,9 @@ def _load_app(csv_path, stats, frame_cls=DummyCTkFrame):
 
 def test_magazyn_displays_all_cards(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
-    header = "name;number;era;set;warehouse_code;price;image;variant\n"
+    header = "name;number;set;warehouse_code;price;image;variant\n"
     rows = [
-        f"Card{i:02d};{i};E;S;K{i};1;img{i}.png;common\n" for i in range(25)
+        f"Card{i:02d};{i};S;K{i};1;img{i}.png;common\n" for i in range(25)
     ]
     csv_path.write_text(header + "".join(rows), encoding="utf-8")
 
@@ -119,10 +119,10 @@ def test_magazyn_adaptive_grid(tmp_path):
 
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;variant\n"
-        "A;1;E;S;K1;1;foo1.png;common\n"
-        "B;2;E;S;K2;1;foo2.png;common\n"
-        "C;3;E;S;K3;1;foo3.png;common\n",
+        "name;number;set;warehouse_code;price;image;variant\n"
+        "A;1;S;K1;1;foo1.png;common\n"
+        "B;2;S;K2;1;foo2.png;common\n"
+        "C;3;S;K3;1;foo3.png;common\n",
         encoding="utf-8",
     )
 

--- a/tests/test_magazyn_search_filters.py
+++ b/tests/test_magazyn_search_filters.py
@@ -59,9 +59,9 @@ def _load_app(csv_path, stats):
 def test_search_by_variant(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;variant\n"
-        "A;1;E1;S;K1;10;foo.png;holo\n"
-        "B;2;E2;S;K2;5;foo.png;reverse\n",
+        "name;number;set;warehouse_code;price;image;variant\n"
+        "A;1;S;K1;10;foo.png;holo\n"
+        "B;2;S;K2;5;foo.png;reverse\n",
         encoding="utf-8",
     )
     app = _load_app(csv_path, (2, 15.0, 0, 0))
@@ -74,9 +74,9 @@ def test_search_by_variant(tmp_path):
 def test_search_by_sold_status(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;variant;sold\n"
-        "A;1;E1;S;K1;1;foo.png;common;\n"
-        "B;2;E2;S;K2;1;foo.png;common;1\n",
+        "name;number;set;warehouse_code;price;image;variant;sold\n"
+        "A;1;S;K1;1;foo.png;common;\n"
+        "B;2;S;K2;1;foo.png;common;1\n",
         encoding="utf-8",
     )
     app = _load_app(csv_path, (1, 1.0, 1, 1.0))
@@ -156,8 +156,8 @@ def _load_app_with_delay(csv_path, stats):
 def test_search_clear_keeps_thumbnails(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image\n"
-        "Card;1;E1;S;K1;1;https://example.com/image.png\n",
+        "name;number;set;warehouse_code;price;image\n"
+        "Card;1;S;K1;1;https://example.com/image.png\n",
         encoding="utf-8",
     )
     app, photo, stack = _load_app_with_delay(csv_path, (1, 1.0, 0, 0))

--- a/tests/test_magazyn_sold_display.py
+++ b/tests/test_magazyn_sold_display.py
@@ -35,9 +35,9 @@ def _extract_label(widget):
 def test_sold_cards_styled(tmp_path):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;sold\n"
-        "A;1;E1;S1;K1R1P1;1;foo.png;\n"
-        "B;2;E2;S2;K1R1P2;1;foo.png;1\n",
+        "name;number;set;warehouse_code;price;image;sold\n"
+        "A;1;S1;K1R1P1;1;foo.png;\n"
+        "B;2;S2;K1R1P2;1;foo.png;1\n",
         encoding="utf-8",
     )
 

--- a/tests/test_mark_as_sold_multiple_codes.py
+++ b/tests/test_mark_as_sold_multiple_codes.py
@@ -7,9 +7,9 @@ from unittest.mock import MagicMock
 def test_mark_as_sold_updates_group(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;sold\n"
-        "A;1;E;S;K1;1;;\n"
-        "A;1;E;S;K2;1;;\n",
+        "name;number;set;warehouse_code;price;image;sold\n"
+        "A;1;S;K1;1;;\n"
+        "A;1;S;K2;1;;\n",
         encoding="utf-8",
     )
 

--- a/tests/test_show_card_details_sprzedano_button.py
+++ b/tests/test_show_card_details_sprzedano_button.py
@@ -11,7 +11,7 @@ from PIL import Image
 def test_show_card_details_sprzedano_button(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;sold\n" "A;1;E1;S1;K1R1P1;10;;\n",
+        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;10;;\n",
         encoding="utf-8",
     )
 

--- a/tests/test_toggle_sold.py
+++ b/tests/test_toggle_sold.py
@@ -26,7 +26,7 @@ import kartoteka.ui as ui
 def test_toggle_sold_updates_csv(tmp_path, monkeypatch):
     csv_path = tmp_path / "magazyn.csv"
     csv_path.write_text(
-        "name;number;era;set;warehouse_code;price;image;sold\n" "A;1;E1;S1;K1R1P1;10;;\n",
+        "name;number;set;warehouse_code;price;image;sold\n" "A;1;S1;K1R1P1;10;;\n",
         encoding="utf-8",
     )
     monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))


### PR DESCRIPTION
## Summary
- drop `era` from warehouse CSV structure and utilities
- handle optional era field during export
- update sample data and tests to the new format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ec52eab0832f80428a9d135e4e9e