### PR TITLE
Aggregate store exports by product code

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -12,6 +12,7 @@ INVENTORY_CSV = os.getenv(
     "INVENTORY_CSV", os.getenv("WAREHOUSE_CSV", "magazyn.csv")
 )
 WAREHOUSE_CSV = os.getenv("WAREHOUSE_CSV", INVENTORY_CSV)
+STORE_EXPORT_CSV = os.getenv("STORE_EXPORT_CSV", "store_export.csv")
 
 # Track last modification time and cached statistics for the warehouse CSV
 WAREHOUSE_CSV_MTIME: Optional[float] = None
@@ -393,36 +394,48 @@ def load_csv_data(app):
     messagebox.showinfo("Sukces", "Plik CSV został scalony i zapisany.")
 
 
-def export_csv(app):
-    """Export collected data to a CSV file."""
-    file_path = filedialog.asksaveasfilename(
-        defaultextension=".csv", filetypes=[("CSV files", "*.csv")]
-    )
-    if not file_path:
-        return
+def export_csv(app, path: str = STORE_EXPORT_CSV):
+    """Export collected data to the store CSV file."""
 
-    combined = {}
+    combined: dict[str, dict[str, str | int]] = {}
+
+    if os.path.exists(path):
+        with open(path, encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter=";")
+            for row in reader:
+                product_code = row.get("product_code")
+                if not product_code:
+                    continue
+                try:
+                    row["stock"] = int(row.get("stock") or 0)
+                except ValueError:
+                    row["stock"] = 0
+                combined[product_code] = row
+
     for row in app.output_data:
         if row is None:
             continue
-        key = f"{row['nazwa']}|{row['numer']}|{row['set']}"
-        if key in combined:
-            combined[key]["stock"] += 1
+        product_code = str(row["product_code"])
+        if product_code in combined:
+            combined[product_code]["stock"] = int(combined[product_code]["stock"]) + 1
         else:
-            combined[key] = row.copy()
-            combined[key]["stock"] = 1
+            row_copy = row.copy()
+            row_copy["stock"] = 1
+            combined[product_code] = format_store_row(row_copy)
 
     fieldnames = STORE_FIELDNAMES
 
-    with open(file_path, mode="w", encoding="utf-8", newline="") as file:
+    with open(path, mode="w", encoding="utf-8", newline="") as file:
         writer = csv.DictWriter(file, fieldnames=fieldnames, delimiter=";")
         writer.writeheader()
         for row in combined.values():
-            writer.writerow(format_store_row(row))
+            row_out = row.copy()
+            row_out["stock"] = str(row_out.get("stock", 0))
+            writer.writerow(row_out)
     append_warehouse_csv(app)
     messagebox.showinfo("Sukces", "Plik CSV został zapisany.")
     if messagebox.askyesno("Wysyłka", "Czy wysłać plik do Shoper?"):
-        send_csv_to_shoper(app, file_path)
+        send_csv_to_shoper(app, path)
     app.back_to_welcome()
 
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -6194,7 +6194,7 @@ class CardEditorApp:
 
     def export_csv(self):
         self.in_scan = False
-        csv_utils.export_csv(self)
+        csv_utils.export_csv(self, csv_utils.STORE_EXPORT_CSV)
 
     def open_config_dialog(self):
         """Display a dialog for editing Shoper API configuration."""

--- a/tests/test_export_csv.py
+++ b/tests/test_export_csv.py
@@ -14,6 +14,7 @@ def test_export_includes_new_fields(tmp_path, monkeypatch):
     out_path = tmp_path / "out.csv"
     inv_path = tmp_path / "inv.csv"
     monkeypatch.setenv("WAREHOUSE_CSV", str(inv_path))
+    monkeypatch.setenv("STORE_EXPORT_CSV", str(out_path))
     import importlib
     importlib.reload(csv_utils)
     importlib.reload(ui)
@@ -35,8 +36,7 @@ def test_export_includes_new_fields(tmp_path, monkeypatch):
     )
     dummy.back_to_welcome = lambda: None
 
-    with patch("tkinter.filedialog.asksaveasfilename", return_value=str(out_path)), \
-         patch("tkinter.messagebox.showinfo"), \
+    with patch("tkinter.messagebox.showinfo"), \
          patch("tkinter.messagebox.askyesno", return_value=False):
         ui.CardEditorApp.export_csv(dummy)
 
@@ -57,10 +57,11 @@ def test_export_includes_new_fields(tmp_path, monkeypatch):
         assert "psa10_price" not in reader.fieldnames
 
 
-def test_merge_ignores_era(tmp_path, monkeypatch):
+def test_merge_by_product_code(tmp_path, monkeypatch):
     out_path = tmp_path / "out.csv"
     inv_path = tmp_path / "inv.csv"
     monkeypatch.setenv("WAREHOUSE_CSV", str(inv_path))
+    monkeypatch.setenv("STORE_EXPORT_CSV", str(out_path))
     import importlib
     importlib.reload(csv_utils)
     importlib.reload(ui)
@@ -72,7 +73,7 @@ def test_merge_ignores_era(tmp_path, monkeypatch):
                 "numer": "1",
                 "set": "Base",
                 "era": "Era1",
