### PR TITLE
Guard OpenAI client and refresh tests

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -42,8 +42,6 @@ else:  # pragma: no cover - optional dependency
         openai.chat = SimpleNamespace(
             completions=SimpleNamespace(create=lambda *a, **k: None)
         )
-    # provide a no-op client so tests don't require a real API key
-    openai.OpenAI = lambda *a, **k: SimpleNamespace()
 
 from shoper_client import ShoperClient
 from webdav_client import WebDAVClient
@@ -112,8 +110,11 @@ WEBDAV_URL = os.getenv("WEBDAV_URL")
 WEBDAV_USER = os.getenv("WEBDAV_USER")
 WEBDAV_PASSWORD = os.getenv("WEBDAV_PASSWORD")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+USE_OPENAI_STUB = not OPENAI_API_KEY or os.getenv("OPENAI_TEST_MODE")
 if OPENAI_API_KEY:
     openai.api_key = OPENAI_API_KEY
+if USE_OPENAI_STUB:
+    openai.OpenAI = lambda *a, **k: SimpleNamespace()
 
 PRICE_DB_PATH = "card_prices.csv"
 PRICE_MULTIPLIER = 1.23

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -36,6 +36,7 @@ class DummyVar:
 
 def test_extract_card_info_openai_maps_set(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
 
     img = tmp_path / "x.jpg"
     img.write_bytes(b"data")

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -22,6 +22,7 @@ SV01_NAME = ui.get_set_name(SV01_CODE)
 
 def test_parse_code_fence(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
 
     img = tmp_path / "x.jpg"
     img.write_bytes(b"data")


### PR DESCRIPTION
## Summary
- Guard the OpenAI client so a stub is only installed when no API key or OPENAI_TEST_MODE is set
- Reload ui module in tests and monkeypatch `openai.OpenAI` explicitly

## Testing
- `pytest` *(fails: test_download_warehouse_csv.py::test_local_warehouse_csv_exists)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdef7c58c832f895977722b23f080