### PR TITLE
Populate price and era from hash matches

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5400,6 +5400,8 @@ class CardEditorApp:
                     "orientation": 0,
                     "set_format": meta.get("set_format", ""),
                     "variant": csv_row.get("variant"),
+                    "price": csv_row.get("price"),
+                    "era": get_set_era(csv_row.get("set", "")),
                 }
             else:
                 result = {
@@ -5441,12 +5443,18 @@ class CardEditorApp:
                     number, total = m.group(1), m.group(2)
             set_name = result.get("set", "")
             era_name = result.get("era", "") or get_set_era(set_name)
+            price = result.get("price")
             number = sanitize_number(str(number))
             self.entries["nazwa"].delete(0, tk.END)
             self.entries["nazwa"].insert(0, name)
             self.entries["numer"].delete(0, tk.END)
             self.entries["numer"].insert(0, number)
             self.entries["era"].set(era_name)
+            if price is not None:
+                price_entry = self.entries.get("cena")
+                if price_entry is not None:
+                    price_entry.delete(0, tk.END)
+                    price_entry.insert(0, price)
             self.update_set_options()
             self.entries["set"].set(set_name)
 

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -619,27 +619,31 @@ def test_analyze_and_fill_uses_hash_db(monkeypatch):
     name_entry = MagicMock()
     num_entry = MagicMock()
     set_var = MagicMock()
+    price_entry = MagicMock()
     name_entry.delete = MagicMock()
     name_entry.insert = MagicMock()
     num_entry.delete = MagicMock()
     num_entry.insert = MagicMock()
     set_var.set = MagicMock()
+    price_entry.delete = MagicMock()
+    price_entry.insert = MagicMock()
 
     dummy = SimpleNamespace(
         root=SimpleNamespace(after=lambda delay, func: func()),
         lang_var=None,
-        entries={"nazwa": name_entry, "numer": num_entry, "set": set_var, "era": DummyVar("")},
+        entries={
+            "nazwa": name_entry,
+            "numer": num_entry,
+            "set": set_var,
+            "era": DummyVar(""),
+            "cena": price_entry,
+        },
         index=0,
         update_set_options=lambda: None,
         update_set_area_preview=lambda *a, **k: None,
         hash_db=SimpleNamespace(
             best_match=lambda fp, max_distance=None: SimpleNamespace(
-                meta={
-                    "name": "Pika",
-                    "number": "001",
-                    "set": SV01_NAME,
-                    "set_code": SV01_CODE,
-                },
+                meta={"warehouse_code": "K1", "set_code": SV01_CODE},
                 distance=0,
             )
         ),
@@ -649,6 +653,14 @@ def test_analyze_and_fill_uses_hash_db(monkeypatch):
     dummy._apply_analysis_result = ui.CardEditorApp._apply_analysis_result.__get__(
         dummy, ui.CardEditorApp
     )
+    csv_row = {
+        "name": "Pika",
+        "number": "001",
+        "set": SV01_NAME,
+        "variant": None,
+        "price": "10",
+    }
+    monkeypatch.setattr(ui.csv_utils, "get_row_by_code", lambda code: csv_row)
 
     class DummyImage:
         def __enter__(self):
@@ -662,7 +674,7 @@ def test_analyze_and_fill_uses_hash_db(monkeypatch):
 
     monkeypatch.setattr(ui, "compute_fingerprint", lambda img: "fp")
     with patch.object(ui.Image, "open", return_value=DummyImage()), patch.object(
-        ui, "analyze_card_image"
+        ui, "analyze_card_image",
     ) as mock_analyze:
         ui.CardEditorApp._analyze_and_fill(dummy, "/tmp/x", 0)
 
@@ -670,6 +682,8 @@ def test_analyze_and_fill_uses_hash_db(monkeypatch):
     name_entry.insert.assert_called_with(0, "Pika")
     num_entry.insert.assert_called_with(0, "1")
     set_var.set.assert_called_with(SV01_NAME)
+    price_entry.insert.assert_called_with(0, "10")
+    assert dummy.entries["era"].value == ui.get_set_era(SV01_NAME)
 
 
 def test_analyze_and_fill_runs_full_pipeline_for_non_matching_card(tmp_path):


### PR DESCRIPTION
## Summary
- include price and era when a hash match resolves to a CSV row
- populate editor fields with detected price and era values
- verify price/era auto-fill via hash match tests

## Testing
- `pytest tests/test_analyze_card_image.py::test_analyze_and_fill_uses_hash_db -q`
- `PYTHONPATH=. pytest tests/test_apply_analysis_result.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baadfb2c58832fbbf3176586cce0c0