-                "product_code": 1,
+                "product_code": "PC1",
                 "cena": "10",
                 "category": "Karty Pokémon > Era1 > Base",
                 "producer": "Pokemon",
@@ -81,12 +82,12 @@ def test_merge_ignores_era(tmp_path, monkeypatch):
                 "image1": "img.jpg",
             },
             {
-                "nazwa": "Pikachu",
-                "numer": "1",
+                "nazwa": "Charmander",
+                "numer": "2",
                 "set": "Base",
                 "era": "Era2",
-                "product_code": 2,
-                "cena": "10",
+                "product_code": "PC1",
+                "cena": "5",
                 "category": "Karty Pokémon > Era2 > Base",
                 "producer": "Pokemon",
                 "short_description": "s",
@@ -97,8 +98,7 @@ def test_merge_ignores_era(tmp_path, monkeypatch):
     )
     dummy.back_to_welcome = lambda: None
 
-    with patch("tkinter.filedialog.asksaveasfilename", return_value=str(out_path)), \
-         patch("tkinter.messagebox.showinfo"), \
+    with patch("tkinter.messagebox.showinfo"), \
          patch("tkinter.messagebox.askyesno", return_value=False):
         ui.CardEditorApp.export_csv(dummy)
 
@@ -108,7 +108,7 @@ def test_merge_ignores_era(tmp_path, monkeypatch):
         assert reader.fieldnames == csv_utils.STORE_FIELDNAMES
         assert len(rows) == 1
         row = rows[0]
-        assert row["category"] == "Karty Pokémon > Era1 > Base"
+        assert row["product_code"] == "PC1"
         assert row["stock"] == "2"
 
 
@@ -116,6 +116,7 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
     out_path = tmp_path / "out.csv"
     inv_path = tmp_path / "inv.csv"
     monkeypatch.setenv("WAREHOUSE_CSV", str(inv_path))
+    monkeypatch.setenv("STORE_EXPORT_CSV", str(out_path))
     import importlib
     importlib.reload(csv_utils)
     importlib.reload(ui)
@@ -138,8 +139,7 @@ def test_export_appends_warehouse(tmp_path, monkeypatch):
     )
     dummy.back_to_welcome = lambda: None
 
-    with patch("tkinter.filedialog.asksaveasfilename", return_value=str(out_path)), \
-         patch("tkinter.messagebox.showinfo"), \
+    with patch("tkinter.messagebox.showinfo"), \
          patch("tkinter.messagebox.askyesno", return_value=False):
         ui.CardEditorApp.export_csv(dummy)
 

--- a/tests/test_session_csv.py
+++ b/tests/test_session_csv.py
@@ -91,8 +91,53 @@ def test_save_current_appends_session(tmp_path):
         assert rows[0]["delivery"] == "3 dni"
 
 
-def test_product_code_persists_between_sessions(tmp_path):
-    dummy = make_dummy()
-    ui.CardEditorApp.save_current_data(dummy)
-    assert dummy.output_data[0]["product_code"] == "PKM-BASE-4"
+def test_export_accumulates_between_sessions(tmp_path, monkeypatch):
+    out_path = tmp_path / "out.csv"
+    inv_path = tmp_path / "inv.csv"
+    monkeypatch.setenv("STORE_EXPORT_CSV", str(out_path))
+    monkeypatch.setenv("WAREHOUSE_CSV", str(inv_path))
+    import importlib
+    importlib.reload(csv_utils)
+    importlib.reload(ui)
+
+    base_row = {
+        "nazwa": "Pikachu",
+        "numer": "1",
+        "set": "Base",
+        "era": "Era1",
+        "product_code": "PC1",
+        "cena": "10",
+        "category": "Karty Pokémon > Era1 > Base",
+        "producer": "Pokemon",
+        "short_description": "s",
+        "description": "d",
+        "image1": "img.jpg",
+    }
+    second_row = {
+        "nazwa": "Charmander",
+        "numer": "2",
+        "set": "Base",
+        "era": "Era1",
+        "product_code": "PC2",
+        "cena": "5",
+        "category": "Karty Pokémon > Era1 > Base",
+        "producer": "Pokemon",
+        "short_description": "s",
+        "description": "d",
+        "image1": "img.jpg",
+    }
+
+    dummy1 = SimpleNamespace(output_data=[base_row], back_to_welcome=lambda: None)
+    dummy2 = SimpleNamespace(output_data=[dict(base_row), second_row], back_to_welcome=lambda: None)
+
+    with patch("tkinter.messagebox.showinfo"), \
+         patch("tkinter.messagebox.askyesno", return_value=False):
+        ui.CardEditorApp.export_csv(dummy1)
+        ui.CardEditorApp.export_csv(dummy2)
+
+    with open(out_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=";")
+        rows = {r["product_code"]: r for r in reader}
+        assert rows["PC1"]["stock"] == "2"
+        assert rows["PC2"]["stock"] == "1"
 


### PR DESCRIPTION
## Summary
- add `STORE_EXPORT_CSV` constant and merge exports by `product_code`
- reuse existing export file, summing `stock` values
- update tests for product-code aggregation and session accumulation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b96beda9e4832facd7767171761ec7