### PR TITLE
Handle missing set info without warning

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -720,16 +720,17 @@ def resolve_set_and_era(
 ) -> tuple[str, str, str]:
     """Normalize set and era names using known mappings.
 
-    Returns a tuple ``(normalized_set_name, set_code, era_name)``. Unknown eras
-    are returned as ``"unknown"``.
+    Returns a tuple ``(normalized_set_name, set_code, era_name)``.
+    Unknown eras are returned as an empty string.
     """
 
     code = set_code or get_set_code(set_name)
     name = get_set_name(code) or set_name
     era = get_set_era(code) or get_set_era(name) or get_set_era(era_name)
     if not era:
-        logger.warning("Unknown set or era: %s / %s", name or code, era_name)
-        era = "unknown"
+        if name or code or era_name:
+            logger.warning("Unknown set or era: %s / %s", name or code, era_name)
+        return name, code, ""
     return name, code, era
 
 def lookup_sets_from_api(name: str, number: str, total: Optional[str] = None):

--- a/tests/test_resolve_set_and_era.py
+++ b/tests/test_resolve_set_and_era.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+import logging
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui  # noqa: E402
+importlib.reload(ui)  # ensure mappings are loaded
+
+
+def test_resolve_set_and_era_empty_no_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="kartoteka.ui"):
+        result = ui.resolve_set_and_era("", "", "")
+    assert result == ("", "", "")
+    assert not caplog.records
+
+
+def test_resolve_set_and_era_unknown_logs_warning(caplog):
+    with caplog.at_level(logging.WARNING, logger="kartoteka.ui"):
+        result = ui.resolve_set_and_era("Nonexistent Set", "", "")
+    assert result == ("Nonexistent Set", "Nonexistent Set", "")
+    assert "Unknown set or era" in caplog.text


### PR DESCRIPTION
## Summary
- Avoid logging `Unknown set or era` when no set data is supplied
- Return empty era when the set or era can't be resolved
- Add regression tests for resolve_set_and_era

## Testing
- `pytest tests/test_resolve_set_and_era.py`
- `pytest` *(fails: tests/test_analyze_card_image.py::test_analyze_card_image_api_multiple_sets, tests/test_analyze_card_image.py::test_analyze_card_image_propagates_openai_era, tests/test_analyze_card_image.py::test_analyze_card_image_hash_preempts_openai, tests/test_analyze_card_image.py::test_analyze_card_image_ocr_unknown_code, tests/test_box100.py::test_compute_box_occupancy_box100, tests/test_box100.py::test_mag_box_order_contains_100, tests/test_download_warehouse_csv.py::test_local_warehouse_csv_exists)*

------
https://chatgpt.com/codex/tasks/task_e_68c15bddff18832fa45417846760285c