### PR TITLE
Use logger for missing set warnings

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -650,8 +650,9 @@ def get_set_name(code: str) -> str:
         for key, name in mapping.items():
             if key.lower() == search:
                 return name
-    print(
-        f"Nie znaleziono nazwy dla setu '{code}'. Weryfikacja ręczna wymagana."
+    logger.warning(
+        "Nie znaleziono nazwy dla setu '%s'. Weryfikacja ręczna wymagana.",
+        code,
     )
     return code
 

--- a/tests/test_get_set_name.py
+++ b/tests/test_get_set_name.py
@@ -2,6 +2,7 @@ import importlib
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
+import logging
 
 sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -9,12 +10,12 @@ import kartoteka.ui as ui  # noqa: E402
 importlib.reload(ui)  # ensure globals use stubbed modules
 
 
-def test_get_set_name_unknown_triggers_warning(capsys):
+def test_get_set_name_unknown_triggers_warning(caplog):
     code = "not_in_map"
-    result = ui.get_set_name(code)
-    captured = capsys.readouterr()
+    with caplog.at_level(logging.WARNING, logger="kartoteka.ui"):
+        result = ui.get_set_name(code)
     assert result == code
-    assert "Weryfikacja ręczna wymagana" in captured.out
+    assert "Weryfikacja ręczna wymagana" in caplog.text
 
 
 def test_get_set_name_from_abbr():


### PR DESCRIPTION
## Summary
- use logger.warning when set name lookup fails
- adjust tests to capture warning via logging

## Testing
- `pytest` *(fails: 65 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68bfe1e3fb50832fbcc51d147d18dff3