### PR TITLE
Force inventory stats refresh after CSV append

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -516,9 +516,12 @@ def append_warehouse_csv(app, path: str = WAREHOUSE_CSV):
                 continue
             writer.writerow(format_warehouse_row(row))
 
+    # Recompute and cache inventory statistics to include newly written rows
+    get_inventory_stats(path, force=True)
+
     if hasattr(app, "update_inventory_stats"):
         try:
-            app.update_inventory_stats()
+            app.update_inventory_stats(force=True)
         except TclError:
             pass
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1873,8 +1873,14 @@ class CardEditorApp:
         )
         author.pack(side="bottom", pady=5)
 
-    def update_inventory_stats(self):
+    def update_inventory_stats(self, force: bool = False):
         """Refresh labels showing total item count and value in the UI.
+
+        Parameters
+        ----------
+        force:
+            When ``True`` statistics are recomputed even if cached values are
+            available.
 
         Also refreshes the daily additions bar chart if matplotlib is available.
         """
@@ -1902,7 +1908,9 @@ class CardEditorApp:
         if not widgets:
             return
 
-        unsold_count, unsold_total, sold_count, sold_total = csv_utils.get_inventory_stats()
+        unsold_count, unsold_total, sold_count, sold_total = csv_utils.get_inventory_stats(
+            force=force
+        )
         if unsold_count == 0 and sold_count == 0:
             messagebox.showinfo("Magazyn", "Brak kart w magazynie")
         unsold_count_text = f"📊 Łączna liczba kart: {unsold_count}"

--- a/tests/test_append_warehouse_csv.py
+++ b/tests/test_append_warehouse_csv.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 from datetime import date
+import pytest
 
 sys.modules.setdefault("customtkinter", MagicMock())
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -28,7 +29,7 @@ def test_append_warehouse_csv_updates_stats(tmp_path):
         update_inventory_stats=MagicMock(),
     )
     csv_utils.append_warehouse_csv(app, path=str(path))
-    app.update_inventory_stats.assert_called_once()
+    app.update_inventory_stats.assert_called_once_with(force=True)
     with open(path, encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter=";")
         rows = list(reader)
@@ -89,3 +90,40 @@ def test_append_warehouse_csv_sets_added_at(tmp_path, monkeypatch):
         reader = csv.DictReader(f, delimiter=";")
         row = next(reader)
         assert row["added_at"] == "2024-01-02"
+
+
+def test_append_warehouse_csv_refreshes_stats_cache(tmp_path):
+    path = tmp_path / "magazyn.csv"
+    path.write_text(
+        "name;number;set;warehouse_code;price;image\n" "A;1;S;K1;1;img\n",
+        encoding="utf-8",
+    )
+
+    # Populate cache with initial statistics
+    assert csv_utils.get_inventory_stats(str(path)) == (1, 1.0, 0, 0.0)
+
+    app = SimpleNamespace(
+        output_data=[
+            {
+                "name": "B",
+                "number": "2",
+                "set": "S2",
+                "warehouse_code": "K2",
+                "price": "2",
+                "image": "",
+                "sold": "",
+            }
+        ],
+        update_inventory_stats=MagicMock(),
+    )
+
+    csv_utils.append_warehouse_csv(app, path=str(path))
+
+    # Immediately read stats without forcing; should include new row
+    count_unsold, total_unsold, count_sold, total_sold = csv_utils.get_inventory_stats(
+        str(path)
+    )
+    assert count_unsold == 2
+    assert total_unsold == pytest.approx(3.0)
+    assert count_sold == 0
+    assert total_sold == pytest.approx(0.0)

--- a/tests/test_empty_inventory_message.py
+++ b/tests/test_empty_inventory_message.py
@@ -19,7 +19,7 @@ def test_update_inventory_stats_empty_shows_message(monkeypatch):
     monkeypatch.setattr(
         ui.csv_utils,
         "get_inventory_stats",
-        lambda path=ui.csv_utils.WAREHOUSE_CSV: (0, 0.0, 0, 0.0),
+        lambda path=ui.csv_utils.WAREHOUSE_CSV, force=False: (0, 0.0, 0, 0.0),
     )
     with patch.object(ui.messagebox, "showinfo") as mock_info:
         ui.CardEditorApp.update_inventory_stats(app)

