### PR TITLE
Adjust auction treeview layout for better resizing

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2591,7 +2591,7 @@ class CardEditorApp:
         tk.Label(left_panel, textvariable=self.remaining_time_var, bg=self.root.cget("background"), fg="white").pack(anchor="w")
 
         win = tk.Frame(container, bg=self.root.cget("background"))
-        win.pack(side="left", fill="y", padx=10, pady=10)
+        win.pack(side="left", fill="both", expand=True, padx=10, pady=10)
         style = ttk.Style(win)
         style.configure(
             "Auction.Treeview",
@@ -2614,7 +2614,7 @@ class CardEditorApp:
             win,
             columns=("name", "price", "warehouse_code"),
             show="headings",
-            height=5,
+            height=15,
             style="Auction.Treeview",
         )
         for col, txt, width in [
@@ -2623,8 +2623,8 @@ class CardEditorApp:
             ("warehouse_code", "Kod magazynu", 120),
         ]:
             tree.heading(col, text=txt)
-            tree.column(col, width=width, stretch=False)
-        tree.pack(padx=5, pady=5, fill="y")
+            tree.column(col, width=width, stretch=True)
+        tree.pack(padx=5, pady=5, fill="both", expand=True)
 
         self.info_var = tk.StringVar()
         tk.Label(


### PR DESCRIPTION
## Summary
- allow the auction list panel to expand with the window and occupy available space
- let the auction treeview display more rows and stretch its columns with the window

## Testing
- not run (GUI change)


------
https://chatgpt.com/codex/tasks/task_e_68c901c66d94832f9926891dc0d8801f