### PR TITLE
feat: optionally relax OpenAI set validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ With dependencies installed, launch the interface:
 python main.py
 ```
 
+## Set validation
+
+OpenAI responses normally validate set and era names against a built-in list.
+To allow unrecognised values and rely on internal mapping instead, disable
+strict validation:
+
+```bash
+STRICT_SET_VALIDATION=0 python main.py
+```
+
+
 ## Card Identifier Format and CSV Export
 Cards are identified with the pattern `PKM-<SET>-<NR>-<VARIANT>`:
 

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -117,6 +117,12 @@ if OPENAI_API_KEY:
 if USE_OPENAI_STUB:
     openai.OpenAI = lambda *a, **k: SimpleNamespace()
 
+STRICT_SET_VALIDATION = os.getenv("STRICT_SET_VALIDATION", "1") not in {
+    "0",
+    "false",
+    "False",
+}
+
 PRICE_DB_PATH = "card_prices.csv"
 PRICE_MULTIPLIER = 1.23
 DATA_DIR = Path(__file__).resolve().parent.parent / "data"
@@ -1296,9 +1302,14 @@ def extract_card_info_openai(
                 "additionalProperties": False,
             },
         }
-        enum_schema = copy.deepcopy(base_schema)
-        enum_schema["schema"]["properties"]["set_name"]["enum"] = enum_values
-        enum_schema["schema"]["properties"]["era_name"]["enum"] = OPENAI_ERAS
+        schemas: list[dict | None]
+        if STRICT_SET_VALIDATION:
+            enum_schema = copy.deepcopy(base_schema)
+            enum_schema["schema"]["properties"]["set_name"]["enum"] = enum_values
+            enum_schema["schema"]["properties"]["era_name"]["enum"] = OPENAI_ERAS
+            schemas = [enum_schema, base_schema, None]
+        else:
+            schemas = [base_schema, None]
 
         openai_error = (
             openai.OpenAIError
@@ -1380,7 +1391,6 @@ def extract_card_info_openai(
                     raise
                 return repaired
 
-        schemas: list[dict | None] = [enum_schema, base_schema, None]
         data_dict: dict | None = None
         for sch in schemas:
             try:

--- a/tests/test_analyze_card_image.py
+++ b/tests/test_analyze_card_image.py
@@ -211,6 +211,46 @@ def test_analyze_card_image_propagates_openai_era(monkeypatch):
     mock_hash.assert_called_once()
 
 
+def test_analyze_card_image_relaxed_validation(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("STRICT_SET_VALIDATION", "0")
+    importlib.reload(ui)
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
+
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": f"{SV01_NAME} EN",
+        "era_name": "SV EN",
+        "set_format": "text",
+    }
+    resp = SimpleNamespace(output_text=json.dumps(payload))
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.responses = SimpleNamespace(create=lambda *a, **k: resp)
+
+    monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
+    with patch.object(ui, "identify_set_by_hash", return_value=[]), patch.object(
+        ui, "extract_set_code_ocr", return_value=[]
+    ), patch.object(ui, "lookup_sets_from_api", return_value=[]):
+        result = ui.analyze_card_image(str(img))
+
+    assert result == {
+        "name": "Pikachu",
+        "number": "037",
+        "total": "198",
+        "set": SV01_NAME,
+        "set_code": SV01_CODE,
+        "orientation": 0,
+        "set_format": "text",
+        "era": ui.get_set_era(SV01_CODE),
+    }
+    importlib.reload(ui)
+
+
 def test_analyze_card_image_hash_preempts_openai(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     class DummyImage:

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -66,6 +66,47 @@ def test_parse_code_fence(monkeypatch, tmp_path):
     assert enums == ui.OPENAI_SETS
 
 
+def test_parse_code_relaxed_validation(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    monkeypatch.setenv("STRICT_SET_VALIDATION", "0")
+    importlib.reload(ui)
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
+
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": f"{SV01_NAME} EN",
+        "era_name": "SV EN",
+        "set_format": "text",
+    }
+    resp = SimpleNamespace(output_text=json.dumps(payload))
+
+    calls = []
+
+    def create(*a, **k):
+        calls.append(k)
+        return resp
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.responses = SimpleNamespace(create=create)
+
+    monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
+    name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(
+        str(img)
+    )
+    assert (name, number, total) == ("Pikachu", "037", "198")
+    assert set_code == SV01_CODE
+    assert set_name == SV01_NAME
+    assert era_name == ui.get_set_era(SV01_CODE)
+    assert set_format == "text"
+    assert calls and "response_format" in calls[0]
+    props = calls[0]["response_format"]["json_schema"]["schema"]["properties"]["set_name"]
+    assert "enum" not in props
+
+
 def test_parse_code_fallback(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "x")
     importlib.reload(ui)


### PR DESCRIPTION
## Summary
- allow disabling OpenAI set/era enums via `STRICT_SET_VALIDATION`
- document relaxed set validation mode
- test both strict and relaxed OpenAI flows

## Testing
- `pytest -q` *(fails: test_box100, test_mag_box_order_contains_100, test_local_warehouse_csv_exists)*

------
https://chatgpt.com/codex/tasks/task_e_68c2803e7760832fbd5857bfde0b4951