--- a/tests/test_magazyn_grid_layout.py
+++ b/tests/test_magazyn_grid_layout.py
@@ -74,7 +74,7 @@ def _load_app(csv_path, stats, frame_cls=DummyCTkFrame):
     ui.ImageTk.PhotoImage = lambda *a, **k: photo_mock
     ui.tk.Canvas = DummyCanvas
     ui.csv_utils.WAREHOUSE_CSV = str(csv_path)
-    ui.csv_utils.get_inventory_stats = lambda: stats
+    ui.csv_utils.get_inventory_stats = lambda path=ui.csv_utils.WAREHOUSE_CSV, force=False: stats
 
     dummy_root = SimpleNamespace(
         minsize=lambda *a, **k: None,

--- a/tests/test_magazyn_inventory_stats_view.py
+++ b/tests/test_magazyn_inventory_stats_view.py
@@ -29,7 +29,11 @@ def test_inventory_stats_display_and_update(tmp_path, monkeypatch):
 
     first_stats = (5, 123.45, 2, 50.0)
     second_stats = (7, 210.0, 3, 60.0)
-    monkeypatch.setattr(csv_utils, "get_inventory_stats", lambda path=str(csv_path): first_stats)
+    monkeypatch.setattr(
+        csv_utils,
+        "get_inventory_stats",
+        lambda path=str(csv_path), force=False: first_stats,
+    )
 
     sys.modules["customtkinter"] = SimpleNamespace(
         CTkFrame=DummyCTkFrame,
@@ -77,7 +81,11 @@ def test_inventory_stats_display_and_update(tmp_path, monkeypatch):
         == f"Wartość sprzedanych: {first_stats[3]:.2f} PLN"
     )
 
-    monkeypatch.setattr(ui.csv_utils, "get_inventory_stats", lambda path=str(csv_path): second_stats)
+    monkeypatch.setattr(
+        ui.csv_utils,
+        "get_inventory_stats",
+        lambda path=str(csv_path), force=False: second_stats,
+    )
     ui.CardEditorApp.update_inventory_stats(app)
     assert app.mag_inventory_count_label.text == f"📊 Łączna liczba kart: {second_stats[0]}"
     assert (

--- a/tests/test_update_inventory_stats_no_labels.py
+++ b/tests/test_update_inventory_stats_no_labels.py
@@ -15,7 +15,7 @@ def test_update_inventory_stats_without_labels(monkeypatch):
     monkeypatch.setattr(
         ui.csv_utils,
         "get_inventory_stats",
-        lambda path=ui.csv_utils.WAREHOUSE_CSV: (1, 2.0, 3, 4.0),
+        lambda path=ui.csv_utils.WAREHOUSE_CSV, force=False: (1, 2.0, 3, 4.0),
     )
     app = SimpleNamespace()
     ui.CardEditorApp.update_inventory_stats(app)

--- a/tests/test_welcome_screen_box_preview.py
+++ b/tests/test_welcome_screen_box_preview.py
@@ -46,7 +46,11 @@ def test_welcome_screen_shows_box_preview(monkeypatch):
     import kartoteka.ui as ui
     importlib.reload(ui)
 
-    monkeypatch.setattr(ui.csv_utils, "get_inventory_stats", lambda path="": (0, 0.0, 0, 0.0))
+    monkeypatch.setattr(
+        ui.csv_utils,
+        "get_inventory_stats",
+        lambda path="", force=False: (0, 0.0, 0, 0.0),
+    )
 
     photo_mock = SimpleNamespace(width=lambda: 150, height=lambda: 150)
     with patch.object(ui.ImageTk, "PhotoImage", return_value=photo_mock), patch.object(


### PR DESCRIPTION
## Summary
- recompute warehouse statistics immediately after appending to CSV
- allow forcing stats refresh in `update_inventory_stats`
- test that stats update immediately after CSV append

## Testing
- `pytest tests/test_append_warehouse_csv.py tests/test_update_inventory_stats_no_labels.py tests/test_empty_inventory_message.py tests/test_welcome_screen_box_preview.py tests/test_magazyn_inventory_stats_view.py tests/test_magazyn_grid_layout.py`

------
https://chatgpt.com/codex/tasks/task_e_68bff4037558832fa3fe41e7cbb5a216