### PR TITLE
Fill era and price for duplicate fingerprint matches

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5195,6 +5195,14 @@ class CardEditorApp:
                 self.entries["numer"].insert(0, number)
                 self.entries["set"].set("")
                 self.entries["set"].set(set_name)
+                era_name = get_set_era(set_name)
+                self.entries["era"].set(era_name)
+                cena = self.get_price_from_db(name, number, set_name)
+                if cena is None:
+                    cena = self.fetch_card_price(name, number, set_name)
+                if cena is not None:
+                    self.entries["cena"].delete(0, tk.END)
+                    self.entries["cena"].insert(0, str(cena))
                 if isinstance(meta.get("typ"), str):
                     for name in meta["typ"].split(","):
                         name = name.strip()


### PR DESCRIPTION
## Summary
- populate era and price when a fingerprint match is found, even if analysis is skipped

## Testing
- `pytest` (fails: 57 errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_68ba91653f14832fab9e9473f2f21cfd