### PR TITLE
Add statistics window and data aggregation helpers

### DIFF
--- a/kartoteka/stats_utils.py
+++ b/kartoteka/stats_utils.py
@@ -1,0 +1,144 @@
+import csv
+import os
+import re
+from collections import defaultdict
+from datetime import date, timedelta
+from typing import Dict, List, Tuple
+
+from . import csv_utils
+
+
+def _parse_date(value: str) -> date | None:
+    """Return ``date`` extracted from ISO string ``value``.
+
+    Empty or malformed values return ``None`` instead of raising an error.
+    """
+    if not value:
+        return None
+    value = value.split("T", 1)[0]
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def _load_rows(path: str) -> List[dict]:
+    """Load rows from ``path`` as dictionaries."""
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        return list(reader)
+
+
+def get_statistics(start: date, end: date, path: str | None = None) -> Dict:
+    """Return aggregated warehouse statistics between ``start`` and ``end``.
+
+    Parameters
+    ----------
+    start, end:
+        Inclusive date range to analyse.
+    path:
+        Optional path to the warehouse CSV.  Defaults to
+        :data:`csv_utils.WAREHOUSE_CSV`.
+    """
+
+    if path is None:
+        path = csv_utils.WAREHOUSE_CSV
+
+    rows = _load_rows(path)
+
+    filtered: List[dict] = []
+    for row in rows:
+        added = _parse_date(str(row.get("added_at") or ""))
+        if added is None:
+            continue
+        if start <= added <= end:
+            filtered.append(row)
+
+    cumulative_count = 0
+    cumulative_value = 0.0
+    sold_count = 0
+    unsold_count = 0
+
+    daily: Dict[str, Dict[str, int]] = {}
+    sets_by_count: Dict[str, int] = defaultdict(int)
+    sets_by_value: Dict[str, float] = defaultdict(float)
+    boxes_by_count: Dict[int, int] = defaultdict(int)
+    boxes_by_value: Dict[int, float] = defaultdict(float)
+
+    for row in filtered:
+        price_raw = str(row.get("price") or "0").replace(",", ".")
+        try:
+            price = float(price_raw)
+        except ValueError:
+            price = 0.0
+        cumulative_count += 1
+        cumulative_value += price
+
+        sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
+        if sold:
+            sold_count += 1
+        else:
+            unsold_count += 1
+
+        added = _parse_date(str(row.get("added_at") or ""))
+        if added is not None:
+            key = added.isoformat()
+            stats = daily.setdefault(key, {"added": 0, "sold": 0})
+            stats["added"] += 1
+            if sold:
+                stats["sold"] += 1
+
+        set_name = row.get("set") or ""
+        sets_by_count[set_name] += 1
+        sets_by_value[set_name] += price
+
+        codes = str(row.get("warehouse_code") or "").split(";")
+        box = None
+        for code in codes:
+            m = re.match(r"K(\d+)", code.strip())
+            if m:
+                box = int(m.group(1))
+                break
+        if box is not None:
+            boxes_by_count[box] += 1
+            boxes_by_value[box] += price
+
+    # ensure every day in the range is present
+    cur = start
+    while cur <= end:
+        daily.setdefault(cur.isoformat(), {"added": 0, "sold": 0})
+        cur += timedelta(days=1)
+
+    def _sort_items(d: Dict) -> List[Tuple]:
+        return sorted(d.items(), key=lambda x: (-x[1], x[0]))[:5]
+
+    avg_price = cumulative_value / cumulative_count if cumulative_count else 0.0
+    sold_ratio = sold_count / cumulative_count if cumulative_count else 0.0
+    unsold_ratio = unsold_count / cumulative_count if cumulative_count else 0.0
+
+    return {
+        "cumulative": {"count": cumulative_count, "total_value": cumulative_value},
+        "daily": dict(sorted(daily.items())),
+        "top_sets_by_count": _sort_items(sets_by_count),
+        "top_sets_by_value": _sort_items(sets_by_value),
+        "top_boxes_by_count": _sort_items(boxes_by_count),
+        "top_boxes_by_value": _sort_items(boxes_by_value),
+        "average_price": avg_price,
+        "sold_ratio": sold_ratio,
+        "unsold_ratio": unsold_ratio,
+    }
+
+
+def export_statistics_csv(data: Dict, path: str) -> None:
+    """Write ``data`` returned from :func:`get_statistics` to ``path``."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f, delimiter=";")
+        writer.writerow(["metric", "value"])
+        cumulative = data.get("cumulative", {})
+        writer.writerow(["count", cumulative.get("count", 0)])
+        writer.writerow(["total_value", cumulative.get("total_value", 0.0)])
+        writer.writerow(["average_price", data.get("average_price", 0.0)])
+        writer.writerow(["sold_ratio", data.get("sold_ratio", 0.0)])
+        writer.writerow(["unsold_ratio", data.get("unsold_ratio", 0.0)])

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -30,7 +30,7 @@ from pathlib import Path
 
 from shoper_client import ShoperClient
 from webdav_client import WebDAVClient
-from . import csv_utils, storage
+from . import csv_utils, storage, stats_utils
 import threading
 from urllib.parse import urlencode, urlparse
 import io
@@ -1660,7 +1660,10 @@ class CardEditorApp:
             ax.tick_params(axis="x", labelrotation=45, labelsize=8)
             canvas = FigureCanvasTkAgg(fig, master=info_frame)
             canvas.draw()
-            canvas.get_tk_widget().pack(anchor="center", pady=(10, 5))
+            widget = canvas.get_tk_widget()
+            widget.pack(anchor="center", pady=(10, 5))
+            if hasattr(widget, "bind"):
+                widget.bind("<Button-1>", lambda _e: self.open_statistics_window())
             self.daily_additions_chart = canvas
 
         config_btn = self.create_button(
@@ -2020,6 +2023,64 @@ class CardEditorApp:
 
         refresh_tree()
         self._update_auction_status()
+
+    def open_statistics_window(self):
+        """Display extended inventory statistics in a new window."""
+        start_var = tk.StringVar(
+            value=(datetime.date.today() - datetime.timedelta(days=6)).isoformat()
+        )
+        end_var = tk.StringVar(value=datetime.date.today().isoformat())
+
+        win = ctk.CTkToplevel(self.root)
+        win.title("Statystyki")
+
+        filter_frame = ctk.CTkFrame(win)
+        filter_frame.pack(fill="x", pady=5)
+        ctk.CTkLabel(filter_frame, text="Od:").pack(side="left", padx=5)
+        ctk.CTkEntry(filter_frame, textvariable=start_var, width=100).pack(
+            side="left"
+        )
+        ctk.CTkLabel(filter_frame, text="Do:").pack(side="left", padx=5)
+        ctk.CTkEntry(filter_frame, textvariable=end_var, width=100).pack(side="left")
+
+        text = tk.Text(win, height=15, bg=self.root.cget("background"), fg="white")
+        text.pack(expand=True, fill="both", padx=5, pady=5)
+
+        def _update():
+            try:
+                start = datetime.date.fromisoformat(start_var.get())
+                end = datetime.date.fromisoformat(end_var.get())
+            except ValueError:
+                messagebox.showerror("Błąd", "Niepoprawny format daty (RRRR-MM-DD)")
+                return
+            data = stats_utils.get_statistics(start, end)
+            text.delete("1.0", tk.END)
+            text.insert(tk.END, json.dumps(data, indent=2, ensure_ascii=False))
+
+        def _export():
+            try:
+                start = datetime.date.fromisoformat(start_var.get())
+                end = datetime.date.fromisoformat(end_var.get())
+            except ValueError:
+                messagebox.showerror("Błąd", "Niepoprawny format daty (RRRR-MM-DD)")
+                return
+            data = stats_utils.get_statistics(start, end)
+            path = filedialog.asksaveasfilename(
+                defaultextension=".csv",
+                filetypes=[("CSV", "*.csv")],
+            )
+            if not path:
+                return
+            stats_utils.export_statistics_csv(data, path)
+            messagebox.showinfo("Zapisano", path)
+
+        ctk.CTkButton(filter_frame, text="Odśwież", command=_update).pack(
+            side="left", padx=5
+        )
+        ctk.CTkButton(filter_frame, text="Eksport", command=_export).pack(
+            side="left", padx=5
+        )
+        _update()
 
     def _build_auction_widgets(self, container):
         """Create auction editor widgets and return a refresh callback."""

--- a/tests/test_statistics_helpers.py
+++ b/tests/test_statistics_helpers.py
@@ -1,0 +1,31 @@
+from datetime import date
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from kartoteka import csv_utils, stats_utils  # noqa: E402
+
+
+def test_get_statistics_aggregates_correctly(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;variant;sold;added_at\n"
+        "A;1;Set1;K1R1P0001;10;;common;;2025-09-01\n"
+        "B;2;Set1;K1R1P0002;5;;common;1;2025-09-01\n"
+        "C;3;Set2;K2R1P0001;8;;common;;2025-09-02\n"
+        "D;4;Set3;K2R1P0002;7;;common;1;2025-09-02\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(csv_utils, "WAREHOUSE_CSV", str(csv_path))
+    stats = stats_utils.get_statistics(date(2025, 9, 1), date(2025, 9, 2))
+    assert stats["cumulative"]["count"] == 4
+    assert abs(stats["cumulative"]["total_value"] - 30) < 1e-6
+    assert stats["daily"]["2025-09-01"] == {"added": 2, "sold": 1}
+    assert stats["daily"]["2025-09-02"] == {"added": 2, "sold": 1}
+    assert stats["top_sets_by_count"][0] == ("Set1", 2)
+    assert stats["top_sets_by_value"][0][0] == "Set1"
+    assert stats["top_boxes_by_count"][0] == (1, 2)
+    assert abs(stats["average_price"] - 7.5) < 1e-6
+    assert abs(stats["sold_ratio"] - 0.5) < 1e-6
+    assert abs(stats["unsold_ratio"] - 0.5) < 1e-6


### PR DESCRIPTION
## Summary
- link the 7-day additions chart to a new statistics window
- implement `stats_utils.get_statistics` for extended metrics and CSV export
- test statistics aggregation across dates, sets and boxes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b821bc59f4832fa4bf4c119b7c515d