### PR TITLE
Adjust button layout widths

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4907,11 +4907,12 @@ class CardEditorApp:
 
         self.api_button = self.create_button(
             self.info_frame,
-            text="Pobierz cenę z bazy",
+            text="Pobierz cenę",
             command=self.fetch_card_data,
             fg_color=FETCH_BUTTON_COLOR,
+            width=120,
         )
-        self.api_button.grid(row=start_row + 8, column=0, columnspan=2, sticky="ew", **grid_opts)
+        self.api_button.grid(row=start_row + 8, column=0, columnspan=1, sticky="ew", **grid_opts)
 
         self.cardmarket_button = self.create_button(
             self.info_frame,
@@ -4928,8 +4929,9 @@ class CardEditorApp:
             text="Zapisz i dalej",
             command=self.save_and_next,
             fg_color=SAVE_BUTTON_COLOR,
+            width=120,
         )
-        self.save_button.grid(row=start_row + 9, column=0, columnspan=2, sticky="ew", **grid_opts)
+        self.save_button.grid(row=start_row + 9, column=0, columnspan=1, sticky="ew", **grid_opts)
 
         self.eur_entry = ctk.CTkEntry(
             self.info_frame, width=120, placeholder_text="Kwota w EUR"


### PR DESCRIPTION
## Summary
- Simplify price fetch button label to "Pobierz cenę" and narrow both fetch and save buttons to width 120
- Limit fetch and save buttons to single column for tighter layout

## Testing
- `pytest -q | tail -n 20` *(fails: tests/test_apply_analysis_result.py::test_apply_analysis_result_duplicate_cancel, tests/test_apply_analysis_result.py::test_apply_analysis_result_duplicate_confirm, tests/test_box100.py::test_mag_box_order_contains_100, tests/test_download_warehouse_csv.py::test_local_warehouse_csv_exists, tests/test_magazyn_pagination_grid.py::test_magazyn_page_navigation, tests/test_magazyn_pagination_grid.py::test_magazyn_grid_positions)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a9b40158832fbe9823ef0ddbfef7