### PR TITLE
Improve OCR set code cropping with padding options

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1084,7 +1084,11 @@ def identify_set_by_hash(
 
 
 def extract_set_code_ocr(
-    scan_path: str, rect: tuple[int, int, int, int], debug: bool = False
+    scan_path: str,
+    rect: tuple[int, int, int, int],
+    debug: bool = False,
+    h_pad: int = 0,
+    v_pad: int = 0,
 ) -> list[str]:
     """Extract potential set codes from the scan using OCR.
 
@@ -1098,6 +1102,12 @@ def extract_set_code_ocr(
     debug:
         When ``True``, save intermediate crop to ``OCR`` directory for
         diagnostic purposes. Errors during saving are ignored.
+    h_pad:
+        Optional horizontal padding (in pixels) removed from both left and
+        right sides of the cropped region.
+    v_pad:
+        Optional vertical padding (in pixels) removed from both the top and
+        bottom of the cropped region *after* the initial bottom slice.
 
     Returns
     -------
@@ -1110,7 +1120,15 @@ def extract_set_code_ocr(
         with Image.open(scan_path) as im:
             crop = im.crop(rect)
             h = crop.height
-            crop = crop.crop((0, int(h * 0.6), crop.width, h))
+            # Focus on the bottom 20% of the region where the set code appears.
+            top = int(h * 0.8)
+            crop = crop.crop((0, top, crop.width, h))
+            if h_pad or v_pad:
+                left = min(max(h_pad, 0), crop.width // 2)
+                upper = min(max(v_pad, 0), crop.height // 2)
+                right = max(crop.width - left, left)
+                lower = max(crop.height - upper, upper)
+                crop = crop.crop((left, upper, right, lower))
         if debug:
             try:
                 from pathlib import Path

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -370,11 +370,31 @@ def test_extract_set_code_ocr_filters_single_letter(tmp_path, monkeypatch):
     ocr.assert_called_once()
     processed = ocr.call_args.args[0]
     assert processed.mode == "L"
-    assert processed.size == (40, 16)
+    assert processed.size == (40, 8)
     assert (
         ocr.call_args.kwargs.get("config")
         == "--psm 7 -c tessedit_char_whitelist=0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ/-"
     )
+
+
+def test_extract_set_code_ocr_crops_bottom_region(tmp_path):
+    img = Image.new("L", (50, 50), color=0)
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((0, 40, 49, 49), fill=255)
+    path = tmp_path / "img.png"
+    img.convert("RGB").save(path)
+
+    def fake_ocr(im, config=""):
+        # After cropping bottom 20% (10px) with padding 5/2 and resizing x4
+        assert im.size == (160, 24)
+        assert all(p == 255 for p in im.getdata())
+        return "SV01"
+
+    with patch("pytesseract.image_to_string", side_effect=fake_ocr) as ocr:
+        result = ui.extract_set_code_ocr(str(path), (0, 0, 50, 50), h_pad=5, v_pad=2)
+
+    assert result == [SV01_CODE]
+    ocr.assert_called_once()
 
 
 def test_analyze_card_image_bad_json(monkeypatch):


### PR DESCRIPTION
## Summary
- Narrow `extract_set_code_ocr` to bottom 20% of input region and allow optional padding adjustments
- Add tests verifying new cropping behaviour and parameterized padding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa66eb4f8832fba4685004a8133a0