### PR TITLE
Generate product codes from card metadata

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -71,6 +71,19 @@ def _sanitize_number(value: str) -> str:
     return value.strip().lstrip("0") or "0"
 
 
+VARIANT_SUFFIXES = {"holo": "H", "reverse": "R"}
+
+
+def build_product_code(set_name: str, number: str, variant: str | None = None) -> str:
+    """Return a product code based on set abbreviation and card number."""
+    from .ui import get_set_abbr  # local import to avoid circular dependency
+
+    abbr = get_set_abbr(set_name)
+    num = _sanitize_number(str(number))
+    suffix = VARIANT_SUFFIXES.get((variant or "").strip().lower(), "")
+    return f"PKM-{abbr}-{num}{suffix}"
+
+
 def find_duplicates(name: str, number: str, set_name: str, variant: str = "common"):
     """Return rows from ``WAREHOUSE_CSV`` matching the given card details.
 
@@ -270,7 +283,6 @@ def format_warehouse_row(row):
 
 def load_csv_data(app):
     """Load a CSV file and merge duplicate rows."""
-    from . import storage
     file_path = filedialog.askopenfilename(filetypes=[("CSV files", "*.csv")])
     if not file_path:
         return
@@ -340,9 +352,13 @@ def load_csv_data(app):
             combined[key] = new_row
 
     for row in combined.values():
-        row["product_code"] = app.next_product_code
-        app.next_product_code += 1
-        storage.save_last_product_code(app.next_product_code - 1)
+        if not row.get("product_code"):
+            number = row.get("numer") or row.get("number") or ""
+            row["product_code"] = build_product_code(
+                row.get("set", ""),
+                number,
+                row.get("variant"),
+            )
 
     if qty_field is None:
         qty_field = "ilość"

--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -3,7 +3,6 @@ import re
 from datetime import datetime
 from . import csv_utils
 
-LAST_PRODUCT_CODE_FILE = "last_product_code.txt"
 LAST_SETS_CHECK_FILE = "last_sets_check.txt"
 
 # Total card capacity per storage box.  Standard boxes hold 4000 cards in
@@ -20,19 +19,6 @@ BOX_COLUMNS: dict[int, int] = {**{b: 4 for b in range(1, BOX_COUNT + 1)}, 100: 1
 # Default per-column capacity for standard boxes.  Used as a fallback when
 # handling boxes outside of :data:`BOX_CAPACITY`.
 BOX_COLUMN_CAPACITY = 1000
-
-
-def load_last_product_code() -> int:
-    try:
-        with open(LAST_PRODUCT_CODE_FILE, "r", encoding="utf-8") as f:
-            return int(f.read().strip())
-    except (FileNotFoundError, ValueError):
-        return 0
-
-
-def save_last_product_code(value: int) -> None:
-    with open(LAST_PRODUCT_CODE_FILE, "w", encoding="utf-8") as f:
-        f.write(str(int(value)))
 
 
 def load_last_sets_check() -> datetime | None:

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -451,6 +451,7 @@ def reload_sets():
     global tcg_sets_jp_by_era, tcg_sets_jp_map, tcg_sets_jp, tcg_sets_jp_code_map
     global tcg_sets_eng_abbr_map, tcg_sets_eng_abbr_name_map
     global tcg_sets_jp_abbr_map, tcg_sets_jp_abbr_name_map
+    global tcg_sets_eng_name_abbr_map, tcg_sets_jp_name_abbr_map
     global SET_TO_ERA
 
     tcg_sets_eng_code_map = globals().get("tcg_sets_eng_code_map", {})
@@ -459,6 +460,8 @@ def reload_sets():
     tcg_sets_eng_abbr_name_map = globals().get("tcg_sets_eng_abbr_name_map", {})
     tcg_sets_jp_abbr_map = globals().get("tcg_sets_jp_abbr_map", {})
     tcg_sets_jp_abbr_name_map = globals().get("tcg_sets_jp_abbr_name_map", {})
+    tcg_sets_eng_name_abbr_map = globals().get("tcg_sets_eng_name_abbr_map", {})
+    tcg_sets_jp_name_abbr_map = globals().get("tcg_sets_jp_name_abbr_map", {})
     SET_TO_ERA = {}
 
     try:
@@ -487,6 +490,12 @@ def reload_sets():
         for sets in tcg_sets_eng_by_era.values()
         for item in sets
         if "abbr" in item
+    }
+    tcg_sets_eng_name_abbr_map = {
+        item["name"]: item.get("abbr")
+        or re.sub(r"[^A-Za-z0-9]", "", item["name"]).upper()
+        for sets in tcg_sets_eng_by_era.values()
+        for item in sets
     }
     tcg_sets_eng = [
         item["name"] for sets in tcg_sets_eng_by_era.values() for item in sets
@@ -524,6 +533,12 @@ def reload_sets():
         for sets in tcg_sets_jp_by_era.values()
         for item in sets
         if "abbr" in item
+    }
+    tcg_sets_jp_name_abbr_map = {
+        item["name"]: item.get("abbr")
+        or re.sub(r"[^A-Za-z0-9]", "", item["name"]).upper()
+        for sets in tcg_sets_jp_by_era.values()
+        for item in sets
     }
     tcg_sets_jp = [
         item["name"] for sets in tcg_sets_jp_by_era.values() for item in sets
@@ -616,6 +631,25 @@ def get_set_name(code: str) -> str:
         f"Nie znaleziono nazwy dla setu '{code}'. Weryfikacja ręczna wymagana."
     )
     return code
+
+
+def get_set_abbr(name: str) -> str:
+    """Return the abbreviation for a set name if available.
+
+    If the abbreviation is not known, a sanitized uppercase variant of the
+    provided name is returned.
+    """
+    if not name:
+        return ""
+    search = name.strip()
+    # remove trailing language or other short alphabetic suffixes like "EN", "JP"
+    search = re.sub(r"[-_\s]+[a-z]{1,2}$", "", search, flags=re.IGNORECASE)
+    lowered = search.lower()
+    for mapping in (tcg_sets_eng_name_abbr_map, tcg_sets_jp_name_abbr_map):
+        for key, abbr in mapping.items():
+            if key.lower() == lowered or abbr.lower() == lowered:
+                return abbr
+    return re.sub(r"[^A-Za-z0-9]", "", search).upper()
 
 
 def get_set_era(code_or_name: str) -> str:
@@ -1520,7 +1554,6 @@ class CardEditorApp:
             self.hash_db = None
         self.auto_lookup = AUTO_HASH_LOOKUP
         self.current_fingerprint = None
-        self.next_product_code = storage.load_last_product_code() + 1
         self.price_db = self.load_price_db()
         self.folder_name = ""
         self.folder_path = ""
@@ -5985,9 +6018,14 @@ class CardEditorApp:
             if current and current.get("warehouse_code"):
                 existing_wc = current["warehouse_code"]
         data["warehouse_code"] = existing_wc or self.next_free_location()
-        data["product_code"] = self.next_product_code
-        self.next_product_code += 1
-        storage.save_last_product_code(self.next_product_code - 1)
+        variant = (
+            "Holo"
+            if types.get("Holo")
+            else "Reverse"
+            if types.get("Reverse")
+            else ""
+        )
+        data["product_code"] = csv_utils.build_product_code(set_name, number, variant)
         data["unit"] = "szt."
         data["category"] = f"Karty Pokémon > {data['era']} > {data['set']}"
         data["producer"] = "Pokémon"

--- a/tests/test_csv_import.py
+++ b/tests/test_csv_import.py
@@ -14,7 +14,7 @@ def run_load_csv(tmp_path, csv_content):
     out_path = tmp_path / "out.csv"
     in_path.write_text(csv_content, encoding="utf-8")
 
-    dummy = SimpleNamespace(product_code_map={}, next_product_code=1)
+    dummy = SimpleNamespace(product_code_map={})
 
     with patch("tkinter.filedialog.askopenfilename", return_value=str(in_path)), \
          patch("tkinter.filedialog.asksaveasfilename", return_value=str(out_path)), \
@@ -38,9 +38,8 @@ def test_old_csv_location_pattern(tmp_path):
     assert len(rows) == 1
     row = rows[0]
     assert row["warehouse_code"] == "K1R1P1"
-    assert row["product_code"] == "1"
+    assert row["product_code"] == "PKM-BASE-1"
     assert dummy.product_code_map == {}
-    assert dummy.next_product_code == 2
 
 
 def test_image_header_replaced(tmp_path):

--- a/tests/test_delivery_id.py
+++ b/tests/test_delivery_id.py
@@ -37,7 +37,6 @@ def test_delivery_field_constant():
         folder_name="folder",
         file_to_key={},
         product_code_map={},
-        next_product_code=1,
         next_free_location=lambda: "K1R1P1",
         generate_location=lambda idx: "K1R1P1",
         output_data=[None],

--- a/tests/test_manual_price.py
+++ b/tests/test_manual_price.py
@@ -34,7 +34,6 @@ def make_dummy(price):
         folder_name="folder",
         file_to_key={},
         product_code_map={},
-        next_product_code=1,
         next_free_location=lambda: "K1R1P1",
         generate_location=lambda idx: "K1R1P1",
         output_data=[None],

--- a/tests/test_save_and_next_destroyed_widgets.py
+++ b/tests/test_save_and_next_destroyed_widgets.py
@@ -46,7 +46,6 @@ def make_dummy():
         folder_name="folder",
         file_to_key={},
         product_code_map={},
-        next_product_code=1,
         next_free_location=lambda: "K1R1P1",
         generate_location=lambda idx: "K1R1P1",
         output_data=[None, None],
@@ -61,8 +60,7 @@ def make_dummy():
 
 def test_save_and_next_with_destroyed_entries():
     dummy = make_dummy()
-    with patch.object(ui.storage, "save_last_product_code"), \
-        patch.object(ui.messagebox, "showinfo"), \
+    with patch.object(ui.messagebox, "showinfo"), \
         patch.object(ui.messagebox, "showwarning"):
         ui.CardEditorApp.save_and_next(dummy)
     assert dummy.output_data[0]["numer"] == "4"

--- a/tests/test_save_current_data_html.py
+++ b/tests/test_save_current_data_html.py
@@ -38,7 +38,6 @@ def make_dummy():
         folder_name="folder",
         file_to_key={},
         product_code_map={},
-        next_product_code=1,
         next_free_location=lambda: "K1R1P1",
         generate_location=lambda idx: "K1R1P1",
         output_data=[None],
@@ -79,5 +78,5 @@ def test_html_generated():
     assert "<li>Profesjonalna obsługa klienta</li>" in data["description"]
     assert "https://kartoteka.shop/pl/c/Base-Set" in data["description"]
     assert dummy.product_code_map == {}
-    assert dummy.next_product_code == 2
+    assert data["product_code"] == "PKM-BASESET-4"
     assert data["warehouse_code"] == "K1R1P1"

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -8,7 +8,6 @@ sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import kartoteka.ui as ui
 import kartoteka.csv_utils as csv_utils
-import kartoteka.storage as storage
 
 
 class DummyVar:
@@ -38,7 +37,6 @@ def make_dummy():
         folder_name="folder",
         file_to_key={},
         product_code_map={},
-        next_product_code=1,
         next_free_location=lambda: "K1R1P1",
         generate_location=lambda idx: "K1R1P1",
         output_data=[None],
@@ -94,32 +92,7 @@ def test_save_current_appends_session(tmp_path):
 
 
 def test_product_code_persists_between_sessions(tmp_path):
-    session_path = tmp_path / "session.csv"
-    last_code_file = tmp_path / "last_product_code.txt"
-
-    with patch.object(storage, "LAST_PRODUCT_CODE_FILE", str(last_code_file)):
-        dummy = make_dummy()
-        dummy.session_csv_path = str(session_path)
-        with open(session_path, "w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(
-                f, fieldnames=csv_utils.STORE_FIELDNAMES, delimiter=";"
-            )
-            writer.writeheader()
-
-        ui.CardEditorApp.save_current_data(dummy)
-
-        root = SimpleNamespace(
-            title=lambda *a, **k: None,
-            configure=lambda *a, **k: None,
-            option_add=lambda *a, **k: None,
-            after=lambda delay, func, *args: func(*args),
-        )
-
-        with patch.object(ui.CardEditorApp, "load_price_db", lambda self: {}), \
-             patch.object(ui.CardEditorApp, "show_loading_screen", lambda self: None), \
-             patch.object(ui.CardEditorApp, "startup_tasks", lambda self: None), \
-             patch("kartoteka.ui.tk.StringVar", lambda *a, **k: DummyVar(k.get("value", ""))):
-            app = ui.CardEditorApp(root)
-
-        assert app.next_product_code == 2
+    dummy = make_dummy()
+    ui.CardEditorApp.save_current_data(dummy)
+    assert dummy.output_data[0]["product_code"] == "PKM-BASE-4"
 

--- a/tests/test_variant_flags.py
+++ b/tests/test_variant_flags.py
@@ -63,7 +63,6 @@ def test_save_and_reload_variant_flags(tmp_path):
             folder_name="folder",
             file_to_key={},
             product_code_map={},
-            next_product_code=1,
             next_free_location=lambda: "K1R1P1",
             generate_location=lambda idx: "K1R1P1",
             output_data=[None],


### PR DESCRIPTION
## Summary
- derive product codes as `PKM-{set_abbr}-{number}{variant}`
- remove sequential product code tracking and persistence
- update CSV import/export and tests for new code format

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9671d771c832fa05300c0f86f49e2