### PR TITLE
Normalize OpenAI card number parsing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1407,14 +1407,15 @@ def extract_card_info_openai(
 
         data = data_dict
 
-        raw_number = data.get("number") or ""
+        raw_number = data.get("number", "")
+        if not isinstance(raw_number, str):
+            raw_number = str(raw_number)
         number, total = "", ""
-        if isinstance(raw_number, str):
-            m = re.search(r"(\d+)(?:\s*/\s*(\d+))?", raw_number)
-            if m:
-                number, total = m.group(1), m.group(2) or ""
-            else:
-                number = re.sub(r"\D+", "", raw_number)
+        m = re.search(r"(\d+)(?:\s*/\s*(\d+))?", raw_number)
+        if m:
+            number, total = m.group(1), m.group(2) or ""
+        else:
+            number = re.sub(r"\D+", "", raw_number)
 
         name = data.get("name") or ""
         set_name = data.get("set_name") or ""


### PR DESCRIPTION
## Summary
- Convert numeric card `number` values to strings before regex parsing in `extract_card_info_openai`

## Testing
- `pytest` *(fails: test_box100::test_compute_box_occupancy_box100, test_box100::test_mag_box_order_contains_100, test_download_warehouse_csv::test_local_warehouse_csv_exists)*

------
https://chatgpt.com/codex/tasks/task_e_68c2833f91e8832f8581f03417012b77