### PR TITLE
Load local thumbnails asynchronously

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3318,10 +3318,10 @@ class CardEditorApp:
                         img = _load_image(url)
                         if img is None:
                             return
-                        img = _resize_to_width(img, thumb_size)
 
                         def _update(img=img) -> None:
-                            photo = _create_image(img)
+                            img_resized = _resize_to_width(img, thumb_size)
+                            photo = _create_image(img_resized)
                             self.mag_card_images[i] = photo
                             lbl = self.mag_card_image_labels[i]
                             exists_fn = getattr(lbl, "winfo_exists", None)
@@ -3352,11 +3352,43 @@ class CardEditorApp:
                     th.start()
                     self._image_threads.append(th)
                 else:
-                    img = _load_image(img_path)
-                    if img is not None:
-                        img = _resize_to_width(img, thumb_size)
-                        photo = _create_image(img)
-                        self.mag_card_images[idx] = photo
+                    def _worker(i=idx, path=img_path):
+                        img = _load_image(path)
+                        if img is None:
+                            return
+
+                        def _update(img=img) -> None:
+                            img_resized = _resize_to_width(img, thumb_size)
+                            photo = _create_image(img_resized)
+                            self.mag_card_images[i] = photo
+                            lbl = self.mag_card_image_labels[i]
+                            exists_fn = getattr(lbl, "winfo_exists", None)
+                            if not lbl or (exists_fn and not exists_fn()):
+                                return
+                            if hasattr(lbl, "configure"):
+                                try:
+                                    lbl.configure(image=photo)
+                                except tk.TclError:
+                                    return
+                            else:  # simple dummy widgets in tests
+                                lbl.image = photo
+                            relayout = getattr(self, "_relayout_mag_cards", None)
+                            if callable(relayout):
+                                after2 = getattr(self.root, "after", None)
+                                if callable(after2):
+                                    after2(0, relayout)
+                                else:
+                                    relayout()
+
+                        after = getattr(self.root, "after", None)
+                        if callable(after):
+                            after(0, _update)
+                        else:
+                            _update()
+
+                    th = threading.Thread(target=_worker, daemon=True)
+                    th.start()
+                    self._image_threads.append(th)
 
         self._mag_prev_thumb = 0
         try:

--- a/tests/test_remote_image_loading.py
+++ b/tests/test_remote_image_loading.py
@@ -199,6 +199,56 @@ def test_show_magazyn_view_remote_thumbnail(tmp_path):
     assert app.mag_card_images[0] is photo_mock
 
 
+def test_show_magazyn_view_local_thumbnail(tmp_path):
+    ui = _setup_module(tmp_path)
+
+    img_path = tmp_path / "card.png"
+    Image.new("RGB", (10, 10), "white").save(img_path, format="PNG")
+    csv_path = tmp_path / "magazyn.csv"
+    _write_csv(csv_path, str(img_path))
+
+    placeholder_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
+    photo_mock = SimpleNamespace(width=lambda: 64, height=lambda: 64)
+
+    dummy_root = SimpleNamespace(
+        minsize=lambda *a, **k: None,
+        title=lambda *a, **k: None,
+    )
+
+    app = SimpleNamespace(
+        root=dummy_root,
+        start_frame=None,
+        pricing_frame=None,
+        shoper_frame=None,
+        frame=None,
+        magazyn_frame=None,
+        location_frame=None,
+        create_button=lambda master, **kwargs: DummyCTkButton(master, **kwargs),
+        refresh_magazyn=lambda: None,
+        back_to_welcome=lambda: None,
+        show_card_details=lambda *a, **k: None,
+    )
+
+    calls = iter([placeholder_mock, photo_mock])
+
+    def _photo_side_effect(*a, **k):
+        try:
+            return next(calls)
+        except StopIteration:
+            return photo_mock
+
+    with patch.object(ui.ImageTk, "PhotoImage", side_effect=_photo_side_effect), \
+         patch.object(ui.tk, "Canvas", DummyCanvas), \
+         patch.object(ui.csv_utils, "WAREHOUSE_CSV", str(csv_path)), \
+         patch.object(ui.messagebox, "showinfo", lambda *a, **k: None):
+        ui.CardEditorApp.show_magazyn_view(app)
+        assert app._image_threads  # ensures a thread was spawned
+        for t in app._image_threads:
+            t.join()
+
+    assert app.mag_card_images[0] is photo_mock
+
+
 def test_show_card_details_remote_uses_cache(tmp_path):
     ui = _setup_module(tmp_path)
 


### PR DESCRIPTION
## Summary
- load local warehouse card thumbnails using background threads like remote URLs
- schedule resizing and image creation via `root.after` so UI updates happen in the main thread
- verify GUI stays responsive while loading local thumbnails

## Testing
- `pytest tests/test_remote_image_loading.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfc35f7058832fad69de33ae0d118a