### PR TITLE
Add daily warehouse tracking and chart

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import csv
+from datetime import date, timedelta
 from typing import Optional, Tuple
 from tkinter import filedialog, messagebox, TclError
 
@@ -38,7 +39,8 @@ STORE_FIELDNAMES = [
     "images 1",
 ]
 
-# include a ``sold`` flag so individual cards can be marked as sold
+# include a ``sold`` flag so individual cards can be marked as sold and track
+# when cards were added to the warehouse
 WAREHOUSE_FIELDNAMES = [
     "name",
     "number",
@@ -48,6 +50,7 @@ WAREHOUSE_FIELDNAMES = [
     "image",
     "variant",
     "sold",
+    "added_at",
 ]
 
 
@@ -194,6 +197,29 @@ def get_inventory_stats(path: str = WAREHOUSE_CSV, force: bool = False):
     return _inventory_stats_cache
 
 
+def get_daily_additions(days: int = 7) -> dict[str, int]:
+    """Return counts of cards added per day for the last ``days`` days."""
+    end = date.today()
+    start = end - timedelta(days=days - 1)
+    counts = {
+        (start + timedelta(days=i)).isoformat(): 0 for i in range(days)
+    }
+    if not os.path.exists(WAREHOUSE_CSV):
+        return counts
+
+    with open(WAREHOUSE_CSV, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        for row in reader:
+            added_raw = (row.get("added_at") or "").split("T", 1)[0]
+            try:
+                added_date = date.fromisoformat(added_raw)
+            except ValueError:
+                continue
+            if start <= added_date <= end:
+                counts[added_date.isoformat()] += 1
+    return counts
+
+
 def format_store_row(row):
     """Return a row formatted for the store CSV."""
     formatted_name = row["nazwa"]
@@ -238,6 +264,7 @@ def format_warehouse_row(row):
         "image": row.get("image1", row.get("images", "")),
         "variant": variant,
         "sold": row.get("sold", ""),
+        "added_at": row.get("added_at") or date.today().isoformat(),
     }
 
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -37,6 +37,12 @@ import io
 import webbrowser
 import logging
 from gettext import gettext as _
+try:  # pragma: no cover - optional dependency
+    from matplotlib.figure import Figure
+    from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+except Exception:  # pragma: no cover - optional dependency
+    Figure = None  # type: ignore[assignment]
+    FigureCanvasTkAgg = None  # type: ignore[assignment]
 try:
     from hash_db import HashDB
 except ImportError as exc:  # pragma: no cover - optional dependency
@@ -1641,6 +1647,21 @@ class CardEditorApp:
             justify="center",
         )
         self.inventory_value_label.pack(anchor="center", pady=(0, 5))
+
+        daily = csv_utils.get_daily_additions()
+        if Figure and FigureCanvasTkAgg and daily:
+            fig = Figure(figsize=(5, 2))
+            ax = fig.add_subplot(111)
+            dates = list(daily.keys())
+            counts = list(daily.values())
+            ax.bar(dates, counts, color="#4a90e2")
+            ax.set_ylabel("Dodane")
+            ax.set_title("Ostatnie 7 dni")
+            ax.tick_params(axis="x", labelrotation=45, labelsize=8)
+            canvas = FigureCanvasTkAgg(fig, master=info_frame)
+            canvas.draw()
+            canvas.get_tk_widget().pack(anchor="center", pady=(10, 5))
+            self.daily_additions_chart = canvas
 
         config_btn = self.create_button(
             menu_frame,

--- a/magazyn.csv
+++ b/magazyn.csv
@@ -1,1 +1,1 @@
-name;number;set;warehouse_code;price;image;variant;sold
+name;number;set;warehouse_code;price;image;variant;sold;added_at

--- a/tests/test_append_warehouse_csv.py
+++ b/tests/test_append_warehouse_csv.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+from datetime import date
 
 sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -33,6 +34,7 @@ def test_append_warehouse_csv_updates_stats(tmp_path):
         rows = list(reader)
         assert reader.fieldnames == csv_utils.WAREHOUSE_FIELDNAMES
         assert rows[0]["warehouse_code"] == "K1"
+        assert rows[0]["added_at"]
 
 
 def test_append_warehouse_csv_writes_variant(tmp_path):
@@ -57,3 +59,33 @@ def test_append_warehouse_csv_writes_variant(tmp_path):
         row = next(reader)
         assert reader.fieldnames == csv_utils.WAREHOUSE_FIELDNAMES
         assert row["variant"] == "holo"
+
+
+def test_append_warehouse_csv_sets_added_at(tmp_path, monkeypatch):
+    path = tmp_path / "magazyn.csv"
+
+    class DummyDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2024, 1, 2)
+
+    monkeypatch.setattr(csv_utils, "date", DummyDate)
+
+    app = SimpleNamespace(
+        output_data=[
+            {
+                "name": "A",
+                "number": "1",
+                "set": "S",
+                "warehouse_code": "K1",
+                "price": "2",
+                "image": "",
+            }
+        ],
+        update_inventory_stats=MagicMock(),
+    )
+    csv_utils.append_warehouse_csv(app, path=str(path))
+    with open(path, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        row = next(reader)
+        assert row["added_at"] == "2024-01-02"

--- a/tests/test_download_warehouse_csv.py
+++ b/tests/test_download_warehouse_csv.py
@@ -19,6 +19,7 @@ def test_local_warehouse_csv_exists():
         "image",
         "variant",
         "sold",
+        "added_at",
     ]
 
 

--- a/tests/test_get_daily_additions.py
+++ b/tests/test_get_daily_additions.py
@@ -1,0 +1,37 @@
+import csv
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from datetime import date
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from kartoteka import csv_utils
+
+
+def test_get_daily_additions_returns_last_days(tmp_path, monkeypatch):
+    path = tmp_path / "magazyn.csv"
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(path))
+
+    class DummyDate(date):
+        @classmethod
+        def today(cls):
+            return cls(2024, 1, 5)
+
+    monkeypatch.setattr(csv_utils, "date", DummyDate)
+
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=csv_utils.WAREHOUSE_FIELDNAMES, delimiter=";")
+        writer.writeheader()
+        blank = {fn: "" for fn in csv_utils.WAREHOUSE_FIELDNAMES}
+        row = blank.copy(); row["added_at"] = "2024-01-04"; writer.writerow(row)
+        row = blank.copy(); row["added_at"] = "2024-01-05"; writer.writerow(row)
+        row = blank.copy(); row["added_at"] = "2024-01-01"; writer.writerow(row)
+
+    result = csv_utils.get_daily_additions(days=3)
+    assert list(result.keys()) == ["2024-01-03", "2024-01-04", "2024-01-05"]
+    assert result["2024-01-04"] == 1
+    assert result["2024-01-05"] == 1
+    assert result["2024-01-03"] == 0


### PR DESCRIPTION
## Summary
- track when cards are added by appending an `added_at` timestamp to warehouse CSV rows
- expose `get_daily_additions` helper and visualize last week's activity on the welcome screen
- test timestamp handling and daily addition counts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82059d804832f97f6dbab08ea5cf8