### PR TITLE
Increase overflow box capacity

### DIFF
--- a/kartoteka/storage_config.py
+++ b/kartoteka/storage_config.py
@@ -25,8 +25,8 @@ STANDARD_BOX_CAPACITY = STANDARD_BOX_COLUMNS * BOX_COLUMN_CAPACITY
 # Identifier of the overflow box.  It differs in layout from the regular ones
 # and typically has reduced capacity.
 SPECIAL_BOX_NUMBER = 100
-SPECIAL_BOX_COLUMNS = 1
-SPECIAL_BOX_CAPACITY = 500
+SPECIAL_BOX_COLUMNS = 2
+SPECIAL_BOX_CAPACITY = 2000
 
 # Derived mappings -----------------------------------------------------------
 

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -29,7 +29,7 @@ def test_compute_box_occupancy_box100(tmp_path, monkeypatch):
     occ = storage.compute_box_occupancy()
     assert occ[100] == 1
     percent = occ[100] / storage.BOX_CAPACITY[100] * 100
-    assert percent == pytest.approx(0.2)
+    assert percent == pytest.approx(0.05)
 
 
 def test_generate_and_next_free_location_box100():
@@ -93,7 +93,7 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
     from kartoteka import storage
 
     percent = occ[100] / storage.BOX_CAPACITY[100] * 100
-    assert percent == pytest.approx(0.2)
+    assert percent == pytest.approx(0.05)
 
     bar = app.mag_progressbars[(100, 1)]
-    assert bar.get() == pytest.approx(1 / ui.storage.BOX_CAPACITY[100])
+    assert bar.get() == pytest.approx(1 / ui.storage.BOX_COLUMN_CAPACITY)

--- a/tests/test_no_free_location.py
+++ b/tests/test_no_free_location.py
@@ -18,7 +18,7 @@ import kartoteka.ui as ui
 
 
 def test_next_free_location_raises_when_full():
-    dummy = SimpleNamespace(output_data=[{"warehouse_code": "K100R1P0500"}])
+    dummy = SimpleNamespace(output_data=[{"warehouse_code": "K100R2P1000"}])
     with pytest.raises(storage.NoFreeLocationError):
         storage.next_free_location(dummy)
 


### PR DESCRIPTION
## Summary
- expand special overflow box to two columns and 2000 slots
- update box 100 tests for new capacity and progress bar scaling
- adjust full-box sentinel to match final slot code

## Testing
- `pytest tests/test_box100.py tests/test_no_free_location.py`

------
https://chatgpt.com/codex/tasks/task_e_68bfdbe2ec18832f81101bbd5b8159da