### PR TITLE
Refactor magazyn grid layout

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2962,9 +2962,12 @@ class CardEditorApp:
                         width = width_fn()
                     if width <= 1:
                         return
-                    padding = MAG_CARD_GAP * 2  # total horizontal padding
                     max_thumb = MAX_CARD_THUMB_SIZE
-                    thumb = max(32, min(width - padding, max_thumb))
+                    cols = max(1, width // (max_thumb + MAG_CARD_GAP * 2))
+                    thumb = max(
+                        32,
+                        min((width - MAG_CARD_GAP * 2 * cols) // cols, max_thumb),
+                    )
                     if thumb != self._mag_prev_thumb:
                         self._mag_prev_thumb = thumb
                         CARD_THUMB_SIZE = thumb
@@ -2998,15 +3001,13 @@ class CardEditorApp:
                                     else:
                                         lbl.image = photo
 
-                    cols = max(1, width // (CARD_THUMB_SIZE + MAG_CARD_GAP * 2))
                     col_conf = getattr(self.mag_list_frame, "grid_columnconfigure", None)
                     if callable(col_conf):
                         prev_cols = getattr(self, "_mag_prev_cols", 0)
-                        total = max(prev_cols, cols) + 2
+                        total = max(prev_cols, cols)
                         for i in range(total):
-                            col_conf(i, weight=0)
-                        col_conf(0, weight=1)
-                        col_conf(cols + 1, weight=1)
+                            weight = 1 if i < cols else 0
+                            col_conf(i, weight=weight)
                         self._mag_prev_cols = cols
                     for i, frame in enumerate(self.mag_card_frames):
                         if frame is None:
@@ -3024,10 +3025,10 @@ class CardEditorApp:
                         if callable(grid):
                             grid(
                                 row=r,
-                                column=c + 1,
+                                column=c,
                                 padx=MAG_CARD_GAP,
                                 pady=MAG_CARD_GAP,
-                                sticky="n",
+                                sticky="nsew",
                             )
 
                     canvas = getattr(self.mag_list_frame, "_parent_canvas", None)

--- a/tests/test_magazyn_grid_layout.py
+++ b/tests/test_magazyn_grid_layout.py
@@ -148,18 +148,18 @@ def test_magazyn_adaptive_grid(tmp_path):
     app.magazyn_frame.winfo_width = lambda: 600
     app._relayout_mag_cards()
     assert frames[0].grid_kwargs["row"] == 0
-    assert frames[0].grid_kwargs["column"] == 1
-    assert frames[0].grid_kwargs["sticky"] == "n"
+    assert frames[0].grid_kwargs["column"] == 0
+    assert frames[0].grid_kwargs["sticky"] == "nsew"
     assert frames[1].grid_kwargs["row"] == 0
-    assert frames[1].grid_kwargs["column"] == 2
-    assert frames[1].grid_kwargs["sticky"] == "n"
+    assert frames[1].grid_kwargs["column"] == 1
+    assert frames[1].grid_kwargs["sticky"] == "nsew"
 
     canvas.width = 200
     app.magazyn_frame.winfo_width = lambda: 200
     app._relayout_mag_cards()
     assert frames[1].grid_kwargs["row"] == 1
-    assert frames[1].grid_kwargs["column"] == 1
-    assert frames[1].grid_kwargs["sticky"] == "n"
+    assert frames[1].grid_kwargs["column"] == 0
+    assert frames[1].grid_kwargs["sticky"] == "nsew"
 
 
 def test_magazyn_grid_expands_with_canvas_width(tmp_path):
@@ -178,7 +178,7 @@ def test_magazyn_grid_expands_with_canvas_width(tmp_path):
         encoding="utf-8",
     )
 
-    app, _ = _load_app(csv_path, (4, 4.0, 0, 0), frame_cls=RecordingFrame)
+    app, ui = _load_app(csv_path, (4, 4.0, 0, 0), frame_cls=RecordingFrame)
 
     class DummyParentCanvas(SimpleNamespace):
         def winfo_width(self):
@@ -206,8 +206,6 @@ def test_magazyn_grid_expands_with_canvas_width(tmp_path):
 
     assert len(wide_cols) > len(narrow_cols)
     grid_cols = app.mag_list_frame._grid_columns
-    trailing = max(grid_cols)
-    assert grid_cols[0]["weight"] == 1
-    assert grid_cols[trailing]["weight"] == 1
-    for i in range(1, trailing):
-        assert grid_cols[i]["weight"] == 0
+    assert all(info["weight"] == 1 for info in grid_cols.values())
+    expected_cols = 1000 // (ui.MAX_CARD_THUMB_SIZE + ui.MAG_CARD_GAP * 2)
+    assert len(grid_cols) == expected_cols


### PR DESCRIPTION
## Summary
- Remove padding columns and evenly distribute column weights for magazyn card grid
- Scale card thumbnails based on canvas width and ensure frames stretch
- Update adaptive grid tests for new responsive behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81111abf4832f9a114853d39758ee