### PR TITLE
Refine pricing UI button layout

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4282,12 +4282,13 @@ class CardEditorApp:
             text="Wyszukaj",
             command=self.run_pricing_search,
             width=120,
+            fg_color="#00a000",
         ).grid(row=0, column=0, padx=5)
 
         self.create_button(
             btn_frame,
-            text="Powrót",
-            command=self.back_to_welcome,
+            text="Wyczyść",
+            command=self.clear_price_pool,
             width=120,
         ).grid(row=0, column=1, padx=5)
 
@@ -4309,8 +4310,8 @@ class CardEditorApp:
         self.pool_total_label.pack(side="left")
         self.create_button(
             self.pool_frame,
-            text="Wyczyść",
-            command=self.clear_price_pool,
+            text="Powrót",
+            command=self.back_to_welcome,
             width=120,
         ).pack(side="left", padx=5)
 


### PR DESCRIPTION
## Summary
- Move pool total and Back button to the pool frame
- Keep Search and Clear buttons in btn_frame with consistent width
- Highlight Search button with a green color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ba838d5b70832fa7f6e6e820c6ccfd