### PR TITLE
Handle whitespace in number sanitizer

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -65,7 +65,7 @@ def _sanitize_number(value: str) -> str:
         Normalised number or ``"0"`` if the result is empty.
     """
 
-    return value.lstrip("0") or "0"
+    return value.strip().lstrip("0") or "0"
 
 
 def find_duplicates(name: str, number: str, set_name: str, variant: str = "common"):

--- a/tests/test_sanitize_number.py
+++ b/tests/test_sanitize_number.py
@@ -1,0 +1,27 @@
+import pytest
+
+from kartoteka.csv_utils import _sanitize_number
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("001", "1"),
+        ("0000", "0"),
+        ("", "0"),
+    ],
+)
+def test_sanitize_number_basic(value, expected):
+    assert _sanitize_number(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (" 001", "1"),
+        ("001 ", "1"),
+        (" 0000 ", "0"),
+    ],
+)
+def test_sanitize_number_with_spaces(value, expected):
+    assert _sanitize_number(value) == expected


### PR DESCRIPTION
## Summary
- strip whitespace before removing leading zeros in `_sanitize_number`
- test `_sanitize_number` with inputs containing surrounding spaces

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b80c09d6c8832fbaccf65d249c8dc1