### PR TITLE
Adjust treeview heading colors

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -2609,13 +2609,14 @@ class CardEditorApp:
         style.map("Auction.Treeview", background=[("selected", HOVER_COLOR)])
         style.configure(
             "Auction.Treeview.Heading",
-            background=ACCENT_COLOR,
+            background=NAV_BUTTON_COLOR,
             foreground=TEXT_COLOR,
             font=("Segoe UI", 14, "bold"),
         )
         style.map(
             "Auction.Treeview.Heading",
-            background=[("active", HOVER_COLOR)]
+            background=[("active", HOVER_COLOR), ("pressed", HOVER_COLOR)],
+            foreground=[("active", TEXT_COLOR), ("pressed", TEXT_COLOR)],
         )
 
         tree = ttk.Treeview(
@@ -2926,13 +2927,14 @@ class CardEditorApp:
         style.map("AuctionPreview.Treeview", background=[("selected", HOVER_COLOR)])
         style.configure(
             "AuctionPreview.Treeview.Heading",
-            background=ACCENT_COLOR,
+            background=NAV_BUTTON_COLOR,
             foreground=TEXT_COLOR,
             font=("Segoe UI", 14, "bold"),
         )
         style.map(
             "AuctionPreview.Treeview.Heading",
-            background=[("active", HOVER_COLOR)],
+            background=[("active", HOVER_COLOR), ("pressed", HOVER_COLOR)],
+            foreground=[("active", TEXT_COLOR), ("pressed", TEXT_COLOR)],
         )
 
         tree = ttk.Treeview(


### PR DESCRIPTION
## Summary
- align auction treeview headers with the navigation button color and existing text color
- define heading hover/pressed state colours to preserve contrast with the theme

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c90ad5bdd8832fa5f9b95c8ba94168