### PR TITLE
Handle OpenAI response_format incompatibility

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1290,6 +1290,9 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str, s
         }
 
         try:
+            logger.debug(
+                "extract_card_info_openai: calling OpenAI with response_format"
+            )
             resp = client.responses.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-4o"),
                 response_format={"type": "json_schema", "json_schema": schema},
@@ -1304,28 +1307,13 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str, s
                 ],
                 max_output_tokens=150,
             )
-            raw = getattr(resp, "output_text", "")
-            raw = raw.strip().strip("`")
-            if raw.startswith("json"):
-                raw = raw[len("json") :].lstrip()
-            match = re.search(r"{.*}", raw, re.DOTALL)
-            if match:
-                raw = match.group(0)
-            if not raw:
-                logger.error(
-                    "extract_card_info_openai got empty response from OpenAI: %r",
-                    resp,
-                )
-                return "", "", "", "", "", "", ""
-            try:
-                data_dict = json.loads(raw)
-            except json.JSONDecodeError:
-                logger.error("OpenAI returned non-JSON: %r", raw)
-                return "", "", "", "", "", "", ""
-        except TypeError:
+        except TypeError as e:
+            logger.debug(
+                "extract_card_info_openai: response_format unsupported (%s); retrying without",
+                e,
+            )
             resp = client.responses.create(
                 model=os.getenv("OPENAI_MODEL", "gpt-4o"),
-                response_format={"type": "json_schema", "json_schema": schema},
                 input=[
                     {
                         "role": "user",
@@ -1337,24 +1325,25 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str, s
                 ],
                 max_output_tokens=150,
             )
-            raw = getattr(resp, "output_text", "")
-            raw = raw.strip().strip("`")
-            if raw.startswith("json"):
-                raw = raw[len("json") :].lstrip()
-            match = re.search(r"{.*}", raw, re.DOTALL)
-            if match:
-                raw = match.group(0)
-            if not raw:
-                logger.error(
-                    "extract_card_info_openai got empty response from OpenAI: %r",
-                    resp,
-                )
-                return "", "", "", "", "", "", ""
-            try:
-                data_dict = json.loads(raw)
-            except json.JSONDecodeError:
-                logger.error("OpenAI returned non-JSON: %r", raw)
-                return "", "", "", "", "", "", ""
+
+        raw = getattr(resp, "output_text", "")
+        raw = raw.strip().strip("`")
+        if raw.startswith("json"):
+            raw = raw[len("json") :].lstrip()
+        match = re.search(r"{.*}", raw, re.DOTALL)
+        if match:
+            raw = match.group(0)
+        if not raw:
+            logger.error(
+                "extract_card_info_openai got empty response from OpenAI: %r",
+                resp,
+            )
+            return "", "", "", "", "", "", ""
+        try:
+            data_dict = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.error("OpenAI returned non-JSON: %r", raw)
+            return "", "", "", "", "", "", ""
 
         data = data_dict
 

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -36,9 +36,15 @@ def test_parse_code_fence(monkeypatch, tmp_path):
     }
     resp = SimpleNamespace(output_text=f"```json\n{json.dumps(payload)}\n```")
 
+    calls = []
+
+    def create(*a, **k):
+        calls.append(k)
+        return resp
+
     class DummyClient:
         def __init__(self, *a, **k):
-            self.responses = SimpleNamespace(create=lambda *a, **k: resp)
+            self.responses = SimpleNamespace(create=create)
 
     monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
     name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(str(img))
@@ -51,3 +57,50 @@ def test_parse_code_fence(monkeypatch, tmp_path):
     assert set_code == SV01_CODE
     assert set_name == SV01_NAME
     assert set_format == "text"
+    assert calls and "response_format" in calls[0]
+
+
+def test_parse_code_fallback(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
+
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": SV01_CODE,
+        "era_name": ui.get_set_era(SV01_CODE),
+        "set_format": "text",
+    }
+    resp = SimpleNamespace(output_text=json.dumps(payload))
+
+    calls = []
+
+    def create(*a, **k):
+        calls.append(k)
+        if len(calls) == 1:
+            raise TypeError("response_format not supported")
+        return resp
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.responses = SimpleNamespace(create=create)
+
+    monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
+    name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(
+        str(img)
+    )
+    assert (name, number, total, era_name) == (
+        "Pikachu",
+        "037",
+        "198",
+        ui.get_set_era(SV01_CODE),
+    )
+    assert set_code == SV01_CODE
+    assert set_name == SV01_NAME
+    assert set_format == "text"
+    assert len(calls) == 2
+    assert "response_format" in calls[0]
+    assert "response_format" not in calls[1]


### PR DESCRIPTION
## Summary
- Retry OpenAI vision call without `response_format` on `TypeError`
- Log which OpenAI branch was taken for easier debugging
- Cover both modern and fallback OpenAI branches with tests

## Testing
- `pytest tests/test_openai_parsing.py -q`
- `pytest -q` *(fails: test_analyze_card_image_api_multiple_sets, test_analyze_card_image_propagates_openai_era, test_analyze_card_image_hash_preempts_openai, test_analyze_card_image_ocr_unknown_code, test_compute_box_occupancy_box100, test_mag_box_order_contains_100, test_local_warehouse_csv_exists)*

------
https://chatgpt.com/codex/tasks/task_e_68c16e089438832f8c86c546f5bcaf94