### PR TITLE
Support dual columns for special storage box

### DIFF
--- a/kartoteka/storage_config.py
+++ b/kartoteka/storage_config.py
@@ -25,7 +25,7 @@ STANDARD_BOX_CAPACITY = STANDARD_BOX_COLUMNS * BOX_COLUMN_CAPACITY
 # Identifier of the overflow box.  It differs in layout from the regular ones
 # and typically has reduced capacity.
 SPECIAL_BOX_NUMBER = 100
-SPECIAL_BOX_COLUMNS = 1
+SPECIAL_BOX_COLUMNS = 2
 SPECIAL_BOX_CAPACITY = 2000
 
 # Derived mappings -----------------------------------------------------------

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -435,7 +435,7 @@ SOLD_COLOR = os.getenv("SOLD_COLOR", "#888888")
 
 # Layout constants to simplify future adjustments
 BOX_THUMB_SIZE = 128  # square thumbnail size for warehouse boxes in pixels
-BOX100_X_INSET = int(BOX_THUMB_SIZE * 235 / 600)
+BOX100_X_INSET = int(BOX_THUMB_SIZE * 175 / 600)
 BOX100_Y_INSET = int(BOX_THUMB_SIZE * 50 / 600)
 CARD_THUMB_SIZE = 160  # larger card thumbnails in the warehouse list
 # Maximum allowed size for card thumbnails; used to cap dynamic calculations
@@ -5883,13 +5883,22 @@ class CardEditorApp:
             return
 
         if box == SPECIAL_BOX_NUMBER:
-            if column != 1 or not (1 <= pos <= SPECIAL_BOX_CAPACITY):
+            special_columns = storage.BOX_COLUMNS.get(SPECIAL_BOX_NUMBER, 1)
+            if not (
+                1 <= column <= special_columns
+                and 1 <= pos <= BOX_COLUMN_CAPACITY
+            ):
                 messagebox.showerror(
                     "Błąd",
-                    f"Dla boxu {SPECIAL_BOX_NUMBER} kolumna musi być 1, pozycja 1-{SPECIAL_BOX_CAPACITY}",
+                    f"Dla boxu {SPECIAL_BOX_NUMBER} kolumna musi być 1-{special_columns}, "
+                    f"pozycja 1-{BOX_COLUMN_CAPACITY}",
                 )
                 return
-            self.starting_idx = BOX_COUNT * BOX_CAPACITY + (pos - 1)
+            self.starting_idx = (
+                BOX_COUNT * BOX_CAPACITY
+                + (column - 1) * BOX_COLUMN_CAPACITY
+                + (pos - 1)
+            )
         else:
             if not (1 <= column <= GRID_COLUMNS and 1 <= pos <= BOX_COLUMN_CAPACITY):
                 messagebox.showerror(

--- a/tests/test_box100.py
+++ b/tests/test_box100.py
@@ -35,8 +35,13 @@ def test_compute_box_occupancy_box100(tmp_path, monkeypatch):
 def test_generate_and_next_free_location_box100():
     from kartoteka import storage
 
+    assert storage.BOX_COLUMNS[100] == 2
     idx = storage.BOX_COUNT * storage.BOX_CAPACITY[1]
     assert storage.generate_location(idx) == "K100R1P0001"
+    assert (
+        storage.generate_location(idx + storage.BOX_COLUMN_CAPACITY)
+        == "K100R2P0001"
+    )
 
     app = SimpleNamespace(output_data=[{"warehouse_code": "K100R1P0001"}], starting_idx=idx)
     assert storage.next_free_location(app) == "K100R1P0002"
@@ -95,5 +100,15 @@ def test_mag_box_order_contains_100(tmp_path, monkeypatch):
     percent = occ[100] / storage.BOX_CAPACITY[100] * 100
     assert percent == pytest.approx(0.05)
 
-    bar = app.mag_progressbars[(100, 1)]
-    assert bar.get() == pytest.approx(1 / ui.storage.BOX_COLUMN_CAPACITY)
+    column_occ = ui.storage.compute_column_occupancy()
+    assert column_occ[100][1] == 1
+    assert column_occ[100][2] == 0
+
+    col1_key = (100, 1)
+    col2_key = (100, 2)
+    assert col1_key in app.mag_progressbars
+    assert col2_key in app.mag_progressbars
+    assert app.mag_progressbars[col1_key].get() == pytest.approx(
+        1 / ui.storage.BOX_COLUMN_CAPACITY
+    )
+    assert app.mag_progressbars[col2_key].get() == 0


### PR DESCRIPTION
## Summary
- configure the special overflow box to use two columns and adjust scan validation/start index logic
- update the UI layout constants and ensure progress bars/occupancy support both columns
- extend the box100 tests to cover the new two-column behaviour and per-column progress bars

## Testing
- pytest tests/test_box100.py


------
https://chatgpt.com/codex/tasks/task_e_68c93997e7a4832fb4f7dfd50ef9bf14