### PR TITLE
Allow wildcard variant in duplicate search

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -87,7 +87,9 @@ def build_product_code(set_name: str, number: str, variant: str | None = None) -
     return f"PKM-{abbr}-{num}{suffix}"
 
 
-def find_duplicates(name: str, number: str, set_name: str, variant: str = "common"):
+def find_duplicates(
+    name: str, number: str, set_name: str, variant: str | None = None
+):
     """Return rows from ``WAREHOUSE_CSV`` matching the given card details.
 
     Parameters
@@ -95,7 +97,7 @@ def find_duplicates(name: str, number: str, set_name: str, variant: str = "commo
     name, number, set_name:
         Card attributes to match against ``WAREHOUSE_CSV`` entries.
     variant:
-        Card variant, defaults to ``"common"``.
+        Optional card variant. When ``None`` or falsy any variant matches.
 
     Returns
     -------
@@ -109,7 +111,7 @@ def find_duplicates(name: str, number: str, set_name: str, variant: str = "commo
     number = _sanitize_number(str(number))
     name_norm = normalize(name)
     set_norm = normalize(set_name)
-    variant_norm = normalize(variant or "common") or "common"
+    variant_norm = normalize(variant) if variant else None
 
     if not os.path.exists(WAREHOUSE_CSV):
         return matches
@@ -126,7 +128,7 @@ def find_duplicates(name: str, number: str, set_name: str, variant: str = "commo
                     row_name == name_norm
                     and row_number == number
                     and row_set == set_norm
-                    and row_variant == variant_norm
+                    and (variant_norm is None or row_variant == variant_norm)
                 ):
                     matches.append(row)
     except OSError:

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5176,7 +5176,14 @@ class CardEditorApp:
                         str(meta.get("numer", meta.get("number", "")))
                     )
                     set_name = meta.get("set", meta.get("set_name", ""))
-                duplicates = csv_utils.find_duplicates(name, number, set_name)
+                variant = (
+                    csv_row.get("variant")
+                    if csv_row
+                    else meta.get("wariant") or meta.get("variant")
+                )
+                duplicates = csv_utils.find_duplicates(
+                    name, number, set_name, variant
+                )
                 if duplicates:
                     codes = ", ".join(
                         [d.get("warehouse_code", "") for d in duplicates if d.get("warehouse_code")]
@@ -5374,6 +5381,7 @@ class CardEditorApp:
                     "set_code": meta.get("set_code", ""),
                     "orientation": 0,
                     "set_format": meta.get("set_format", ""),
+                    "variant": csv_row.get("variant"),
                 }
             else:
                 result = {
@@ -5384,6 +5392,7 @@ class CardEditorApp:
                     "set_code": meta.get("set_code", ""),
                     "orientation": 0,
                     "set_format": meta.get("set_format", ""),
+                    "variant": meta.get("wariant") or meta.get("variant"),
                 }
         else:
             result = analyze_card_image(
@@ -5423,7 +5432,10 @@ class CardEditorApp:
             self.update_set_options()
             self.entries["set"].set(set_name)
 
-            duplicates = csv_utils.find_duplicates(name, number, set_name)
+            variant = result.get("variant")
+            duplicates = csv_utils.find_duplicates(
+                name, number, set_name, variant
+            )
             if duplicates:
                 codes = ", ".join(
                     [d.get("warehouse_code", "") for d in duplicates if d.get("warehouse_code")]

--- a/tests/test_apply_analysis_result.py
+++ b/tests/test_apply_analysis_result.py
@@ -56,7 +56,7 @@ def test_apply_analysis_result_duplicate_cancel(monkeypatch):
         {"name": "Pika", "number": "001", "set": "Set X", "era": ""}, 0
     )
 
-    find_mock.assert_called_once_with("Pika", "1", "Set X")
+    find_mock.assert_called_once_with("Pika", "1", "Set X", None)
     ask_mock.assert_called_once()
     assert dummy._update_card_progress.call_args_list == [
         call(0, hide=True),
@@ -77,7 +77,7 @@ def test_apply_analysis_result_duplicate_confirm(monkeypatch):
         {"name": "Pika", "number": "001", "set": "Set X", "era": ""}, 0
     )
 
-    find_mock.assert_called_once_with("Pika", "1", "Set X")
+    find_mock.assert_called_once_with("Pika", "1", "Set X", None)
     ask_mock.assert_called_once()
     dummy._update_card_progress.assert_called_once_with(0, hide=True)
     dummy.next_free_location.assert_called_once()

--- a/tests/test_find_duplicates_normalized.py
+++ b/tests/test_find_duplicates_normalized.py
@@ -18,3 +18,18 @@ def test_find_duplicates_normalized(tmp_path):
         matches = csv_utils.find_duplicates("POKEMON", "1", "example set", variant="holo")
 
     assert {m["warehouse_code"] for m in matches} == {"K1"}
+
+
+def test_find_duplicates_variant_wildcard(tmp_path):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;variant\n"
+        "Poke;1;Set;K1;1;foo.png;holo\n"
+        "Poke;1;Set;K2;1;bar.png;reverse\n",
+        encoding="utf-8",
+    )
+
+    with patch.object(csv_utils, "WAREHOUSE_CSV", str(csv_path)):
+        matches = csv_utils.find_duplicates("Poke", "1", "Set", variant=None)
+
+    assert {m["warehouse_code"] for m in matches} == {"K1", "K2"}

--- a/tests/test_magazyn_duplicates.py
+++ b/tests/test_magazyn_duplicates.py
@@ -41,9 +41,9 @@ def test_group_duplicates(tmp_path):
 
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), \
          patch.object(ui.tk, "Canvas", DummyCanvas), \
-         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)), \
-         patch.object(ui.messagebox, "showinfo", lambda *a, **k: None):
-        duplicates = ui.csv_utils.find_duplicates("A", "1", "S")
+        patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)), \
+        patch.object(ui.messagebox, "showinfo", lambda *a, **k: None):
+        duplicates = ui.csv_utils.find_duplicates("A", "1", "S", None)
         assert {row["warehouse_code"] for row in duplicates} == {"K1R1P1", "K1R1P2"}
 
         dummy_root = SimpleNamespace(

--- a/tests/test_show_card_duplicate_entries.py
+++ b/tests/test_show_card_duplicate_entries.py
@@ -91,7 +91,7 @@ def test_show_card_warns_on_magazyn_duplicate(tmp_path, monkeypatch):
     with patch.object(ui.Image, "open", return_value=DummyImage()):
         ui.CardEditorApp.show_card(dummy)
 
-    find_mock.assert_called_once_with("Pika", "1", "Set X")
+    find_mock.assert_called_once_with("Pika", "1", "Set X", None)
     assert ask_mock.called
     assert name_entry.get() == ""
     assert num_entry.get() == ""


### PR DESCRIPTION
## Summary
- allow `find_duplicates` to accept `variant: str | None` and ignore variant when none is provided
- propagate variant through UI duplicate checks
- cover wildcard variants with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa4a3abe0832f95842e07d49d64ab