### PR TITLE
Handle truncated OpenAI JSON responses

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1339,11 +1339,43 @@ def extract_card_info_openai(path: str) -> tuple[str, str, str, str, str, str, s
                 resp,
             )
             return "", "", "", "", "", "", ""
+
+        def repair_json(text: str) -> dict | None:
+            stack: list[str] = []
+            in_string = False
+            escape = False
+            pairs = {"{": "}", "[": "]"}
+            for ch in text:
+                if escape:
+                    escape = False
+                    continue
+                if ch == "\\":
+                    escape = True
+                    continue
+                if ch == '"':
+                    in_string = not in_string
+                    continue
+                if in_string:
+                    continue
+                if ch in pairs:
+                    stack.append(ch)
+                elif ch in pairs.values():
+                    if not stack or pairs[stack[-1]] != ch:
+                        return None
+                    stack.pop()
+            fixed = text + "".join(pairs[c] for c in reversed(stack))
+            try:
+                return json.loads(fixed)
+            except json.JSONDecodeError:
+                return None
+
         try:
             data_dict = json.loads(raw)
         except json.JSONDecodeError:
-            logger.error("OpenAI returned non-JSON: %r", raw)
-            return "", "", "", "", "", "", ""
+            data_dict = repair_json(raw)
+            if data_dict is None:
+                logger.error("OpenAI returned non-JSON: %r", raw)
+                return "", "", "", "", "", "", ""
 
         data = data_dict
 

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -150,3 +150,42 @@ def test_parse_code_fallback_openai_error(monkeypatch, tmp_path):
     assert len(calls) == 2
     assert "response_format" in calls[0]
     assert "response_format" not in calls[1]
+
+
+def test_parse_truncated_json_repair(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
+
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": SV01_CODE,
+        "era_name": ui.get_set_era(SV01_CODE),
+        "set_format": "text",
+    }
+    truncated = json.dumps(payload)[:-1]
+    resp = SimpleNamespace(output_text=truncated)
+
+    def create(*a, **k):
+        return resp
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.responses = SimpleNamespace(create=create)
+
+    monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
+    name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(
+        str(img)
+    )
+    assert (name, number, total, era_name) == (
+        "Pikachu",
+        "037",
+        "198",
+        ui.get_set_era(SV01_CODE),
+    )
+    assert set_code == SV01_CODE
+    assert set_name == SV01_NAME
+    assert set_format == "text"


### PR DESCRIPTION
## Summary
- add `repair_json` helper that closes unbalanced braces/brackets in OpenAI responses
- retry parsing with the repaired JSON before falling back to empty values
- test that truncated JSON is repaired and parsed correctly

## Testing
- `pytest tests/test_openai_parsing.py -q`
- `pytest -q` *(fails: test_compute_box_occupancy_box100, test_mag_box_order_contains_100, test_local_warehouse_csv_exists, test_parse_code_fallback, test_parse_code_fallback_openai_error)*

------
https://chatgpt.com/codex/tasks/task_e_68c265fb6b30832f9e628eec5414e41d