### PR TITLE
Cache and reuse magazyn column occupancy

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3244,15 +3244,18 @@ class CardEditorApp:
         self.mag_card_image_labels = []
         self.mag_card_frames = []
         self._image_threads = []
+        self._mag_column_occ: dict[tuple[int, int], int] = {}
 
         if not os.path.exists(csv_path):
             self._mag_prev_thumb = 0
             self._mag_csv_mtime = None
+            self._mag_column_occ = {}
             return
 
         with open(csv_path, encoding="utf-8") as f:
             reader = csv.DictReader(f, delimiter=";")
             groups: dict[tuple[str, ...], list[dict]] = defaultdict(list)
+            column_occ: dict[tuple[int, int], int] = {}
             for row in reader:
                 if not row.get("name"):
                     logger.warning("Skipping row with missing name: %s", row)
@@ -3265,6 +3268,21 @@ class CardEditorApp:
                     str(row.get("sold") or ""),
                 )
                 groups[key].append(row)
+
+                if str(row.get("sold") or "").lower() in {"1", "true", "yes"}:
+                    continue
+                codes = str(row.get("warehouse_code") or "").split(";")
+                for code in codes:
+                    code = code.strip()
+                    if not code:
+                        continue
+                    m = re.match(r"K(\d+)R(\d)P(\d+)", code)
+                    if not m:
+                        continue
+                    box = int(m.group(1))
+                    col = int(m.group(2))
+                    column_occ[(box, col)] = column_occ.get((box, col), 0) + 1
+            self._mag_column_occ = column_occ
 
             for rows in groups.values():
                 combined = dict(rows[0])
@@ -3950,10 +3968,10 @@ class CardEditorApp:
         if not getattr(self, "mag_progressbars", None):
             return
 
-        col_occ = storage.compute_column_occupancy()
+        col_occ = getattr(self, "_mag_column_occ", {})
 
         for (box, col), bar in self.mag_progressbars.items():
-            filled = col_occ.get(box, {}).get(col, 0)
+            filled = col_occ.get((box, col), 0)
             columns = storage.BOX_COLUMNS.get(box, 4)
             total_capacity = storage.BOX_CAPACITY.get(
                 box, columns * storage.BOX_COLUMN_CAPACITY

--- a/tests/test_magazyn_column_cache.py
+++ b/tests/test_magazyn_column_cache.py
@@ -1,0 +1,71 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_refresh_magazyn_uses_cached_columns(tmp_path, monkeypatch):
+    csv_path = tmp_path / "magazyn.csv"
+    csv_path.write_text("name;number;set;warehouse_code;price;image;sold\n", encoding="utf-8")
+
+    sys.modules.setdefault("customtkinter", MagicMock())
+    sys.modules.setdefault("tkinter", MagicMock())
+    sys.modules.setdefault("tkinter.ttk", MagicMock())
+    sys.modules.setdefault("PIL", MagicMock())
+    sys.modules.setdefault("PIL.Image", MagicMock())
+    sys.modules.setdefault("PIL.ImageTk", MagicMock())
+    sys.modules.setdefault("imagehash", MagicMock())
+    sys.modules.setdefault("openai", MagicMock())
+    sys.modules.setdefault("requests", MagicMock())
+    sys.modules.setdefault("pydantic", MagicMock())
+    sys.modules.setdefault("pytesseract", MagicMock())
+    sys.modules.setdefault("dotenv", MagicMock())
+    sys.modules.setdefault("numpy", MagicMock())
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+    import kartoteka.ui as ui
+    importlib.reload(ui)
+
+    monkeypatch.setattr(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path))
+
+    def boom():  # pragma: no cover - ensures no file read
+        raise AssertionError("compute_column_occupancy called")
+
+    monkeypatch.setattr(ui.storage, "compute_column_occupancy", boom)
+
+    class DummyBar:
+        def __init__(self):
+            self.value = None
+
+        def set(self, value):
+            self.value = value
+
+    class DummyLabel:
+        def __init__(self):
+            self.kwargs = {}
+
+        def configure(self, **kwargs):
+            self.kwargs.update(kwargs)
+
+    bar1 = DummyBar()
+    bar2 = DummyBar()
+    lbl1 = DummyLabel()
+    lbl2 = DummyLabel()
+
+    app = SimpleNamespace(
+        _mag_csv_mtime=os.path.getmtime(csv_path),
+        _update_mag_list=lambda: None,
+        mag_progressbars={(1, 1): bar1, (1, 2): bar2},
+        mag_percent_labels={(1, 1): lbl1, (1, 2): lbl2},
+        _mag_column_occ={(1, 1): 500, (1, 2): 1000},
+        update_inventory_stats=lambda: None,
+    )
+
+    ui.CardEditorApp.refresh_magazyn(app)
+
+    assert bar1.value == 0.5
+    assert bar2.value == 1.0
+    assert lbl1.kwargs.get("text") == "50%"
+    assert lbl2.kwargs.get("text") == "100%"


### PR DESCRIPTION
## Summary
- Track per-column occupancy when loading magazyn cards
- Reuse cached column occupancy in magazyn refresh
- Test refresh uses cached data without reading file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfc1e743e4832fafe03604aa31d35a