### PR TITLE
Add stats button and enlarge daily additions chart

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -358,6 +358,7 @@ PRICE_BUTTON_COLOR = "#3498DB"  # blue
 SHOPER_BUTTON_COLOR = "#E67E22"  # orange
 MAGAZYN_BUTTON_COLOR = "#9B59B6"  # purple
 AUCTION_BUTTON_COLOR = "#E74C3C"  # red
+STATS_BUTTON_COLOR = "#1ABC9C"  # teal
 
 # color highlighting current price labels
 CURRENT_PRICE_COLOR = "#FFD700"
@@ -1649,6 +1650,14 @@ class CardEditorApp:
             width=200,
         ).pack(padx=10, pady=5, fill="x")
 
+        self.create_button(
+            menu_frame,
+            text="\U0001F4C8 Statystyki",
+            command=getattr(self, "open_statistics_window", lambda: None),
+            fg_color=STATS_BUTTON_COLOR,
+            width=200,
+        ).pack(padx=10, pady=5, fill="x")
+
         box_frame = ctk.CTkFrame(main_frame, fg_color=BG_COLOR)
         box_frame.pack(anchor="w", padx=10, pady=10)
 
@@ -1700,7 +1709,7 @@ class CardEditorApp:
 
         daily = dict(sorted(csv_utils.get_daily_additions().items()))
         if Figure and FigureCanvasTkAgg and daily:
-            fig = Figure(figsize=(5, 2), facecolor=BG_COLOR)
+            fig = Figure(figsize=(6, 3), facecolor=BG_COLOR)
             ax = fig.add_subplot(111)
             ax.set_facecolor(BG_COLOR)
             dates = list(daily.keys())
@@ -1727,7 +1736,7 @@ class CardEditorApp:
             canvas = FigureCanvasTkAgg(fig, master=info_frame)
             canvas.draw()
             widget = canvas.get_tk_widget()
-            widget.pack(anchor="center", pady=(10, 5))
+            widget.pack(anchor="w", pady=(20, 5))
             if hasattr(widget, "bind"):
                 widget.bind("<Button-1>", lambda _e: self.open_statistics_window())
             self.daily_additions_chart = canvas

--- a/tests/test_welcome_screen_box_preview.py
+++ b/tests/test_welcome_screen_box_preview.py
@@ -68,6 +68,7 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
             open_shoper_window=lambda: None,
             show_magazyn_view=lambda: None,
             open_auctions_window=lambda: None,
+            open_statistics_window=lambda: None,
         )
         app.refresh_home_preview = lambda: ui.CardEditorApp.refresh_home_preview(app)
         ui.CardEditorApp.setup_welcome_screen(app)
@@ -102,15 +103,16 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
     assert app.start_frame._grid_columns[1]["weight"] == 2
 
     texts = [b.kwargs["text"] for b in created_buttons]
-    assert len(texts) == 6
-    assert texts[:5] == [
+    assert len(texts) == 7
+    assert texts[:6] == [
         "\U0001f50d Skanuj",
         "\U0001f4b0 Wyceniaj",
         "\U0001f5c3\ufe0f Shoper",
         "\U0001f4e6 Magazyn",
         "\U0001f528 Licytacje",
+        "\U0001F4C8 Statystyki",
     ]
-    for b in created_buttons[:5]:
+    for b in created_buttons[:6]:
         assert b.pack_params.get("side") in (None, "top")
 
     assert created_buttons[-1].kwargs["text"] == "\u2699\ufe0f Konfiguracja"


### PR DESCRIPTION
## Summary
- add STATS_BUTTON_COLOR and "📈 Statystyki" start menu button
- enlarge daily additions chart and reposition with extra top padding
- update welcome screen test for new button

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b946c9155c832f9f28a527b874dd58