### PR TITLE
Upgrade Pillow requirement for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 ## Overview
 Kartoteka is a lightweight Tkinter app for organizing Pokémon card scans and exporting pricing data to CSV.
 
+## Python Compatibility
+Kartoteka supports Python 3.9 through 3.13. The default requirements use `Pillow>=10.4`, which ships pre-built wheels for Python 3.13.
+
+If you must stay on an older Python release that cannot install Pillow 10.4 or later, pin `Pillow<10.4` in `requirements.txt` and use a compatible Python version (for example, Python 3.12).
+
 ## Running the App
 With dependencies installed, launch the interface:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Pillow==10.3.0
+Pillow>=10.4
 requests==2.31.0
 python-dotenv==1.0.1
 customtkinter==5.2.2


### PR DESCRIPTION
## Summary
- loosen Pillow dependency to `>=10.4` so Python 3.13 wheels install
- document supported Python versions and fallback for older Pillow releases

## Testing
- `~/.pyenv/versions/3.13.3/bin/pip install -r requirements.txt`
- `~/.pyenv/versions/3.13.3/bin/python -m pytest` *(fails: tests/test_analyze_card_image.py::test_analyze_card_image_api_multiple_sets, tests/test_analyze_card_image.py::test_analyze_card_image_propagates_openai_era, tests/test_analyze_card_image.py::test_analyze_card_image_hash_preempts_openai, tests/test_analyze_card_image.py::test_analyze_card_image_ocr_unknown_code, tests/test_box100.py::test_compute_box_occupancy_box100, tests/test_box100.py::test_mag_box_order_contains_100, tests/test_download_warehouse_csv.py::test_local_warehouse_csv_exists)*

------
https://chatgpt.com/codex/tasks/task_e_68c16f500e74832fb23e0f08fdbda3c8