### PR TITLE
Add manual search trigger for magazyn view

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3179,8 +3179,12 @@ class CardEditorApp:
             control_frame,
             textvariable=self.mag_search_var,
             placeholder_text="Szukaj",
+            width=250,
         )
         search_entry.pack(side="left", padx=5, pady=5)
+
+        search_button = ctk.CTkButton(control_frame, text="Szukaj")
+        search_button.pack(side="left", padx=5, pady=5)
 
         self.mag_sort_var = _safe_var("added")
         sort_menu = ctk.CTkOptionMenu(
@@ -3521,7 +3525,12 @@ class CardEditorApp:
                 self._root_mag_bind_id = root_bind("<Configure>", _relayout_mag_cards)
 
         self._update_mag_list = _update_mag_list
-        self.mag_search_var.trace_add("write", _update_mag_list)
+        if hasattr(search_entry, "bind"):
+            search_entry.bind("<Return>", lambda _e: _update_mag_list())
+        if hasattr(search_button, "configure"):
+            search_button.configure(command=_update_mag_list)
+        else:
+            search_button.command = _update_mag_list
         self.mag_sold_filter_var.trace_add("write", _update_mag_list)
         if hasattr(sort_menu, "configure"):
             sort_menu.configure(command=lambda _: _update_mag_list())

--- a/tests/test_magazyn_search_filters.py
+++ b/tests/test_magazyn_search_filters.py
@@ -67,6 +67,7 @@ def test_search_by_variant(tmp_path):
     app = _load_app(csv_path, (2, 15.0, 0, 0))
 
     app.mag_search_var.set("holo")
+    app._update_mag_list()
     assert len(app.mag_card_labels) == 1
     assert app.mag_card_labels[0].text == "A"
 
@@ -82,14 +83,17 @@ def test_search_by_sold_status(tmp_path):
     app = _load_app(csv_path, (1, 1.0, 1, 1.0))
 
     app.mag_search_var.set("sold")
+    app._update_mag_list()
     assert len(app.mag_sold_labels) == 1
     assert len(app.mag_card_labels) == 0
 
     app.mag_search_var.set("unsold")
+    app._update_mag_list()
     assert len(app.mag_card_labels) == 1
     assert len(app.mag_sold_labels) == 0
 
     app.mag_search_var.set("")
+    app._update_mag_list()
     app.mag_sold_filter_var.set("sold")
     assert len(app.mag_sold_labels) == 1
     assert len(app.mag_card_labels) == 0
@@ -110,6 +114,7 @@ def test_search_with_accents(tmp_path):
     app = _load_app(csv_path, (2, 2.0, 0, 0))
 
     app.mag_search_var.set("pokemon cafe")
+    app._update_mag_list()
     assert len(app.mag_card_labels) == 1
     assert app.mag_card_labels[0].text == "Pokémon Café"
 
@@ -125,6 +130,7 @@ def test_search_multiple_terms_across_fields(tmp_path):
     app = _load_app(csv_path, (2, 2.0, 0, 0))
 
     app.mag_search_var.set("pikachu base")
+    app._update_mag_list()
     assert len(app.mag_card_labels) == 1
     assert app.mag_card_labels[0].text == "Pikachu"
 
@@ -193,7 +199,9 @@ def test_search_clear_keeps_thumbnails(tmp_path):
     app, photo, stack = _load_app_with_delay(csv_path, (1, 1.0, 0, 0))
     try:
         app.mag_search_var.set("x")
+        app._update_mag_list()
         app.mag_search_var.set("")
+        app._update_mag_list()
         for t in app._image_threads:
             t.join()
         assert app.mag_card_image_labels[0] is not None


### PR DESCRIPTION
## Summary
- widen search entry and add Search button to magazyn view
- trigger filtering with Enter key and remove automatic trace
- adjust tests to manually call `_update_mag_list`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b98b26bb70832f9430d3e927934eb7