### PR TITLE
chore: require openai version with response_format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@ Pillow==10.3.0
 requests==2.31.0
 python-dotenv==1.0.1
 customtkinter==5.2.2
-openai==1.7.2
+openai>=1.12
 imagehash==4.3.1
 httpx==0.27.2
 pytesseract==0.3.10
-numpy==1.26.4
+numpy>=2.0,<2.3
 opencv-python-headless==4.12.0.88


### PR DESCRIPTION
## Summary
- require OpenAI Python library >=1.12
- bump numpy to satisfy opencv-python-headless dependency

## Testing
- `pip install --upgrade -r requirements.txt`
- `python - <<'PY'
import openai
client=openai.OpenAI(api_key='dummy')
try:
    client.responses.create(model='gpt-4o-mini', response_format={'type':'json_schema','json_schema':{'name':'x','schema':{}}}, input='hi')
except Exception as e:
    print(type(e).__name__)
    print(str(e)[:200])
PY`
- `pytest tests/test_analyze_card_image.py::test_extract_card_info_openai_maps_set tests/test_openai_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16b906314832f9df69306d83aa171