### PR TITLE
Handle alt OpenAI response fields

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -1397,8 +1397,28 @@ def extract_card_info_openai(
             return client.responses.create(**params)
 
         def parse_resp(resp) -> dict:
-            raw = getattr(resp, "output_text", "")
-            raw = raw.strip().strip("`")
+            def _nested_get(obj, *path):
+                for key in path:
+                    if obj is None:
+                        return None
+                    try:
+                        if isinstance(key, int):
+                            obj = obj[key]
+                        else:
+                            obj = obj.get(key) if isinstance(obj, dict) else getattr(obj, key, None)
+                    except (KeyError, IndexError, TypeError, AttributeError):
+                        return None
+                return obj
+
+            raw = getattr(resp, "output_text", None)
+            if not raw:
+                raw = (
+                    _nested_get(resp, "output", 0, "content", 0, "text", "value")
+                    or _nested_get(resp, "output", 0, "content", 0, "text")
+                    or _nested_get(resp, "output", 0, "content", 0)
+                    or ""
+                )
+            raw = str(raw).strip().strip("`")
             if raw.startswith("json"):
                 raw = raw[len("json") :].lstrip()
             match = re.search(r"{.*}", raw, re.DOTALL)

--- a/tests/test_openai_parsing.py
+++ b/tests/test_openai_parsing.py
@@ -368,3 +368,87 @@ def test_parse_with_available_sets(monkeypatch, tmp_path):
         calls[0]["response_format"]["json_schema"]["schema"]["properties"]["set_name"]["enum"]
     )
     assert enums == [SV01_NAME]
+
+
+def test_parse_alt_output_attr(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
+
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": SV01_CODE,
+        "era_name": ui.get_set_era(SV01_CODE),
+        "set_format": "text",
+    }
+    resp = SimpleNamespace(
+        output=[SimpleNamespace(content=[SimpleNamespace(text=json.dumps(payload))])]
+    )
+
+    def create(*a, **k):
+        return resp
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.responses = SimpleNamespace(create=create)
+
+    monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
+    name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(
+        str(img)
+    )
+    assert (name, number, total, era_name) == (
+        "Pikachu",
+        "037",
+        "198",
+        ui.get_set_era(SV01_CODE),
+    )
+    assert set_code == SV01_CODE
+    assert set_name == SV01_NAME
+    assert set_format == "text"
+
+
+def test_parse_alt_output_dict(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    importlib.reload(ui)
+
+    img = tmp_path / "x.jpg"
+    img.write_bytes(b"data")
+
+    payload = {
+        "name": "Pikachu",
+        "number": "037/198",
+        "set_name": SV01_CODE,
+        "era_name": ui.get_set_era(SV01_CODE),
+        "set_format": "text",
+    }
+    resp = {
+        "output": [
+            {
+                "content": [{"text": {"value": json.dumps(payload)}}]
+            }
+        ]
+    }
+
+    def create(*a, **k):
+        return resp
+
+    class DummyClient:
+        def __init__(self, *a, **k):
+            self.responses = SimpleNamespace(create=create)
+
+    monkeypatch.setattr(ui.openai, "OpenAI", DummyClient)
+    name, number, total, era_name, set_name, set_code, set_format = ui.extract_card_info_openai(
+        str(img)
+    )
+    assert (name, number, total, era_name) == (
+        "Pikachu",
+        "037",
+        "198",
+        ui.get_set_era(SV01_CODE),
+    )
+    assert set_code == SV01_CODE
+    assert set_name == SV01_NAME
+    assert set_format == "text"


### PR DESCRIPTION
## Summary
- Expand OpenAI response parsing to search alternative output locations when `output_text` is missing
- Extract JSON payload from found field before JSON decoding
- Add unit tests covering different response shapes without `output_text`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c296e4c148832fa11f2031c4eb5b2f