### PR TITLE
Preserve location for confirmed duplicates

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1590,6 +1590,7 @@ class CardEditorApp:
         self.in_scan = False
         self.current_image_path = ""
         self.current_analysis_thread = None
+        self.current_location = ""
         self.show_loading_screen()
         self.root.after(0, self.startup_tasks)
 
@@ -5063,6 +5064,7 @@ class CardEditorApp:
         filename = os.path.basename(image_path)
         self.current_image_path = image_path
         self.current_fingerprint = None
+        self.current_location = ""
         cache_key = self.file_to_key.get(filename)
         if not cache_key:
             cache_key = self._guess_key_from_filename(image_path)
@@ -5189,6 +5191,12 @@ class CardEditorApp:
                         if progress_cb:
                             progress_cb(1.0, hide=True)
                         return
+                    self.current_location = self.next_free_location()
+                    if hasattr(self, "location_label"):
+                        self.location_label.configure(text=self.current_location)
+                    logger.info(
+                        "Assigned storage location %s to duplicate card", self.current_location
+                    )
                 self.entries["nazwa"].delete(0, tk.END)
                 self.entries["numer"].delete(0, tk.END)
                 self.entries["nazwa"].insert(0, name)
@@ -5197,9 +5205,13 @@ class CardEditorApp:
                 self.entries["set"].set(set_name)
                 era_name = get_set_era(set_name)
                 self.entries["era"].set(era_name)
-                cena = self.get_price_from_db(name, number, set_name)
+                cena = getattr(
+                    self, "get_price_from_db", lambda *a, **k: None
+                )(name, number, set_name)
                 if cena is None:
-                    cena = self.fetch_card_price(name, number, set_name)
+                    cena = getattr(
+                        self, "fetch_card_price", lambda *a, **k: None
+                    )(name, number, set_name)
                 if cena is not None:
                     self.entries["cena"].delete(0, tk.END)
                     self.entries["cena"].insert(0, str(cena))
@@ -6269,7 +6281,8 @@ class CardEditorApp:
             current = self.output_data[self.index]
             if current and current.get("warehouse_code"):
                 existing_wc = current["warehouse_code"]
-        data["warehouse_code"] = existing_wc or self.next_free_location()
+        current_loc = getattr(self, "current_location", "")
+        data["warehouse_code"] = existing_wc or current_loc or self.next_free_location()
         fp = getattr(self, "current_fingerprint", None)
         if (
             fp is None
@@ -6422,6 +6435,8 @@ class CardEditorApp:
                     delimiter=";",
                 )
                 writer.writerow(csv_utils.format_store_row(data))
+        if hasattr(self, "current_location"):
+            self.current_location = ""
 
     def save_and_next(self):
         """Save the current card data and display the next scan."""

--- a/tests/test_current_location_reuse.py
+++ b/tests/test_current_location_reuse.py
@@ -1,0 +1,54 @@
+import importlib
+import sys
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+
+
+class DummyVar:
+    def __init__(self, value):
+        self.value = value
+    def get(self):
+        return self.value
+
+
+def make_dummy():
+    return SimpleNamespace(
+        entries={
+            "nazwa": DummyVar("Card"),
+            "numer": DummyVar("1"),
+            "set": DummyVar("Set"),
+            "era": DummyVar(""),
+            "język": DummyVar("ENG"),
+            "stan": DummyVar("NM"),
+            "cena": DummyVar(""),
+            "psa10_price": DummyVar("")
+        },
+        type_vars={"Reverse": DummyVar(False), "Holo": DummyVar(False)},
+        card_cache={},
+        cards=["/tmp/card.jpg"],
+        index=0,
+        folder_name="folder",
+        file_to_key={},
+        product_code_map={},
+        next_free_location=MagicMock(return_value="K1R1P2"),
+        output_data=[None],
+        get_price_from_db=lambda *a: None,
+        fetch_card_price=lambda *a: None,
+        fetch_psa10_price=lambda *a: None,
+        current_location="K1R1P1",
+    )
+
+
+def test_current_location_used_without_generating_new():
+    importlib.reload(ui)
+    dummy = make_dummy()
+    ui.CardEditorApp.save_current_data(dummy)
+    assert dummy.output_data[0]["warehouse_code"] == "K1R1P1"
+    dummy.next_free_location.assert_not_called()


### PR DESCRIPTION
## Summary
- Store next free warehouse location when user confirms keeping a duplicate and show it in the UI
- Reuse stored location during save instead of generating a new slot
- Add regression test ensuring saved data honors preassigned locations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba93dfff38832fac6345249103ef41