### PR TITLE
Normalize magazyn search tokens

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -371,6 +371,7 @@ def normalize(text: str, keep_spaces: bool = False) -> str:
     if not text:
         return ""
     text = unicodedata.normalize("NFKD", text)
+    text = "".join(c for c in text if not unicodedata.combining(c))
     text = text.lower()
     for suffix in [
         " shiny",
@@ -3033,9 +3034,12 @@ class CardEditorApp:
             self._relayout_mag_cards = _relayout_mag_cards
 
             def _update_mag_list(*_):
-                query = self.mag_search_var.get().lower()
+                query_raw = self.mag_search_var.get().strip()
                 sort_key = self.mag_sort_var.get()
                 status_filter = self.mag_sold_filter_var.get()
+
+                normalized_query = normalize(query_raw, keep_spaces=True)
+                tokens = [tok for tok in normalized_query.split() if tok]
 
                 def _matches(row: dict) -> bool:
                     is_sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
@@ -3044,17 +3048,26 @@ class CardEditorApp:
                     if status_filter == "unsold" and is_sold:
                         return False
                     price_str = str(row.get("price", "")).replace(",", ".")
-                    variant = (row.get("variant") or "").lower()
-                    return (
-                        query in row.get("name", "").lower()
-                        or query in str(row.get("number", "")).lower()
-                        or query in row.get("set", "").lower()
-                        or query in row.get("warehouse_code", "").lower()
-                        or query in variant
-                        or query in price_str
-                        or (query == "sold" and is_sold)
-                        or (query == "unsold" and not is_sold)
-                    )
+                    fields = [
+                        normalize(row.get("name", "")),
+                        normalize(str(row.get("number", ""))),
+                        normalize(row.get("set", "")),
+                        normalize(row.get("warehouse_code", "")),
+                        normalize(row.get("variant") or ""),
+                        normalize(price_str),
+                    ]
+                    for token in tokens:
+                        if token == "sold":
+                            if not is_sold:
+                                return False
+                            continue
+                        if token == "unsold":
+                            if is_sold:
+                                return False
+                            continue
+                        if not any(token in field for field in fields):
+                            return False
+                    return True
 
                 indices = [i for i, r in enumerate(self.mag_card_rows) if _matches(r)]
                 if sort_key == "name":

--- a/tests/test_magazyn_search_filters.py
+++ b/tests/test_magazyn_search_filters.py
@@ -99,6 +99,36 @@ def test_search_by_sold_status(tmp_path):
     assert len(app.mag_sold_labels) == 0
 
 
+def test_search_with_accents(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image\n"
+        "Pokémon Café;1;S;K1;1;foo.png\n"
+        "Pokemon Base;1;S;K2;1;foo.png\n",
+        encoding="utf-8",
+    )
+    app = _load_app(csv_path, (2, 2.0, 0, 0))
+
+    app.mag_search_var.set("pokemon cafe")
+    assert len(app.mag_card_labels) == 1
+    assert app.mag_card_labels[0].text == "Pokémon Café"
+
+
+def test_search_multiple_terms_across_fields(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image\n"
+        "Pikachu;1;Base;K1;1;foo.png\n"
+        "Pikachu;1;Jungle;K2;1;foo.png\n",
+        encoding="utf-8",
+    )
+    app = _load_app(csv_path, (2, 2.0, 0, 0))
+
+    app.mag_search_var.set("pikachu base")
+    assert len(app.mag_card_labels) == 1
+    assert app.mag_card_labels[0].text == "Pikachu"
+
+
 def _load_app_with_delay(csv_path, stats):
     sys.modules["customtkinter"] = SimpleNamespace(
         CTkFrame=DummyCTkFrame,


### PR DESCRIPTION
## Summary
- Normalize query and fields in magazyn search
- Tokenize normalized query and require all tokens to match card fields
- Add tests for accent-insensitive and multi-term searches

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7f859f598832fb4cfaec476a45ea9