### PR TITLE
docs: document card code format and CSV merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,17 @@ With dependencies installed, launch the interface:
 ```bash
 python main.py
 ```
+
+## Card Identifier Format and CSV Export
+Cards are identified with the pattern `PKM-<SET>-<NR>-<VARIANT>`:
+
+* `SET` – the set code, e.g. `BS` for Base Set.
+* `NR` – the card number within that set.
+* `VARIANT` – optional variant flag such as `H` (holofoil) or `R` (reverse).
+
+Examples:
+
+* `PKM-BS-1-H`
+* `PKM-BS-1-R`
+
+When exporting, the application creates a single consolidated CSV file. Entries with the same card code are merged so duplicates appear only once.


### PR DESCRIPTION
## Summary
- document the `PKM-<SET>-<NR>-<VARIANT>` identifier pattern with H/R examples
- explain how export creates a single CSV and merges duplicate card codes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b96dcadfe0832f984a439258f38a0d