### PR TITLE
Simplify card progress bar handling

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5185,6 +5185,9 @@ class CardEditorApp:
         self.show_card()
 
     def show_card(self):
+        progress_cb = getattr(self, "_update_card_progress", None)
+        if progress_cb:
+            progress_cb(0, show=True)
         if self.index >= len(self.cards):
             if getattr(self, "failed_cards", None):
                 msg = "Failed to load images:\n" + "\n".join(self.failed_cards)
@@ -5419,7 +5422,7 @@ class CardEditorApp:
                         fp_match.distance,
                     )
                     if progress_cb:
-                        progress_cb(1.0, hide=True)
+                        progress_cb(1.0)
 
         if not skip_analysis:
             if progress_cb:
@@ -5461,7 +5464,7 @@ class CardEditorApp:
             return f"{name}|{number}|{set_name}|"
         return None
 
-    def _update_card_progress(self, value: float, show: bool = False, hide: bool = False):
+    def _update_card_progress(self, value: float, show: bool = False):
         """Update the progress bar for analyzing a single card."""
         if not hasattr(self, "progress_bar"):
             return
@@ -5469,8 +5472,6 @@ class CardEditorApp:
             self.progress_bar.set(value)
             if show and hasattr(self, "progress_frame"):
                 self.progress_frame.grid()
-            if hide and hasattr(self, "progress_frame"):
-                self.progress_frame.grid_remove()
         except tk.TclError:
             pass
 
@@ -5684,7 +5685,7 @@ class CardEditorApp:
             return
         progress_cb = getattr(self, "_update_card_progress", None)
         if progress_cb:
-            progress_cb(0, hide=True)
+            progress_cb(1.0)
         if result:
             name = result.get("name", "")
             number = result.get("number", "")
@@ -5732,7 +5733,7 @@ class CardEditorApp:
                         "Skipping duplicate card %s #%s in set %s", name, number, set_name
                     )
                     if progress_cb:
-                        progress_cb(1.0, hide=True)
+                        progress_cb(1.0)
                     self.current_analysis_thread = None
                     return
                 self.current_location = self.next_free_location()

--- a/tests/test_apply_analysis_result.py
+++ b/tests/test_apply_analysis_result.py
@@ -59,8 +59,8 @@ def test_apply_analysis_result_duplicate_cancel(monkeypatch):
     find_mock.assert_called_once_with("Pika", "1", "Set X", None)
     ask_mock.assert_called_once()
     assert dummy._update_card_progress.call_args_list == [
-        call(0, hide=True),
-        call(1.0, hide=True),
+        call(1.0),
+        call(1.0),
     ]
     dummy.next_free_location.assert_not_called()
     assert dummy.current_analysis_thread is None
@@ -79,7 +79,7 @@ def test_apply_analysis_result_duplicate_confirm(monkeypatch):
 
     find_mock.assert_called_once_with("Pika", "1", "Set X", None)
     ask_mock.assert_called_once()
-    dummy._update_card_progress.assert_called_once_with(0, hide=True)
+    dummy._update_card_progress.assert_called_once_with(1.0)
     dummy.next_free_location.assert_called_once()
     dummy.location_label.configure.assert_called_once_with(text="K1R1P1")
     assert dummy.current_location == "K1R1P1"


### PR DESCRIPTION
## Summary
- keep progress bar visible by removing hide parameter
- reset progress bar when showing a new card
- update tests for revised progress bar API

## Testing
- `pytest tests/test_apply_analysis_result.py::test_apply_analysis_result_duplicate_cancel tests/test_apply_analysis_result.py::test_apply_analysis_result_duplicate_confirm -q`
- `pytest tests/test_show_card_duplicate_entries.py::test_show_card_warns_on_magazyn_duplicate -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfff44e378832fb1e2f089d853d0b2