### PR TITLE
Use red badge with white text for duplicates

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3083,8 +3083,8 @@ class CardEditorApp:
                         badge = ctk.CTkLabel(
                             frame,
                             text=str(count),
-                            fg_color="white",
-                            text_color="black",
+                            fg_color="#FF0000",
+                            text_color="white",
                             width=20,
                             height=20,
                             corner_radius=10,

--- a/tests/test_magazyn_badge_display.py
+++ b/tests/test_magazyn_badge_display.py
@@ -80,8 +80,8 @@ def test_badge_display_for_duplicates_only(tmp_path):
     assert len(badges) == 1
     badge = badges[0]
     assert badge.text == "2"
-    assert badge.fg_color == "white"
-    assert badge.text_color == "black"
+    assert badge.fg_color == "#FF0000"
+    assert badge.text_color == "white"
     assert badge.kwargs.get("height") == 20
     assert badge.kwargs.get("corner_radius") == 10
     assert badge.place_kwargs.get("relx") == 1.0


### PR DESCRIPTION
## Summary
- Render duplicate count badge with red background and white text in magazyn view
- Update badge display test to expect new colors

## Testing
- `pytest tests/test_magazyn_badge_display.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f161bd04832f92d2c8363a3a1d13