### PR TITLE
Integrate store export data into card analysis

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -55,6 +55,35 @@ WAREHOUSE_FIELDNAMES = [
 ]
 
 
+def load_store_export(path: str = STORE_EXPORT_CSV) -> dict[str, dict[str, str]]:
+    """Return mapping of ``product_code`` to rows from the store export CSV.
+
+    Parameters
+    ----------
+    path:
+        Optional path to the store export CSV.  Defaults to
+        :data:`STORE_EXPORT_CSV`.
+
+    Returns
+    -------
+    dict[str, dict[str, str]]
+        Mapping where keys are product codes and values are the corresponding
+        CSV rows.  Missing files result in an empty mapping.
+    """
+
+    data: dict[str, dict[str, str]] = {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter=";")
+            for row in reader:
+                code = (row.get("product_code") or "").strip()
+                if code:
+                    data[code] = row
+    except OSError:
+        return {}
+    return data
+
+
 def _sanitize_number(value: str) -> str:
     """Return ``value`` without leading zeros.
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1565,6 +1565,7 @@ class CardEditorApp:
         self.card_cache = {}
         self.file_to_key = {}
         self.product_code_map = {}
+        self.store_data = csv_utils.load_store_export()
         try:
             if HashDB and HASH_DB_FILE:
                 db_path = Path(HASH_DB_FILE)
@@ -5422,6 +5423,19 @@ class CardEditorApp:
                 preview_cb=getattr(self, "update_set_area_preview", None),
                 preview_image=getattr(self, "current_card_image", None),
             )
+        product_code = csv_utils.build_product_code(
+            result.get("set", ""),
+            result.get("number", ""),
+            result.get("variant"),
+        )
+        result["product_code"] = product_code
+        store_row = getattr(self, "store_data", {}).get(product_code)
+        if store_row:
+            result.update(store_row)
+            cat = store_row.get("category", "")
+            parts = [p.strip() for p in cat.split(">")]
+            if len(parts) >= 2:
+                result["era"] = parts[1]
         if update_progress:
             self.root.after(0, lambda: update_progress(1.0))
 

--- a/tests/test_store_export_usage.py
+++ b/tests/test_store_export_usage.py
@@ -1,0 +1,108 @@
+import csv
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+import tkinter as tk
+import importlib
+
+# provide minimal customtkinter stub before importing modules
+sys.modules["customtkinter"] = SimpleNamespace(
+    CTkEntry=tk.Entry,
+    CTkImage=MagicMock(),
+    CTkButton=MagicMock,
+    CTkToplevel=MagicMock,
+)
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui
+import kartoteka.csv_utils as csv_utils
+importlib.reload(ui)
+importlib.reload(csv_utils)
+
+
+class DummyVar:
+    def __init__(self, value=""):
+        self.value = value
+
+    def get(self):
+        return self.value
+
+    def set(self, value):
+        self.value = value
+
+
+def _create_store_csv(path):
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=csv_utils.STORE_FIELDNAMES, delimiter=";")
+        writer.writeheader()
+        writer.writerow({
+            "product_code": "PKM-PAL-1",
+            "name": "Pikachu",
+            "producer_code": "1",
+            "category": "Karty Pokémon > EraX > Paldea Evolved",
+            "producer": "",
+            "short_description": "",
+            "description": "",
+            "price": "99",
+            "currency": "PLN",
+            "availability": "1",
+            "unit": "szt.",
+            "delivery": "",
+            "stock": "1",
+            "active": "1",
+            "seo_title": "",
+            "vat": "23%",
+            "images 1": "",
+        })
+
+
+def test_load_store_export(tmp_path):
+    csv_path = tmp_path / "store_export.csv"
+    _create_store_csv(csv_path)
+    data = csv_utils.load_store_export(str(csv_path))
+    assert "PKM-PAL-1" in data
+    assert data["PKM-PAL-1"]["price"] == "99"
+
+
+def test_analyze_and_fill_uses_store_export(monkeypatch, tmp_path):
+    csv_path = tmp_path / "store_export.csv"
+    _create_store_csv(csv_path)
+    store_data = csv_utils.load_store_export(str(csv_path))
+
+    name_entry = MagicMock()
+    num_entry = MagicMock()
+    set_var = DummyVar("")
+    era_var = DummyVar("")
+    price_entry = MagicMock()
+    for entry in (name_entry, num_entry, price_entry):
+        entry.delete = MagicMock()
+        entry.insert = MagicMock()
+
+    dummy = SimpleNamespace(
+        root=SimpleNamespace(after=lambda delay, func: func()),
+        entries={
+            "nazwa": name_entry,
+            "numer": num_entry,
+            "set": set_var,
+            "era": era_var,
+            "cena": price_entry,
+        },
+        index=0,
+        update_set_options=lambda: None,
+        update_set_area_preview=lambda *a, **k: None,
+        store_data=store_data,
+        hash_db=None,
+        auto_lookup=False,
+    )
+    dummy._apply_analysis_result = ui.CardEditorApp._apply_analysis_result.__get__(dummy, ui.CardEditorApp)
+
+    monkeypatch.setattr(
+        ui,
+        "analyze_card_image",
+        lambda *a, **k: {"name": "Pikachu", "number": "1", "set": "Paldea Evolved"},
+    )
+
+    ui.CardEditorApp._analyze_and_fill(dummy, "x", 0)
+    assert era_var.value == "EraX"
+    price_entry.insert.assert_called_with(0, "99")


### PR DESCRIPTION
## Summary
- add `load_store_export` utility to map product codes to store export rows
- preload store export data in `CardEditorApp`
- during card analysis, merge store export info such as price and era based on `product_code`
- cover new behaviour with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bab0312c70832f9e1161fa23b0fc04