### PR TITLE
Handle missing price data in Cardmarket extraction

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -895,7 +895,8 @@ def extract_cardmarket_price(card):
     ``None`` is returned when no positive price can be determined.
     """
 
-    cardmarket = card.get("prices", {}).get("cardmarket", {}) or {}
+    prices = (card or {}).get("prices") or {}
+    cardmarket = prices.get("cardmarket") or {}
 
     def _get_float(key: str) -> float:
         try:

--- a/tests/test_extract_cardmarket_price.py
+++ b/tests/test_extract_cardmarket_price.py
@@ -4,6 +4,9 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 sys.modules.setdefault("customtkinter", MagicMock())
+sys.modules.setdefault("imagehash", MagicMock())
+sys.modules.setdefault("pytesseract", MagicMock())
+sys.modules.setdefault("fingerprint", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import kartoteka.ui as ui
 importlib.reload(ui)
@@ -22,3 +25,13 @@ def test_single_metric_fallback():
 def test_lowest_near_mint_fallback():
     card = {"prices": {"cardmarket": {"lowest_near_mint": 5}}}
     assert ui.extract_cardmarket_price(card) == 5
+
+
+def test_missing_prices():
+    card = {}
+    assert ui.extract_cardmarket_price(card) is None
+
+
+def test_none_prices():
+    card = {"prices": None}
+    assert ui.extract_cardmarket_price(card) is None


### PR DESCRIPTION
## Summary
- Guard `extract_cardmarket_price` against `None` or missing `prices`
- Test price extraction when price data is missing or `None`

## Testing
- `pytest tests/test_extract_cardmarket_price.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfee89345c832f8b156d9bc3cf24a0