### PR TITLE
Handle remote image connection errors with retry

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -54,6 +54,7 @@ import io
 import webbrowser
 import logging
 from gettext import gettext as _
+from http.client import RemoteDisconnected
 try:  # pragma: no cover - optional dependency
     from matplotlib.figure import Figure
     from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
@@ -154,6 +155,21 @@ _IMAGE_CACHE: dict[str, tuple[Optional[bytes], float]] = {}
 
 # cache for resized thumbnails keyed by source path/URL
 _THUMB_CACHE: dict[str, Image.Image] = {}
+
+_REMOTE_IMAGE_HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+def _download_remote_image(url: str, *, verify: bool) -> bytes:
+    """Return raw image bytes fetched from ``url``."""
+
+    response = requests.get(
+        url,
+        timeout=5,
+        headers=_REMOTE_IMAGE_HEADERS,
+        verify=verify,
+    )
+    response.raise_for_status()
+    return response.content
 
 
 def draw_box_usage(canvas: "tk.Canvas", box_num: int, occupancy: dict[int, int]) -> float:
@@ -263,40 +279,43 @@ def _load_image(path: str) -> Optional[Image.Image]:
             else:
                 # expire stale entry
                 _IMAGE_CACHE.pop(path, None)
+        download_errors = (
+            requests.exceptions.RequestException,
+            urllib3.exceptions.HTTPError,
+            RemoteDisconnected,
+        )
+        retryable_errors = (
+            requests.exceptions.SSLError,
+            requests.exceptions.ConnectionError,
+            urllib3.exceptions.ProtocolError,
+            urllib3.exceptions.MaxRetryError,
+            urllib3.exceptions.NewConnectionError,
+            RemoteDisconnected,
+        )
+
+        def _cache_failure() -> None:
+            _IMAGE_CACHE[path] = (None, time.time())
+
         try:
-            resp = requests.get(path, timeout=5)
-            resp.raise_for_status()
-            data = resp.content
-            img = load_rgba_image(io.BytesIO(data))
-            if img is not None:
-                _IMAGE_CACHE[path] = (data, time.time())
-                return img
-            _IMAGE_CACHE[path] = (None, time.time())
-            return None
-        except requests.exceptions.SSLError:
+            data = _download_remote_image(path, verify=True)
+        except retryable_errors:
             try:
-                resp = requests.get(
-                    path,
-                    timeout=5,
-                    verify=False,
-                    headers={"User-Agent": "Mozilla/5.0"},
-                )
-                resp.raise_for_status()
-                data = resp.content
-                img = load_rgba_image(io.BytesIO(data))
-                if img is not None:
-                    _IMAGE_CACHE[path] = (data, time.time())
-                    return img
-                _IMAGE_CACHE[path] = (None, time.time())
-                return None
-            except requests.RequestException as exc:
+                data = _download_remote_image(path, verify=False)
+            except download_errors as exc:
                 logger.warning("Failed to download image %s: %s", path, exc)
-                _IMAGE_CACHE[path] = (None, time.time())
+                _cache_failure()
                 return None
-        except requests.RequestException as exc:
+        except download_errors as exc:
             logger.warning("Failed to download image %s: %s", path, exc)
-            _IMAGE_CACHE[path] = (None, time.time())
+            _cache_failure()
             return None
+
+        img = load_rgba_image(io.BytesIO(data))
+        if img is not None:
+            _IMAGE_CACHE[path] = (data, time.time())
+            return img
+        _cache_failure()
+        return None
 
     return None
 

--- a/tests/test_remote_image_loading.py
+++ b/tests/test_remote_image_loading.py
@@ -322,6 +322,57 @@ def test_load_image_ssl_error_retry(tmp_path):
 
     assert img is not None
     assert mock_get.call_count == 2
+    first_kwargs = mock_get.call_args_list[0][1]
+    assert first_kwargs["verify"] is True
+    assert first_kwargs["headers"]["User-Agent"] == "Mozilla/5.0"
     assert mock_get.call_args_list[1][1]["verify"] is False
     assert mock_get.call_args_list[1][1]["headers"]["User-Agent"] == "Mozilla/5.0"
 
+
+def test_load_image_connection_error_retry_cached(tmp_path):
+    url = "https://example.com/card.png"
+    img_bytes = io.BytesIO()
+    Image.new("RGB", (10, 10), "white").save(img_bytes, format="PNG")
+    img_bytes = img_bytes.getvalue()
+
+    def _run_with_error(error_factory):
+        ui = _setup_module(tmp_path)
+        resp = SimpleNamespace(content=img_bytes, raise_for_status=lambda: None)
+        side_effects = [error_factory(ui), resp]
+
+        def _side_effect(*args, **kwargs):
+            result = side_effects.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        with patch.object(ui.requests, "get", side_effect=_side_effect) as mock_get:
+            first_img = ui._load_image(url)
+            cached_img = ui._load_image(url)
+
+        assert first_img is not None
+        assert cached_img is not None
+        assert mock_get.call_count == 2
+        first_kwargs = mock_get.call_args_list[0][1]
+        second_kwargs = mock_get.call_args_list[1][1]
+        assert first_kwargs["verify"] is True
+        assert first_kwargs["headers"]["User-Agent"] == "Mozilla/5.0"
+        assert second_kwargs["verify"] is False
+        assert second_kwargs["headers"]["User-Agent"] == "Mozilla/5.0"
+
+    disconnect_message = "Remote end closed connection without response"
+    error_factories = [
+        lambda module: module.requests.exceptions.ConnectionError(
+            module.urllib3.exceptions.ProtocolError(
+                "Connection aborted.",
+                module.RemoteDisconnected(disconnect_message),
+            )
+        ),
+        lambda module: module.urllib3.exceptions.ProtocolError(
+            "Connection aborted.",
+            module.RemoteDisconnected(disconnect_message),
+        ),
+    ]
+
+    for factory in error_factories:
+        _run_with_error(factory)


### PR DESCRIPTION
## Summary
- refactor remote image fetching to share a helper and retry for SSL, connection, and RemoteDisconnected failures
- ensure fallback attempts set a friendly User-Agent header, optionally disable certificate verification once, and cache results
- extend remote image tests to cover connection/RemoteDisconnected retries and caching behaviour

## Testing
- `pytest tests/test_remote_image_loading.py`


------
https://chatgpt.com/codex/tasks/task_e_68d1324fc1d0832fb7377ce347483588