### PR TITLE
Adjust card thumbnail size and maximum threshold

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -343,9 +343,9 @@ SOLD_COLOR = os.getenv("SOLD_COLOR", "#888888")
 
 # Layout constants to simplify future adjustments
 BOX_THUMB_SIZE = 128  # square thumbnail size for warehouse boxes in pixels
-CARD_THUMB_SIZE = 128  # larger card thumbnails in the warehouse list
+CARD_THUMB_SIZE = 96  # larger card thumbnails in the warehouse list
 # Maximum allowed size for card thumbnails; used to cap dynamic calculations
-MAX_CARD_THUMB_SIZE = 256
+MAX_CARD_THUMB_SIZE = 192
 GRID_COLUMNS = 4  # number of columns per storage box
 WAREHOUSE_GRID_COLUMNS = 5  # number of columns in the warehouse grid
 BOX_COLUMN_CAPACITY = 1000  # slots per column in a regular box


### PR DESCRIPTION
## Summary
- reduce CARD_THUMB_SIZE from 128 to 96
- lower MAX_CARD_THUMB_SIZE to 192 and rely on them in `_relayout_mag_cards`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ef16d7c8832fb74cad00ef892cc9