### PR TITLE
Fix magazyn card grid resizing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2949,8 +2949,15 @@ class CardEditorApp:
                     if not self.mag_list_frame or not exists_fn():
                         return
                     global CARD_THUMB_SIZE
-                    width_fn = getattr(self.mag_list_frame, "winfo_width", lambda: 0)
-                    width = width_fn()
+                    width = 0
+                    canvas = getattr(self.mag_list_frame, "_parent_canvas", None)
+                    if canvas is not None:
+                        width_fn = getattr(canvas, "winfo_width", None)
+                        if callable(width_fn):
+                            width = width_fn()
+                    if width <= 1:
+                        width_fn = getattr(self.magazyn_frame, "winfo_width", lambda: 0)
+                        width = width_fn()
                     if width <= 1:
                         return
                     padding = 10  # total horizontal padding (padx=5 on each side)
@@ -2990,6 +2997,10 @@ class CardEditorApp:
                                         lbl.image = photo
 
                     cols = max(1, width // (CARD_THUMB_SIZE + 10))
+                    col_conf = getattr(self.mag_list_frame, "grid_columnconfigure", None)
+                    if callable(col_conf):
+                        for i in range(cols):
+                            col_conf(i, weight=1)
                     for i, frame in enumerate(self.mag_card_frames):
                         r = i // cols
                         c = i % cols

--- a/tests/ctk_mocks.py
+++ b/tests/ctk_mocks.py
@@ -16,6 +16,12 @@ class _Widget:
     def winfo_exists(self):
         return True
 
+    def grid_columnconfigure(self, index, weight=0):
+        if not hasattr(self, "_grid_columns"):
+            self._grid_columns = {}
+        self._grid_columns[index] = {"weight": weight}
+        return self
+
 
 class DummyCTkFrame(_Widget):
     def __init__(self, master=None, fg_color=None, **kwargs):

--- a/tests/test_magazyn_grid_layout.py
+++ b/tests/test_magazyn_grid_layout.py
@@ -129,15 +129,78 @@ def test_magazyn_adaptive_grid(tmp_path):
     app, _ = _load_app(csv_path, (3, 3.0, 0, 0), frame_cls=RecordingFrame)
 
     frames = app.mag_card_frames
-    app.mag_list_frame.winfo_width = lambda: 600
+
+    class DummyParentCanvas(SimpleNamespace):
+        def winfo_width(self):
+            return self.width
+
+        def bbox(self, *a, **k):
+            return (0, 0, 0, 0)
+
+        def configure(self, **k):
+            self.config = k
+
+        def after_idle(self, func):
+            func()
+
+    canvas = DummyParentCanvas(width=600)
+    app.mag_list_frame._parent_canvas = canvas
+    app.magazyn_frame.winfo_width = lambda: 600
     app._relayout_mag_cards()
     assert frames[0].grid_kwargs["row"] == 0
     assert frames[0].grid_kwargs["column"] == 0
     assert frames[1].grid_kwargs["row"] == 0
     assert frames[1].grid_kwargs["column"] == 1
 
-    app.mag_list_frame.winfo_width = lambda: 200
+    canvas.width = 200
+    app.magazyn_frame.winfo_width = lambda: 200
     app._relayout_mag_cards()
     assert frames[1].grid_kwargs["row"] == 1
     assert frames[1].grid_kwargs["column"] == 0
 
+
+def test_magazyn_grid_expands_with_canvas_width(tmp_path):
+    class RecordingFrame(DummyCTkFrame):
+        def grid(self, **kwargs):
+            self.grid_kwargs = kwargs
+            return self
+
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;variant\n"
+        "A;1;S;K1;1;foo1.png;common\n"
+        "B;2;S;K2;1;foo2.png;common\n"
+        "C;3;S;K3;1;foo3.png;common\n"
+        "D;4;S;K4;1;foo4.png;common\n",
+        encoding="utf-8",
+    )
+
+    app, _ = _load_app(csv_path, (4, 4.0, 0, 0), frame_cls=RecordingFrame)
+
+    class DummyParentCanvas(SimpleNamespace):
+        def winfo_width(self):
+            return self.width
+
+        def bbox(self, *a, **k):
+            return (0, 0, 0, 0)
+
+        def configure(self, **k):
+            self.config = k
+
+        def after_idle(self, func):
+            func()
+
+    canvas = DummyParentCanvas(width=200)
+    app.mag_list_frame._parent_canvas = canvas
+    app.magazyn_frame.winfo_width = lambda: 200
+    app._relayout_mag_cards()
+    narrow_cols = {f.grid_kwargs["column"] for f in app.mag_card_frames}
+
+    canvas.width = 1000
+    app.magazyn_frame.winfo_width = lambda: 1000
+    app._relayout_mag_cards()
+    wide_cols = {f.grid_kwargs["column"] for f in app.mag_card_frames}
+
+    assert len(wide_cols) > len(narrow_cols)
+    for i in range(len(wide_cols)):
+        assert app.mag_list_frame._grid_columns[i]["weight"] == 1


### PR DESCRIPTION
## Summary
- compute magazyn grid width from parent canvas with fallback to frame width
- configure grid columns to expand evenly and adapt on window resize
- add tests verifying grid layout adjusts with canvas width

## Testing
- `pytest tests/test_magazyn_grid_layout.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f356cbf0832fb961c5ad5e708d7e