### PR TITLE
Handle OpenAI error during response_format call

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1307,7 +1307,7 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str, s
                 ],
                 max_output_tokens=150,
             )
-        except TypeError as e:
+        except (TypeError, openai.OpenAIError) as e:
             logger.debug(
                 "extract_card_info_openai: response_format unsupported (%s); retrying without",
                 e,

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -104,3 +104,49 @@ def test_parse_code_fallback(monkeypatch, tmp_path):
     assert len(calls) == 2
     assert "response_format" in calls[0]
     assert "response_format" not in calls[1]
+
+
+def test_parse_code_fallback_openai_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
+
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": SV01_CODE,
+        "era_name": ui.get_set_era(SV01_CODE),
+        "set_format": "text",
+    }
+    resp = SimpleNamespace(output_text=json.dumps(payload))
+
+    calls = []
+
+    def create(*a, **k):
+        calls.append(k)
+        if len(calls) == 1:
+            raise ui.openai.OpenAIError("unexpected keyword argument 'response_format'")
+        return resp
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.responses = SimpleNamespace(create=create)
+
+    monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
+    name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(
+        str(img)
+    )
+    assert (name, number, total, era_name) == (
+        "Pikachu",
+        "037",
+        "198",
+        ui.get_set_era(SV01_CODE),
+    )
+    assert set_code == SV01_CODE
+    assert set_name == SV01_NAME
+    assert set_format == "text"
+    assert len(calls) == 2
+    assert "response_format" in calls[0]
+    assert "response_format" not in calls[1]


### PR DESCRIPTION
## Summary
- handle OpenAI errors when calling OpenAI Responses API with `response_format`, logging and retrying without the parameter
- test fallback behavior when OpenAI raises `OpenAIError` about unexpected `response_format`

## Testing
- `pytest tests/test_openai_parsing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1715e4040832fa29b1b92bc1aff1e