### PR TITLE
Use image-based warehouse box preview with occupancy overlays

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -119,48 +119,34 @@ _THUMB_CACHE: dict[str, Image.Image] = {}
 def draw_box_usage(canvas: "tk.Canvas", box_num: int, occupancy: dict[int, int]) -> float:
     """Draw occupancy of a single storage box on ``canvas``.
 
-    The function draws a rectangle for each column, filling it with
-    :data:`OCCUPIED_COLOR` when the column contains any cards.  It returns
-    the percentage of occupied slots within the box so callers can update
-    labels or other UI elements accordingly.
+    Instead of drawing individual column rectangles, the function overlays a
+    single tinted rectangle on top of the box background image.  The height of
+    the overlay is proportional to the percentage of occupied slots in the
+    given ``box_num``.  The function returns this percentage so callers can
+    update accompanying labels.
     """
 
     box_w = BOX_THUMB_SIZE
     box_h = BOX_THUMB_SIZE
-    columns = storage.BOX_COLUMNS.get(box_num, 4)
-    counts = [occupancy.get(col, 0) for col in range(1, columns + 1)]
+
+    used = occupancy.get(box_num, 0)
     total_capacity = storage.BOX_CAPACITY.get(
-        box_num, columns * storage.BOX_COLUMN_CAPACITY
+        box_num,
+        storage.BOX_COLUMNS.get(box_num, 4) * storage.BOX_COLUMN_CAPACITY,
     )
-    filled = sum(counts)
-    occupied_percent = filled / total_capacity * 100 if total_capacity else 0
+    occupied_percent = used / total_capacity * 100 if total_capacity else 0
 
-    col_w = box_w / columns
+    fill_height = box_h * occupied_percent / 100
+    y1 = box_h - fill_height
 
-    if hasattr(canvas, "find_all"):
-        rects = list(canvas.find_all())
-    else:  # fallback for DummyCanvas used in tests
-        rects = list(getattr(canvas, "items", {}).keys())
-
-    if len(rects) < columns:
-        for col in range(len(rects), columns):
-            x1 = col * col_w
-            x2 = (col + 1) * col_w
-            rid = canvas.create_rectangle(
-                x1, 0, x2, box_h, outline="black", width=1
-            )
-            rects.append(rid)
-    elif len(rects) > columns:
-        for rid in rects[columns:]:
-            canvas.delete(rid)
-        rects = rects[:columns]
-
-    for col, rid in enumerate(rects):
-        x1 = col * col_w
-        x2 = (col + 1) * col_w
-        canvas.coords(rid, x1, 0, x2, box_h)
-        fill = OCCUPIED_COLOR if counts[col] > 0 else ""
-        canvas.itemconfigure(rid, fill=fill)
+    # ``overlay_id`` attribute is used to track the rectangle so subsequent
+    # calls simply adjust its coordinates instead of creating new items.
+    overlay_id = getattr(canvas, "overlay_id", None)
+    if overlay_id is None:
+        overlay_id = canvas.create_rectangle(0, y1, box_w, box_h, fill=OCCUPIED_COLOR, outline="")
+        canvas.overlay_id = overlay_id
+    else:
+        canvas.coords(overlay_id, 0, y1, box_w, box_h)
 
     return occupied_percent
 
@@ -2664,7 +2650,21 @@ class CardEditorApp:
 
         self.mag_box_order = list(range(1, BOX_COUNT + 1)) + [SPECIAL_BOX_NUMBER]
         self.home_percent_labels = {}
+        self.home_box_canvases = {}
         self.mag_labels = []
+
+        base_dir = Path(__file__).resolve().parents[1]
+        if not hasattr(self, "_box_photo"):
+            img = Image.open(base_dir / "box.png").resize(
+                (BOX_THUMB_SIZE, BOX_THUMB_SIZE), Image.LANCZOS
+            )
+            self._box_photo = ImageTk.PhotoImage(img)
+        if not hasattr(self, "_box100_photo"):
+            img = Image.open(base_dir / "box100.png").resize(
+                (BOX_THUMB_SIZE, BOX_THUMB_SIZE), Image.LANCZOS
+            )
+            self._box100_photo = ImageTk.PhotoImage(img)
+
         for i, box_num in enumerate(self.mag_box_order):
             frame = ctk.CTkFrame(container, fg_color=BG_COLOR)
             lbl = ctk.CTkLabel(
@@ -2674,8 +2674,18 @@ class CardEditorApp:
                 text_color=TEXT_COLOR,
                 font=("Segoe UI", 24, "bold"),
             )
-            lbl.pack(side="left")
+            lbl.pack()
             self.mag_labels.append(lbl)
