### PR TITLE
Refactor welcome screen layout

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1602,11 +1602,8 @@ class CardEditorApp:
             fg_color=AUCTION_BUTTON_COLOR,
         ).pack(padx=10, pady=5, fill="x")
 
-        preview_container = ctk.CTkFrame(main_frame, fg_color=BG_COLOR)
-        preview_container.pack(pady=10, fill="x")
-
-        box_frame = ctk.CTkFrame(preview_container, fg_color=BG_COLOR)
-        box_frame.pack(side="left")
+        box_frame = ctk.CTkFrame(main_frame, fg_color=BG_COLOR)
+        box_frame.pack(pady=10)
 
         CardEditorApp.build_home_box_preview(self, box_frame)
         # Refresh the initial box preview if possible.  The welcome screen does
@@ -1624,8 +1621,8 @@ class CardEditorApp:
             except Exception:  # pragma: no cover - defensive logging
                 logger.exception("Failed to refresh magazyn preview")
 
-        info_frame = ctk.CTkFrame(preview_container, fg_color=BG_COLOR)
-        info_frame.pack(side="right", anchor="n", padx=(10, 40))
+        info_frame = ctk.CTkFrame(main_frame, fg_color=BG_COLOR)
+        info_frame.pack(anchor="n", pady=(0, 40))
 
         self.inventory_count_label = ctk.CTkLabel(
             info_frame,

--- a/tests/test_welcome_screen_box_preview.py
+++ b/tests/test_welcome_screen_box_preview.py
@@ -87,6 +87,13 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
     overlay = first_canvas.items[first_canvas.overlay_id]
     assert overlay["fill"] == ui.OCCUPIED_COLOR
 
+    box_frame = first_canvas.master.master
+    info_frame = app.inventory_count_label.master
+    assert info_frame is app.inventory_value_label.master
+    assert info_frame.master is not box_frame
+    assert box_frame.pack_params.get("side") in (None, "top")
+    assert info_frame.pack_params.get("side") in (None, "top")
+
     # Verify new layout
     assert app.start_frame._grid_columns[0]["weight"] == 1
     assert app.start_frame._grid_columns[1]["weight"] == 2


### PR DESCRIPTION
## Summary
- Place box preview frame directly within the main area and add a separate info frame below it for inventory stats
- Adapt welcome screen test to check the new vertical layout of preview and info frames

## Testing
- `pytest tests/test_welcome_screen_box_preview.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b81ef2db94832fbcd433a77e8b4684