### PR TITLE
Center magazine card grid without stretching

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3001,8 +3001,13 @@ class CardEditorApp:
                     cols = max(1, width // (CARD_THUMB_SIZE + MAG_CARD_GAP * 2))
                     col_conf = getattr(self.mag_list_frame, "grid_columnconfigure", None)
                     if callable(col_conf):
-                        for i in range(cols):
-                            col_conf(i, weight=1)
+                        prev_cols = getattr(self, "_mag_prev_cols", 0)
+                        total = max(prev_cols, cols) + 2
+                        for i in range(total):
+                            col_conf(i, weight=0)
+                        col_conf(0, weight=1)
+                        col_conf(cols + 1, weight=1)
+                        self._mag_prev_cols = cols
                     for i, frame in enumerate(self.mag_card_frames):
                         if frame is None:
                             continue
@@ -3019,10 +3024,10 @@ class CardEditorApp:
                         if callable(grid):
                             grid(
                                 row=r,
-                                column=c,
+                                column=c + 1,
                                 padx=MAG_CARD_GAP,
                                 pady=MAG_CARD_GAP,
-                                sticky="nsew",
+                                sticky="n",
                             )
 
                     canvas = getattr(self.mag_list_frame, "_parent_canvas", None)

--- a/tests/test_magazyn_grid_layout.py
+++ b/tests/test_magazyn_grid_layout.py
@@ -148,15 +148,18 @@ def test_magazyn_adaptive_grid(tmp_path):
     app.magazyn_frame.winfo_width = lambda: 600
     app._relayout_mag_cards()
     assert frames[0].grid_kwargs["row"] == 0
-    assert frames[0].grid_kwargs["column"] == 0
+    assert frames[0].grid_kwargs["column"] == 1
+    assert frames[0].grid_kwargs["sticky"] == "n"
     assert frames[1].grid_kwargs["row"] == 0
-    assert frames[1].grid_kwargs["column"] == 1
+    assert frames[1].grid_kwargs["column"] == 2
+    assert frames[1].grid_kwargs["sticky"] == "n"
 
     canvas.width = 200
     app.magazyn_frame.winfo_width = lambda: 200
     app._relayout_mag_cards()
     assert frames[1].grid_kwargs["row"] == 1
-    assert frames[1].grid_kwargs["column"] == 0
+    assert frames[1].grid_kwargs["column"] == 1
+    assert frames[1].grid_kwargs["sticky"] == "n"
 
 
 def test_magazyn_grid_expands_with_canvas_width(tmp_path):
@@ -202,5 +205,9 @@ def test_magazyn_grid_expands_with_canvas_width(tmp_path):
     wide_cols = {f.grid_kwargs["column"] for f in app.mag_card_frames}
 
     assert len(wide_cols) > len(narrow_cols)
-    for i in range(len(wide_cols)):
-        assert app.mag_list_frame._grid_columns[i]["weight"] == 1
+    grid_cols = app.mag_list_frame._grid_columns
+    trailing = max(grid_cols)
+    assert grid_cols[0]["weight"] == 1
+    assert grid_cols[trailing]["weight"] == 1
+    for i in range(1, trailing):
+        assert grid_cols[i]["weight"] == 0


### PR DESCRIPTION
## Summary
- Avoid horizontal stretching of magazine card thumbnails by using `sticky="n"`
- Center card grid via leading/trailing weighted columns in `_relayout_mag_cards`
- Update magazine grid layout tests for new centering behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80e200b68832f9813a6154946435c