+
+            canvas = tk.Canvas(
+                frame, width=BOX_THUMB_SIZE, height=BOX_THUMB_SIZE, highlightthickness=0
+            )
+            img = self._box100_photo if box_num == SPECIAL_BOX_NUMBER else self._box_photo
+            canvas.create_image(0, 0, anchor="nw", image=img)
+            canvas.image = img
+            canvas.pack()
+            self.home_box_canvases[box_num] = canvas
+
             pct_label = ctk.CTkLabel(
                 frame,
                 text="0%",
@@ -2684,8 +2694,9 @@ class CardEditorApp:
                 text_color=_occupancy_color(0),
                 font=("Segoe UI", 24, "bold"),
             )
-            pct_label.pack(side="left", padx=(5, 0))
+            pct_label.pack(pady=(5, 0))
             self.home_percent_labels[box_num] = pct_label
+
             row, col_idx = divmod(i, WAREHOUSE_GRID_COLUMNS)
             if box_num == SPECIAL_BOX_NUMBER:
                 row = 0
@@ -3371,12 +3382,16 @@ class CardEditorApp:
         box_occ = storage.compute_box_occupancy()
 
         for box, lbl in self.home_percent_labels.items():
-            columns = storage.BOX_COLUMNS.get(box, 4)
             total_capacity = storage.BOX_CAPACITY.get(
-                box, columns * storage.BOX_COLUMN_CAPACITY
+                box,
+                storage.BOX_COLUMNS.get(box, 4) * storage.BOX_COLUMN_CAPACITY,
             )
             value = box_occ.get(box, 0) / total_capacity if total_capacity else 0
             lbl.configure(text=f"{value * 100:.0f}%", text_color=_occupancy_color(value))
+
+            canvas = self.home_box_canvases.get(box)
+            if canvas is not None:
+                draw_box_usage(canvas, box, box_occ)
 
     def refresh_magazyn(self):
         """Refresh storage view and update column usage bars."""

--- a/tests/test_welcome_screen_box_preview.py
+++ b/tests/test_welcome_screen_box_preview.py
@@ -18,6 +18,7 @@ from ctk_mocks import (
 def test_welcome_screen_shows_box_preview(monkeypatch):
     created_buttons = []
     created_labels = []
+    created_canvases = []
 
     class TrackingButton(DummyCTkButton):
         def __init__(self, master=None, **kwargs):
@@ -28,6 +29,11 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
         def __init__(self, master=None, **kwargs):
             super().__init__(master, **kwargs)
             created_labels.append(self)
+
+    class TrackingCanvas(DummyCanvas):
+        def __init__(self, master=None, **kwargs):
+            super().__init__(master, **kwargs)
+            created_canvases.append(self)
 
     sys.modules["customtkinter"] = SimpleNamespace(
         CTkFrame=DummyCTkFrame,
@@ -45,7 +51,7 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
     photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(
         ui.tk, "Frame", DummyCTkFrame
-    ), patch.object(ui.tk, "Canvas", DummyCanvas), patch.object(
+    ), patch.object(ui.tk, "Canvas", TrackingCanvas), patch.object(
         ui.messagebox, "showinfo", lambda *a, **k: None
     ):
         dummy_root = SimpleNamespace(
@@ -56,7 +62,6 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
             root=dummy_root,
             create_button=lambda master, **kwargs: TrackingButton(master, **kwargs),
             refresh_magazyn=lambda: None,
-            refresh_home_preview=lambda: None,
             open_config_dialog=lambda: None,
             show_location_frame=lambda: None,
             setup_pricing_ui=lambda: None,
@@ -64,6 +69,7 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
             show_magazyn_view=lambda: None,
             open_auctions_window=lambda: None,
         )
+        app.refresh_home_preview = lambda: ui.CardEditorApp.refresh_home_preview(app)
         ui.CardEditorApp.setup_welcome_screen(app)
 
     assert hasattr(app, "home_percent_labels")
@@ -71,6 +77,15 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
     first = app.home_percent_labels[app.mag_box_order[0]]
     assert first.font == ("Segoe UI", 24, "bold")
     assert first.text_color == ui._occupancy_color(0)
+
+    assert hasattr(app, "home_box_canvases")
+    assert len(app.home_box_canvases) == len(app.mag_box_order)
+    first_canvas = app.home_box_canvases[app.mag_box_order[0]]
+    assert isinstance(first_canvas, TrackingCanvas)
+    assert getattr(first_canvas, "image", None) is photo_mock
+    assert getattr(first_canvas, "overlay_id", None) is not None
+    overlay = first_canvas.items[first_canvas.overlay_id]
+    assert overlay["fill"] == ui.OCCUPIED_COLOR
 
     # Verify new layout
     assert app.start_frame._grid_columns[0]["weight"] == 1


### PR DESCRIPTION
## Summary
- Render home screen box previews as canvases with box images and occupancy overlays
- Overlay tinted rectangles to reflect box fill percentage and keep percentage labels
- Update tests to validate new image-based box previews

## Testing
- `pytest tests/test_welcome_screen_box_preview.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b81d3ce728832f88e38f0b08dfd71f