### PR TITLE
centralize storage constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ Examples:
 * `PKM-BS-1-R`
 
 When exporting, the application creates a single consolidated CSV file. Entries with the same card code are merged so duplicates appear only once.
+
+## Storage configuration
+
+Box layout and capacities are centralised in `kartoteka/storage_config.py`.
+The module defines shared constants such as the number of regular boxes
+(`BOX_COUNT`), column counts (`STANDARD_BOX_COLUMNS`), per-column capacity
+(`BOX_COLUMN_CAPACITY`), total capacity of each box (`BOX_CAPACITY`), and
+details for the overflow box (`SPECIAL_BOX_NUMBER`, `SPECIAL_BOX_CAPACITY`).
+Both `storage.py` and `ui.py` import these values so any changes to the
+physical warehouse setup only need to be made in a single place.

--- a/kartoteka/storage.py
+++ b/kartoteka/storage.py
@@ -2,24 +2,24 @@ import csv
 import re
 from datetime import datetime
 from . import csv_utils
+from .storage_config import (
+    BOX_CAPACITY,
+    BOX_COLUMNS,
+    BOX_COLUMN_CAPACITY,
+    BOX_COUNT,
+    SPECIAL_BOX_CAPACITY,
+    SPECIAL_BOX_NUMBER,
+    STANDARD_BOX_CAPACITY,
+    STANDARD_BOX_COLUMNS,
+)
 
 LAST_SETS_CHECK_FILE = "last_sets_check.txt"
 LAST_LOCATION_FILE = "last_location.txt"
 
-# Total card capacity per storage box.  Standard boxes hold 4000 cards in
-# four columns, while the special box ``100`` is a single 500-card column.
-BOX_COUNT = 10  # number of standard boxes
-BOX_CAPACITY: dict[int, int] = {**{b: 4000 for b in range(1, BOX_COUNT + 1)}, 100: 500}
-
-# Number of columns per storage box.  All regular boxes (1-10) have four
-# columns, while the overflow box ``100`` only one.  The mapping is kept
-# explicit so the column layout can be adjusted independently of
-# :data:`BOX_CAPACITY`.
-BOX_COLUMNS: dict[int, int] = {**{b: 4 for b in range(1, BOX_COUNT + 1)}, 100: 1}
-
-# Default per-column capacity for standard boxes.  Used as a fallback when
-# handling boxes outside of :data:`BOX_CAPACITY`.
-BOX_COLUMN_CAPACITY = 1000
+# Constants are provided by :mod:`kartoteka.storage_config` to keep the storage
+# layout in one place.  The mappings above describe the capacity and column
+# counts for each storage box.  ``STANDARD_BOX_CAPACITY`` and
+# ``BOX_COLUMN_CAPACITY`` are used when performing index calculations.
 
 
 class NoFreeLocationError(Exception):
@@ -86,9 +86,13 @@ def location_to_index(code: str) -> int:
     if not match:
         return 0
     box, column, pos = map(int, match.groups())
