### PR TITLE
Use PNG transparency for box preview images

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2753,25 +2753,11 @@ class CardEditorApp:
             img = Image.open(base_dir / "box.png").resize(
                 (BOX_THUMB_SIZE, BOX_THUMB_SIZE), Image.LANCZOS
             ).convert("RGBA")
-            data = []
-            for px in img.getdata():
-                if px[:3] == (255, 255, 255):
-                    data.append((255, 255, 255, 0))
-                else:
-                    data.append(px)
-            img.putdata(data)
             self._box_photo = ImageTk.PhotoImage(img)
         if not hasattr(self, "_box100_photo"):
             img = Image.open(base_dir / "box100.png").resize(
                 (BOX_THUMB_SIZE, BOX_THUMB_SIZE), Image.LANCZOS
             ).convert("RGBA")
-            data = []
-            for px in img.getdata():
-                if px[:3] == (255, 255, 255):
-                    data.append((255, 255, 255, 0))
-                else:
-                    data.append(px)
-            img.putdata(data)
             self._box100_photo = ImageTk.PhotoImage(img)
 
         for i, box_num in enumerate(self.mag_box_order):


### PR DESCRIPTION
## Summary
- Remove manual white-to-transparent pixel replacement when loading `box.png` and `box100.png`
- Rely on the images' built-in alpha channels for box preview icons

## Testing
- `python - <<'PY' ...` (build_home_box_preview with real transparent PNGs)
- `pytest tests/test_welcome_screen_box_preview.py tests/test_box100.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8309fec30832faf878775f42c093b