### PR TITLE
Retry SSL images without verification

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -8,6 +8,7 @@ import os
 import csv
 import json
 import requests
+import urllib3
 import base64
 import mimetypes
 import re
@@ -97,6 +98,7 @@ ENV_FILE = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env")
 load_dotenv(ENV_FILE)
 
 logger = logging.getLogger(__name__)
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 BASE_IMAGE_URL = os.getenv("BASE_IMAGE_URL", "https://sklep839679.shoparena.pl/upload/images")
 SCANS_DIR = os.getenv("SCANS_DIR", "scans")
@@ -264,11 +266,32 @@ def _load_image(path: str) -> Optional[Image.Image]:
             resp = requests.get(path, timeout=5)
             resp.raise_for_status()
             data = resp.content
-            _IMAGE_CACHE[path] = (data, time.time())
             img = load_rgba_image(io.BytesIO(data))
             if img is not None:
+                _IMAGE_CACHE[path] = (data, time.time())
                 return img
+            _IMAGE_CACHE[path] = (None, time.time())
             return None
+        except requests.exceptions.SSLError:
+            try:
+                resp = requests.get(
+                    path,
+                    timeout=5,
+                    verify=False,
+                    headers={"User-Agent": "Mozilla/5.0"},
+                )
+                resp.raise_for_status()
+                data = resp.content
+                img = load_rgba_image(io.BytesIO(data))
+                if img is not None:
+                    _IMAGE_CACHE[path] = (data, time.time())
+                    return img
+                _IMAGE_CACHE[path] = (None, time.time())
+                return None
+            except requests.RequestException as exc:
+                logger.warning("Failed to download image %s: %s", path, exc)
+                _IMAGE_CACHE[path] = (None, time.time())
+                return None
         except requests.RequestException as exc:
             logger.warning("Failed to download image %s: %s", path, exc)
             _IMAGE_CACHE[path] = (None, time.time())

--- a/tests/test_remote_image_loading.py
+++ b/tests/test_remote_image_loading.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import csv
 import io
 from PIL import Image
+import requests
 
 
 # Dummy widgets to simulate customtkinter components
@@ -295,4 +296,32 @@ def test_show_card_details_remote_uses_cache(tmp_path):
 
     # only one HTTP request despite two image loads
     assert mock_get.call_count == 1
+
+
+def test_load_image_ssl_error_retry(tmp_path):
+    ui = _setup_module(tmp_path)
+
+    url = "https://example.com/card.png"
+    img_bytes = io.BytesIO()
+    Image.new("RGB", (10, 10), "white").save(img_bytes, format="PNG")
+    img_bytes = img_bytes.getvalue()
+    resp = SimpleNamespace(content=img_bytes, raise_for_status=lambda: None)
+
+    DummySSLError = type("DummySSLError", (Exception,), {})
+    side_effects = [DummySSLError("bad ssl"), resp]
+
+    def _side_effect(*args, **kwargs):
+        result = side_effects.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    with patch.object(ui.requests, "get", side_effect=_side_effect) as mock_get, \
+         patch.object(ui.requests.exceptions, "SSLError", DummySSLError):
+        img = ui._load_image(url)
+
+    assert img is not None
+    assert mock_get.call_count == 2
+    assert mock_get.call_args_list[1][1]["verify"] is False
+    assert mock_get.call_args_list[1][1]["headers"]["User-Agent"] == "Mozilla/5.0"
 


### PR DESCRIPTION
## Summary
- handle `requests.exceptions.SSLError` in `_load_image`
- retry image download with `verify=False` and a user-agent header
- suppress `urllib3` `InsecureRequestWarning`
- add regression test for SSL retry logic

## Testing
- `pytest tests/test_remote_image_loading.py::test_load_image_ssl_error_retry -q`
- `pytest` *(fails: tests/test_apply_analysis_result.py::test_apply_analysis_result_duplicate_cancel, tests/test_apply_analysis_result.py::test_apply_analysis_result_duplicate_confirm, tests/test_box100.py::test_mag_box_order_contains_100, tests/test_download_warehouse_csv.py::test_local_warehouse_csv_exists, tests/test_magazyn_pagination_grid.py::test_magazyn_page_navigation, tests/test_magazyn_pagination_grid.py::test_magazyn_grid_positions)*

------
https://chatgpt.com/codex/tasks/task_e_68c80d615a28832f809355083c69e514