### PR TITLE
Add max price and order stats

### DIFF
--- a/kartoteka/stats_utils.py
+++ b/kartoteka/stats_utils.py
@@ -72,6 +72,7 @@ def get_statistics(start: date, end: date, path: str | None = None) -> Dict:
     sets_by_value: Dict[str, float] = defaultdict(float)
     boxes_by_count: Dict[int, int] = defaultdict(int)
     boxes_by_value: Dict[int, float] = defaultdict(float)
+    max_price = 0.0
 
     for row in filtered:
         price_raw = str(row.get("price") or "0").replace(",", ".")
@@ -85,6 +86,8 @@ def get_statistics(start: date, end: date, path: str | None = None) -> Dict:
         sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
         if sold:
             sold_count += 1
+            if price > max_price:
+                max_price = price
         else:
             unsold_count += 1
 
@@ -123,6 +126,7 @@ def get_statistics(start: date, end: date, path: str | None = None) -> Dict:
     avg_price = cumulative_value / cumulative_count if cumulative_count else 0.0
     sold_ratio = sold_count / cumulative_count if cumulative_count else 0.0
     unsold_ratio = unsold_count / cumulative_count if cumulative_count else 0.0
+    max_order = max((stats.get("sold", 0) for stats in daily.values()), default=0)
 
     return {
         "cumulative": {"count": cumulative_count, "total_value": cumulative_value},
@@ -134,6 +138,8 @@ def get_statistics(start: date, end: date, path: str | None = None) -> Dict:
         "average_price": avg_price,
         "sold_ratio": sold_ratio,
         "unsold_ratio": unsold_ratio,
+        "max_price": max_price,
+        "max_order": max_order,
     }
 
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2428,31 +2428,8 @@ class CardEditorApp:
             count = cumulative.get("count", 0)
             total_value = cumulative.get("total_value", 0.0)
             daily = data.get("daily", {})
-            max_order = max((d.get("sold", 0) for d in daily.values()), default=0)
-            max_price = 0.0
-            try:
-                with open(csv_utils.WAREHOUSE_CSV, encoding="utf-8") as f:
-                    reader = csv.DictReader(f, delimiter=";")
-                    for row in reader:
-                        added = str(row.get("added_at") or "")
-                        try:
-                            added_date = datetime.date.fromisoformat(added.split("T", 1)[0])
-                        except ValueError:
-                            continue
-                        if not (start <= added_date <= end):
-                            continue
-                        sold = str(row.get("sold") or "").lower() in {"1", "true", "yes"}
-                        if not sold:
-                            continue
-                        price_raw = str(row.get("price") or "0").replace(",", ".")
-                        try:
-                            price = float(price_raw)
-                        except ValueError:
-                            price = 0.0
-                        if price > max_price:
-                            max_price = price
-            except OSError:
-                pass
+            max_order = data.get("max_order", 0)
+            max_price = data.get("max_price", 0.0)
 
             self.stats_total_label.configure(
                 text=f"Wartość kolekcji: {total_value:.2f} zł"

--- a/tests/test_statistics_helpers.py
+++ b/tests/test_statistics_helpers.py
@@ -33,6 +33,8 @@ def test_get_statistics_aggregates_correctly(tmp_path):
     assert abs(stats["average_price"] - 7.5) < 1e-6
     assert abs(stats["sold_ratio"] - 0.5) < 1e-6
     assert abs(stats["unsold_ratio"] - 0.5) < 1e-6
+    assert abs(stats["max_price"] - 7) < 1e-6
+    assert stats["max_order"] == 1
 
 
 def test_get_statistics_handles_missing_added_at(tmp_path, caplog):


### PR DESCRIPTION
## Summary
- expose max sale price and largest order in `stats_utils.get_statistics`
- fetch max price/order directly from statistics data in UI
- extend statistics helper tests for new fields

## Testing
- `pytest tests/test_statistics_helpers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bff258ed08832faf5a04b050452ac8