### PR TITLE
Optimize fingerprint lookup using max-distance filtering

### DIFF
--- a/hash_db.py
+++ b/hash_db.py
@@ -233,11 +233,20 @@ class HashDB:
 
         return max(0, int(score))
 
-    def candidates(self, source, limit: int = 4) -> List[Candidate]:
+    def candidates(
+        self, source, limit: int = 4, max_distance: Optional[int] = None
+    ) -> List[Candidate]:
         """Return best matching candidates for ``source``.
 
         ``source`` may either be a fingerprint mapping or any value accepted by
         :func:`PIL.Image.open`.
+
+        Parameters
+        ----------
+        max_distance:
+            Optional maximum allowed distance for returned candidates.  Once
+            ``limit`` candidates within this distance have been found the
+            search stops early.
         """
 
         fp_query = self._prepare_fp(source)
@@ -256,8 +265,12 @@ class HashDB:
                 "orb": unpack_ndarray(row["orb"]) if row["orb"] else np.empty((0, 32), dtype=np.uint8),
             }
             dist = self._distance(fp_query, fp_row)
+            if max_distance is not None and dist > max_distance:
+                continue
             meta = json.loads(row["meta"] or "{}")
             results.append(Candidate(meta=meta, distance=dist))
+            if max_distance is not None and len(results) >= limit:
+                break
 
         results.sort(key=lambda c: c.distance)
         return results[:limit]
@@ -274,7 +287,7 @@ class HashDB:
             candidate exceeds this distance, ``None`` is returned instead.
         """
 
-        candidates = self.candidates(source, limit=1)
+        candidates = self.candidates(source, limit=1, max_distance=max_distance)
         if not candidates:
             return None
         best = candidates[0]

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5406,7 +5406,12 @@ class CardEditorApp:
         if not getattr(self, "hash_db", None):
             return None
         try:
-            candidates = self.hash_db.candidates(fp, limit=5)
+            best = self.hash_db.best_match(fp, max_distance=HASH_MATCH_THRESHOLD)
+            if not best:
+                return None
+            candidates = self.hash_db.candidates(
+                fp, limit=5, max_distance=HASH_MATCH_THRESHOLD
+            )
         except Exception as exc:
             logger.warning("Fingerprint lookup failed: %s", exc)
             return None

--- a/tests/test_hash_db_performance.py
+++ b/tests/test_hash_db_performance.py
@@ -1,0 +1,41 @@
+import timeit
+import numpy as np
+
+from hash_db import HashDB
+
+
+def _random_fp():
+    return {
+        "phash": np.random.randint(0, 2, (8, 8), dtype=np.uint8),
+        "dhash": np.random.randint(0, 2, (8, 8), dtype=np.uint8),
+        "tile_phash": np.random.randint(0, 2, (4, 8, 8), dtype=np.uint8),
+        "orb": np.empty((0, 32), dtype=np.uint8),
+    }
+
+
+def _best_match_old(db: HashDB, source, max_distance: int):
+    candidates = db.candidates(source, limit=1)
+    if not candidates:
+        return None
+    best = candidates[0]
+    if best.distance > max_distance:
+        return None
+    return best
+
+
+def test_best_match_performance():
+    db = HashDB()
+    fp = _random_fp()
+    db.add_card_from_fp(fp, meta={"id": "match"})
+    for i in range(1000):
+        db.add_card_from_fp(_random_fp(), meta={"id": str(i)})
+
+    def run_old():
+        assert _best_match_old(db, fp, 5) is not None
+
+    def run_new():
+        assert db.best_match(fp, max_distance=5) is not None
+
+    old_time = timeit.timeit(run_old, number=3)
+    new_time = timeit.timeit(run_new, number=3)
+    assert new_time < old_time

--- a/tests/test_lookup_fp_candidate.py
+++ b/tests/test_lookup_fp_candidate.py
@@ -27,22 +27,37 @@ def test_lookup_fp_candidate_threshold(monkeypatch):
         return "chosen"
 
     # mixed candidates: dialog should receive only the valid one
+    candidate_calls: list[int] = []
+
+    def fake_candidates(fp, limit=5, max_distance=None):
+        candidate_calls.append(1)
+        return [good, bad]
+
     app = SimpleNamespace(
-        hash_db=SimpleNamespace(candidates=lambda fp, limit=5: [good, bad]),
+        hash_db=SimpleNamespace(
+            best_match=lambda fp, max_distance=None: good,
+            candidates=fake_candidates,
+        ),
         _show_candidates_dialog=fake_dialog,
     )
     result = ui.CardEditorApp._lookup_fp_candidate(app, fp)
     assert result == "chosen"
     assert calls == [[good]]
+    assert candidate_calls == [1]
 
     calls.clear()
+    candidate_calls.clear()
 
     # only invalid candidate: dialog should not be invoked
     app = SimpleNamespace(
-        hash_db=SimpleNamespace(candidates=lambda fp, limit=5: [bad]),
+        hash_db=SimpleNamespace(
+            best_match=lambda fp, max_distance=None: None,
+            candidates=fake_candidates,
+        ),
         _show_candidates_dialog=fake_dialog,
     )
     result = ui.CardEditorApp._lookup_fp_candidate(app, fp)
     assert result is None
     assert calls == []
+    assert candidate_calls == []
 


### PR DESCRIPTION
## Summary
- allow HashDB to filter candidates by max distance and stop when enough matches found
- use best_match threshold in _lookup_fp_candidate before loading extra candidates
- add benchmark comparing new best_match against previous approach

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baca345be8832fbc2959ba5c9c83a7