### PR TITLE
Remove unused card variant UI

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4920,16 +4920,6 @@ class CardEditorApp:
             command=self.fetch_card_data,
         )
         self.api_button.grid(row=start_row + 8, column=0, columnspan=2, sticky="ew", **grid_opts)
-
-        self.variants_button = self.create_button(
-            self.info_frame,
-            text="Inne warianty",
-            command=self.show_variants,
-        )
-        self.variants_button.grid(
-            row=start_row + 8, column=2, columnspan=2, sticky="ew", **grid_opts
-        )
-
         self.cardmarket_button = self.create_button(
             self.info_frame,
             text="Cardmarket",
@@ -6318,89 +6308,6 @@ class CardEditorApp:
             logger.warning("Invalid JSON from TCGGO: %s", e)
         return ""
 
-    def fetch_card_variants(self, name, number, set_name):
-        """Return all matching cards from the API with prices."""
-        name_api = normalize(name, keep_spaces=True)
-        name_input = normalize(name)
-        number_input = number.strip().lower()
-        set_input = set_name.strip().lower()
-        if set_input == "prismatic evolutions: additionals":
-            set_code = "xpre"
-        else:
-            set_code = get_set_code(set_name)
-        full_name = get_set_name(set_code)
-        if hasattr(self, "set_var"):
-            try:
-                self.set_var.set(full_name)
-            except tk.TclError:
-                pass
-
-        try:
-            headers = {}
-            if RAPIDAPI_KEY and RAPIDAPI_HOST:
-                url = f"https://{RAPIDAPI_HOST}/cards/search"
-                params = {"search": name_api}
-                headers = {
-                    "X-RapidAPI-Key": RAPIDAPI_KEY,
-                    "X-RapidAPI-Host": RAPIDAPI_HOST,
-                }
-            else:
-                url = "https://www.tcggo.com/api/cards/"
-                params = {
-                    "name": name_api,
-                    "number": number_input,
-                    "set": set_code,
-                }
-
-            response = requests.get(url, params=params, headers=headers, timeout=10)
-            if response.status_code != 200:
-                logger.warning("API error: %s", response.status_code)
-                return []
-
-            cards = response.json()
-            if isinstance(cards, dict):
-                if "cards" in cards:
-                    cards = cards["cards"]
-                elif "data" in cards:
-                    cards = cards["data"]
-                else:
-                    cards = []
-
-            results = []
-            eur_pln = self.get_exchange_rate()
-            for card in cards:
-                card_name = normalize(card.get("name", ""))
-                card_number = str(card.get("card_number", "")).lower()
-                card_set = str(card.get("episode", {}).get("name", "")).lower()
-
-                name_match = name_input in card_name
-                number_match = number_input == card_number
-                set_match = set_input in card_set or card_set.startswith(set_input)
-
-                if name_match and number_match and set_match:
-                    price_eur = extract_cardmarket_price(card)
-                    price_pln = 0
-                    if price_eur is not None:
-                        price_pln = round(
-                            float(price_eur) * eur_pln * PRICE_MULTIPLIER, 2
-                        )
-                    results.append(
-                        {
-                            "name": card.get("name"),
-                            "number": card_number,
-                            "set": card.get("episode", {}).get("name", ""),
-                            "price": price_pln,
-                        }
-                    )
-            return results
-        except requests.Timeout:
-            logger.warning("Request timed out")
-        except requests.RequestException as e:
-            logger.warning("Fetching variants from TCGGO failed: %s", e)
-        except ValueError as e:
-            logger.warning("Invalid JSON from TCGGO: %s", e)
-        return []
-
     def lookup_card_info(self, name, number, set_name, is_holo=False, is_reverse=False):
         """Return image URL and pricing information for the first matching card."""
         name_api = normalize(name, keep_spaces=True)
@@ -6562,62 +6469,6 @@ class CardEditorApp:
             self.log(f"PSA10 price for {name} {number}: {psa10_price} zł")
         else:
             self.log(f"PSA10 price for {name} {number} not found")
-
-    def show_variants(self):
-        """Display a list of matching cards from the API."""
-        name = self.entries["nazwa"].get()
-        number = sanitize_number(self.entries["numer"].get())
-        set_name = self.entries["set"].get()
-
-        is_reverse = self.type_vars["Reverse"].get()
-        is_holo = self.type_vars["Holo"].get()
-
-        variants = self.fetch_card_variants(name, number, set_name)
-        if not variants:
-            messagebox.showinfo("Brak wyników", "Nie znaleziono dodatkowych wariantów.")
-            self.open_cardmarket_search()
-            return
-
-        top = ctk.CTkToplevel(self.root)
-        top.title("Inne warianty")
-        top.geometry("600x400")
-
-        logo_path = os.path.join(os.path.dirname(__file__), "banner22.png")
-        if os.path.exists(logo_path):
-            logo_img = load_rgba_image(logo_path)
-            if logo_img:
-                logo_img.thumbnail((140, 140))
-                top.logo_image = _create_image(logo_img)
-                ctk.CTkLabel(top, image=top.logo_image, text="").pack(pady=(10, 10))
-
-        columns = ("name", "number", "set", "price")
-        tree = ttk.Treeview(top, columns=columns, show="headings")
-        tree.heading("name", text="Nazwa")
-        tree.heading("number", text="Numer")
-        tree.heading("set", text="Set")
-        tree.heading("price", text="Cena (PLN)")
-
-        for card in variants:
-            price = self.apply_variant_multiplier(
-                card["price"], is_reverse=is_reverse, is_holo=is_holo
-            )
-            tree.insert(
-                "", "end", values=(card["name"], card["number"], card["set"], price)
-            )
-
-        tree.pack(expand=True, fill="both", padx=10, pady=10)
-
-        def set_selected_price(event=None):
-            selected = tree.selection()
-            if not selected:
-                return
-            values = tree.item(selected[0], "values")
-            self.entries["cena"].delete(0, tk.END)
-            self.entries["cena"].insert(0, values[3])
-            top.destroy()
-
-        self.create_button(top, text="Ustaw cenę", command=set_selected_price).pack(pady=5)
-        tree.bind("<Double-1>", set_selected_price)
 
     def open_cardmarket_search(self):
         """Open a Cardmarket search for the current card in the default browser."""


### PR DESCRIPTION
## Summary
- drop unused `variants_button` and related variant lookup methods

## Testing
- `pytest -q` *(fails: test_compute_box_occupancy_box100, test_mag_box_order_contains_100, test_local_warehouse_csv_exists)*

------
https://chatgpt.com/codex/tasks/task_e_68c0032bccf8832fbcabc5da9f4f6a2d