### PR TITLE
Normalize duplicate search

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -84,8 +84,14 @@ def find_duplicates(name: str, number: str, set_name: str, variant: str = "commo
         List of matching rows including warehouse codes.
     """
 
+    from .ui import normalize  # local import to avoid circular dependency
+
     matches = []
     number = _sanitize_number(str(number))
+    name_norm = normalize(name)
+    set_norm = normalize(set_name)
+    variant_norm = normalize(variant or "common") or "common"
+
     if not os.path.exists(WAREHOUSE_CSV):
         return matches
 
@@ -94,11 +100,14 @@ def find_duplicates(name: str, number: str, set_name: str, variant: str = "commo
             reader = csv.DictReader(f, delimiter=";")
             for row in reader:
                 row_number = _sanitize_number(str(row.get("number", "")))
+                row_name = normalize(row.get("name") or "")
+                row_set = normalize(row.get("set") or "")
+                row_variant = normalize(row.get("variant") or "common") or "common"
                 if (
-                    row.get("name") == name
+                    row_name == name_norm
                     and row_number == number
-                    and row.get("set") == set_name
-                    and (row.get("variant") or "common") == variant
+                    and row_set == set_norm
+                    and row_variant == variant_norm
                 ):
                     matches.append(row)
     except OSError:

--- a/tests/test_find_duplicates_normalized.py
+++ b/tests/test_find_duplicates_normalized.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.csv_utils as csv_utils
+
+
+def test_find_duplicates_normalized(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;variant\n"
+        "Pokémon;1;Éxample Set;K1;1;foo.png;HólO\n",
+        encoding="utf-8",
+    )
+
+    with patch.object(csv_utils, "WAREHOUSE_CSV", str(csv_path)):
+        matches = csv_utils.find_duplicates("POKEMON", "1", "example set", variant="holo")
+
+    assert {m["warehouse_code"] for m in matches} == {"K1"}


### PR DESCRIPTION
## Summary
- normalize duplicate search parameters and CSV values
- add test for case-insensitive, accent-insensitive duplicate detection

## Testing
- `pytest tests/test_find_duplicates_normalized.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8065b0234832f9aa4b174b9598f2f