### PR TITLE
Improve set resolution with fuzzy matching

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -745,9 +745,20 @@ def resolve_set_and_era(
     Returns a tuple ``(normalized_set_name, set_code, era_name)``. Unknown eras
     are returned as ``"unknown"``.
     """
-
     code = set_code or get_set_code(set_name)
     name = get_set_name(code) or set_name
+
+    # if the provided ``set_name`` could not be resolved, attempt fuzzy match
+    if not set_code and set_name and name == code:
+        # combine English and Japanese set names for matching
+        candidates = list(tcg_sets_eng_map.keys()) + list(tcg_sets_jp_map.keys())
+        match = difflib.get_close_matches(
+            set_name, candidates, n=1, cutoff=SET_CODE_MATCH_CUTOFF
+        )
+        if match:
+            code = get_set_code(match[0])
+            name = get_set_name(code) or match[0]
+
     era = get_set_era(code) or get_set_era(name) or get_set_era(era_name)
     if not era:
         logger.warning("Unknown set or era: %s / %s", name or code, era_name)

--- a/tests/test_resolve_set_and_era.py
+++ b/tests/test_resolve_set_and_era.py
@@ -1,0 +1,23 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("customtkinter", MagicMock())
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import kartoteka.ui as ui  # noqa: E402
+importlib.reload(ui)
+
+
+def test_resolve_set_and_era_fuzzy_scarlet_violet():
+    name, code, era = ui.resolve_set_and_era("Obsidian Flame")
+    assert name == "Obsidian Flames"
+    assert code == "sv03"
+    assert era == "Scarlet & Violet"
+
+
+def test_resolve_set_and_era_fuzzy_sword_shield():
+    name, code, era = ui.resolve_set_and_era("Darkness Ablze")
+    assert name == "Darkness Ablaze"
+    assert code == "swsh3"
+    assert era == "Sword & Shield"


### PR DESCRIPTION
## Summary
- enhance `resolve_set_and_era` with fuzzy matching on set names
- map fuzzy matched names to canonical set codes and eras
- add regression tests for misspelled set names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2983997c0832f8053459c2b9e5cfa