### PR TITLE
Add duplicate check after analysis result

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5422,6 +5422,29 @@ class CardEditorApp:
             self.entries["era"].set(era_name)
             self.update_set_options()
             self.entries["set"].set(set_name)
+
+            duplicates = csv_utils.find_duplicates(name, number, set_name)
+            if duplicates:
+                codes = ", ".join(
+                    [d.get("warehouse_code", "") for d in duplicates if d.get("warehouse_code")]
+                )
+                msg = _("Card already exists in magazyn: {codes}. Add anyway?").format(
+                    codes=codes
+                )
+                if not messagebox.askyesno(_("Duplicate"), msg):
+                    logger.info(
+                        "Skipping duplicate card %s #%s in set %s", name, number, set_name
+                    )
+                    if progress_cb:
+                        progress_cb(1.0, hide=True)
+                    self.current_analysis_thread = None
+                    return
+                self.current_location = self.next_free_location()
+                if hasattr(self, "location_label"):
+                    self.location_label.configure(text=self.current_location)
+                logger.info(
+                    "Assigned storage location %s to duplicate card", self.current_location
+                )
             rect = result.get("rect")
             self._analysis_orientation = result.get("orientation", 0)
             if rect and hasattr(self, "current_card_image"):

--- a/tests/test_apply_analysis_result.py
+++ b/tests/test_apply_analysis_result.py
@@ -1,6 +1,6 @@
 import importlib
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 import tkinter as tk
 
 import kartoteka.ui as ui
@@ -34,3 +34,52 @@ def test_apply_analysis_result_updates_fields():
     name_entry.insert.assert_called_with(0, "Pikachu")
     num_entry.insert.assert_called_with(0, "37")
     set_var.set.assert_called_with("Set X")
+
+
+def make_dummy_with_progress():
+    dummy, name_entry, num_entry, set_var = make_dummy()
+    dummy._update_card_progress = MagicMock()
+    dummy.next_free_location = MagicMock(return_value="K1R1P1")
+    dummy.location_label = SimpleNamespace(configure=MagicMock())
+    dummy.current_analysis_thread = "t"
+    return dummy, name_entry, num_entry, set_var
+
+
+def test_apply_analysis_result_duplicate_cancel(monkeypatch):
+    dummy, _, _, _ = make_dummy_with_progress()
+    find_mock = MagicMock(return_value=[{"warehouse_code": "K1"}])
+    ask_mock = MagicMock(return_value=False)
+    monkeypatch.setattr(ui.csv_utils, "find_duplicates", find_mock)
+    monkeypatch.setattr(ui.messagebox, "askyesno", ask_mock)
+
+    dummy._apply_analysis_result(
+        {"name": "Pika", "number": "001", "set": "Set X", "era": ""}, 0
+    )
+
+    find_mock.assert_called_once_with("Pika", "1", "Set X")
+    ask_mock.assert_called_once()
+    assert dummy._update_card_progress.call_args_list == [
+        call(0, hide=True),
+        call(1.0, hide=True),
+    ]
+    dummy.next_free_location.assert_not_called()
+    assert dummy.current_analysis_thread is None
+
+
+def test_apply_analysis_result_duplicate_confirm(monkeypatch):
+    dummy, _, _, _ = make_dummy_with_progress()
+    find_mock = MagicMock(return_value=[{"warehouse_code": "K1"}])
+    ask_mock = MagicMock(return_value=True)
+    monkeypatch.setattr(ui.csv_utils, "find_duplicates", find_mock)
+    monkeypatch.setattr(ui.messagebox, "askyesno", ask_mock)
+
+    dummy._apply_analysis_result(
+        {"name": "Pika", "number": "001", "set": "Set X", "era": ""}, 0
+    )
+
+    find_mock.assert_called_once_with("Pika", "1", "Set X")
+    ask_mock.assert_called_once()
+    dummy._update_card_progress.assert_called_once_with(0, hide=True)
+    dummy.next_free_location.assert_called_once()
+    dummy.location_label.configure.assert_called_once_with(text="K1R1P1")
+    assert dummy.current_location == "K1R1P1"


### PR DESCRIPTION
## Summary
- run `csv_utils.find_duplicates` after filling card details in `_apply_analysis_result`
- warn about existing cards and let user cancel or confirm
- assign location and update progress for duplicates similar to fingerprint branch
- test duplicate handling for both cancel and confirm paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa2a2108c832f8666dc892148de37