### PR TITLE
cache magazyn.csv mtime for conditional reload

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1600,6 +1600,7 @@ class CardEditorApp:
         self.mag_progressbars: dict[tuple[int, int], ctk.CTkProgressBar] = {}
         self.mag_percent_labels: dict[tuple[int, int], ctk.CTkLabel] = {}
         self.mag_labels: list[ctk.CTkLabel] = []
+        self._mag_csv_mtime: Optional[float] = None
         self.log_widget = None
         self.cheat_frame = None
         self.set_logos = {}
@@ -3246,6 +3247,7 @@ class CardEditorApp:
 
         if not os.path.exists(csv_path):
             self._mag_prev_thumb = 0
+            self._mag_csv_mtime = None
             return
 
         with open(csv_path, encoding="utf-8") as f:
@@ -3339,6 +3341,10 @@ class CardEditorApp:
                         self.mag_card_images[idx] = photo
 
         self._mag_prev_thumb = 0
+        try:
+            self._mag_csv_mtime = os.path.getmtime(csv_path)
+        except OSError:
+            self._mag_csv_mtime = None
 
     def show_magazyn_view(self):
         """Display storage occupancy inside the main window."""
@@ -3925,9 +3931,15 @@ class CardEditorApp:
 
     def refresh_magazyn(self):
         """Refresh storage view and update column usage bars."""
-        reload_fn = getattr(self, "reload_mag_cards", None)
-        if callable(reload_fn):
-            reload_fn()
+        csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
+        try:
+            current_mtime = os.path.getmtime(csv_path)
+        except OSError:
+            current_mtime = None
+        if getattr(self, "_mag_csv_mtime", None) != current_mtime:
+            reload_fn = getattr(self, "reload_mag_cards", None)
+            if callable(reload_fn):
+                reload_fn()
         update_fn = getattr(self, "_update_mag_list", None)
         if callable(update_fn):
             try:

--- a/tests/test_refresh_magazyn_mtime.py
+++ b/tests/test_refresh_magazyn_mtime.py
@@ -1,0 +1,50 @@
+import importlib
+import sys
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_refresh_magazyn_skips_reload_if_mtime_unchanged(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text(
+        "name;number;set;warehouse_code;price;image;sold\n", encoding="utf-8"
+    )
+
+    sys.modules.setdefault("customtkinter", MagicMock())
+    sys.modules.setdefault("tkinter", MagicMock())
+    sys.modules.setdefault("tkinter.ttk", MagicMock())
+    sys.modules.setdefault("PIL", MagicMock())
+    sys.modules.setdefault("PIL.Image", MagicMock())
+    sys.modules.setdefault("PIL.ImageTk", MagicMock())
+    sys.modules.setdefault("imagehash", MagicMock())
+    sys.modules.setdefault("openai", MagicMock())
+    sys.modules.setdefault("requests", MagicMock())
+    sys.modules.setdefault("pydantic", MagicMock())
+    sys.modules.setdefault("pytesseract", MagicMock())
+    sys.modules.setdefault("dotenv", MagicMock())
+    sys.modules.setdefault("numpy", MagicMock())
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
+
+    mtime = os.path.getmtime(csv_path)
+    reload_called = False
+
+    def reload_mock():
+        nonlocal reload_called
+        reload_called = True
+
+    app = SimpleNamespace(
+        _mag_csv_mtime=mtime,
+        reload_mag_cards=reload_mock,
+        _update_mag_list=lambda: None,
+        mag_progressbars={},
+    )
+
+    ui.CardEditorApp.refresh_magazyn(app)
+    assert not reload_called


### PR DESCRIPTION
## Summary
- track last modification time of `magazyn.csv`
- reload warehouse cards only if the CSV timestamp changes
- add regression test for conditional reload logic

## Testing
- `pytest tests/test_refresh_magazyn_mtime.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68bfbf13995c832fb7f68bf77fa461cf