-    if box == 100:
-        return BOX_COUNT * 4000 + (pos - 1)
-    return (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
+    if box == SPECIAL_BOX_NUMBER:
+        return BOX_COUNT * STANDARD_BOX_CAPACITY + (pos - 1)
+    return (
+        (box - 1) * STANDARD_BOX_CAPACITY
+        + (column - 1) * BOX_COLUMN_CAPACITY
+        + (pos - 1)
+    )
 
 
 def location_from_code(code: str) -> str:
@@ -102,22 +106,24 @@ def location_from_code(code: str) -> str:
 def generate_location(idx):
     """Return a warehouse code for a sequential slot index.
 
-    The first 40 000 indices map to boxes 1-10 (four 1000-card columns each).
-    Subsequent indices map to the special box 100 which has a single
-    500-card column.
+    The first ``BOX_COUNT * STANDARD_BOX_CAPACITY`` indices map to boxes
+    ``1`` through ``BOX_COUNT`` (each consisting of
+    ``STANDARD_BOX_COLUMNS`` columns of ``BOX_COLUMN_CAPACITY`` slots).
+    Subsequent indices map to the special box ``SPECIAL_BOX_NUMBER`` which
+    has a single ``SPECIAL_BOX_CAPACITY``-card column.
     """
 
-    if idx < BOX_COUNT * 4000:
-        pos = idx % 1000 + 1
-        column = (idx // 1000) % 4 + 1
-        box = (idx // 4000) + 1
+    if idx < BOX_COUNT * STANDARD_BOX_CAPACITY:
+        pos = idx % BOX_COLUMN_CAPACITY + 1
+        column = (idx // BOX_COLUMN_CAPACITY) % STANDARD_BOX_COLUMNS + 1
+        box = (idx // STANDARD_BOX_CAPACITY) + 1
         return f"K{box:02d}R{column}P{pos:04d}"
 
-    idx -= BOX_COUNT * 4000
-    if idx < 500:
+    idx -= BOX_COUNT * STANDARD_BOX_CAPACITY
+    if idx < SPECIAL_BOX_CAPACITY:
         # box 100, only one column
         pos = idx + 1
-        return f"K100R1P{pos:04d}"
+        return f"K{SPECIAL_BOX_NUMBER}R1P{pos:04d}"
 
     raise ValueError("Index out of range for known storage boxes")
 
@@ -136,10 +142,14 @@ def next_free_location(app):
             box = int(match.group(1))
             column = int(match.group(2))
             pos = int(match.group(3))
-            if box == 100:
-                idx = BOX_COUNT * 4000 + (pos - 1)
+            if box == SPECIAL_BOX_NUMBER:
+                idx = BOX_COUNT * STANDARD_BOX_CAPACITY + (pos - 1)
             else:
-                idx = (box - 1) * 4000 + (column - 1) * 1000 + (pos - 1)
+                idx = (
+                    (box - 1) * STANDARD_BOX_CAPACITY
+                    + (column - 1) * BOX_COLUMN_CAPACITY
+                    + (pos - 1)
+                )
             used.add(idx)
 
     last_idx = load_last_location() if not output_data else 0
@@ -159,7 +169,10 @@ def compute_column_occupancy() -> dict[int, dict[int, int]]:
     """
 
     occ: dict[int, dict[int, int]] = {
-        box: {col: 0 for col in range(1, BOX_COLUMNS.get(box, 4) + 1)}
+        box: {
+            col: 0
+            for col in range(1, BOX_COLUMNS.get(box, STANDARD_BOX_COLUMNS) + 1)
+        }
         for box in BOX_COLUMNS
     }
     try:

--- a/kartoteka/storage_config.py
+++ b/kartoteka/storage_config.py
@@ -1,0 +1,46 @@
+"""Shared configuration for storage boxes.
+
+This module centralizes storage-related constants used by both the backend
+and UI.  Adjust the values here to match the physical warehouse layout and
+all modules will pick up the changes automatically.
+"""
+
+from __future__ import annotations
+
+# Basic box layout -----------------------------------------------------------
+
+# Number of regularly sized boxes available.
+BOX_COUNT = 10
+
+# Regular boxes have four columns and each column can hold ``BOX_COLUMN_CAPACITY``
+# cards.  Adjust these numbers to match the real storage boxes.
+STANDARD_BOX_COLUMNS = 4
+BOX_COLUMN_CAPACITY = 1000
+
+# Total capacity for a standard box.
+STANDARD_BOX_CAPACITY = STANDARD_BOX_COLUMNS * BOX_COLUMN_CAPACITY
+
+# Special overflow box -------------------------------------------------------
+
+# Identifier of the overflow box.  It differs in layout from the regular ones
+# and typically has reduced capacity.
+SPECIAL_BOX_NUMBER = 100
+SPECIAL_BOX_COLUMNS = 1
+SPECIAL_BOX_CAPACITY = 500
+
+# Derived mappings -----------------------------------------------------------
+
+# Mapping of ``box -> total capacity``.  Regular boxes use
+# ``STANDARD_BOX_CAPACITY`` while the overflow box has
+# ``SPECIAL_BOX_CAPACITY``.
+BOX_CAPACITY: dict[int, int] = {
+    **{b: STANDARD_BOX_CAPACITY for b in range(1, BOX_COUNT + 1)},
+    SPECIAL_BOX_NUMBER: SPECIAL_BOX_CAPACITY,
+}
+
+# Mapping of ``box -> column count``.  Regular boxes share the same column
+# layout while the overflow box has its own.
+BOX_COLUMNS: dict[int, int] = {
+    **{b: STANDARD_BOX_COLUMNS for b in range(1, BOX_COUNT + 1)},
+    SPECIAL_BOX_NUMBER: SPECIAL_BOX_COLUMNS,
+}

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -69,6 +69,14 @@ except ImportError as exc:  # pragma: no cover - optional dependency
 from fingerprint import compute_fingerprint
 from tooltip import Tooltip
 from .image_utils import load_rgba_image
+from .storage_config import (
+    BOX_COUNT,
+    BOX_COLUMN_CAPACITY,
+    SPECIAL_BOX_CAPACITY,
+    SPECIAL_BOX_NUMBER,
+    STANDARD_BOX_CAPACITY,
+    STANDARD_BOX_COLUMNS,
+)
 
 # Ensure tkinter dialog modules provide the expected functions even when tests
 # replace them with simple stubs.  Missing attributes are replaced with no-op
@@ -164,7 +172,7 @@ def draw_box_usage(canvas: "tk.Canvas", box_num: int, occupancy: dict[int, int])
 
     box_w = BOX_THUMB_SIZE
     box_h = BOX_THUMB_SIZE
-    columns = storage.BOX_COLUMNS.get(box_num, 4)
+    columns = storage.BOX_COLUMNS.get(box_num, STANDARD_BOX_COLUMNS)
     total_capacity = storage.BOX_CAPACITY.get(
         box_num, columns * storage.BOX_COLUMN_CAPACITY
     )
@@ -403,13 +411,11 @@ CARD_THUMB_SIZE = 160  # larger card thumbnails in the warehouse list
 # Maximum allowed size for card thumbnails; used to cap dynamic calculations
 MAX_CARD_THUMB_SIZE = 160
 MAG_CARD_GAP = 3  # spacing between card frames in magazine view
-GRID_COLUMNS = 4  # number of columns per storage box
+GRID_COLUMNS = STANDARD_BOX_COLUMNS  # number of columns per storage box
 WAREHOUSE_GRID_COLUMNS = 5  # number of columns in the warehouse grid
-BOX_COLUMN_CAPACITY = 1000  # slots per column in a regular box
-BOX_COUNT = 10  # number of standard boxes
-SPECIAL_BOX_NUMBER = 100  # identifier for the large overflow box
-SPECIAL_BOX_CAPACITY = 500  # slots in the special box
-BOX_CAPACITY = GRID_COLUMNS * BOX_COLUMN_CAPACITY  # slots in a standard box
+# BOX_COLUMN_CAPACITY, BOX_COUNT, SPECIAL_BOX_NUMBER and SPECIAL_BOX_CAPACITY
+# are imported from :mod:`kartoteka.storage_config`.
+BOX_CAPACITY = STANDARD_BOX_CAPACITY  # slots in a standard box
 
 
 def _occupancy_color(value: float) -> str:
@@ -3213,7 +3219,9 @@ class CardEditorApp:
             )
             lbl.pack(anchor="w")
             self.mag_labels.append(lbl)
-            for col in range(1, storage.BOX_COLUMNS.get(box_num, 4) + 1):
+            for col in range(
+                1, storage.BOX_COLUMNS.get(box_num, STANDARD_BOX_COLUMNS) + 1
+            ):
                 row_frame = ctk.CTkFrame(frame, fg_color=BG_COLOR)
                 row_frame.pack(fill="x", padx=2, pady=2)
                 bar = ctk.CTkProgressBar(


### PR DESCRIPTION
## Summary
- extract storage constants to `storage_config.py`
- use shared constants across `storage.py` and `ui.py`
- document storage configuration in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfd02c739c832f8de8b8ba786fbe6b