### PR TITLE
Handle max added_at in reload_mag_cards

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3026,6 +3026,17 @@ class CardEditorApp:
 
             for rows in groups.values():
                 combined = dict(rows[0])
+                added_dates: list[datetime.date] = []
+                for r in rows:
+                    value = (r.get("added_at") or "").strip()
+                    if not value:
+                        continue
+                    try:
+                        added_dates.append(datetime.date.fromisoformat(value))
+                    except ValueError:
+                        logger.warning("Skipping invalid added_at: %s", value)
+                if added_dates:
+                    combined["added_at"] = max(added_dates).isoformat()
                 combined["image"] = next(
                     (r.get("image") for r in rows if r.get("image")),
                     "",


### PR DESCRIPTION
## Summary
- Ensure grouped warehouse cards display the most recent `added_at` date
- Skip empty or invalid date values when deriving `added_at`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b988f5143c832faf4b18dc92870268