### PR TITLE
Fix Shoper order fetch and track sold inventory codes

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -200,6 +200,89 @@ def build_product_code(
     return f"PKM-{abbr}-{num}{variant_code}{ball}"
 
 
+def mark_warehouse_codes_as_sold(codes, *, path: str | None = None) -> int:
+    """Mark cards associated with ``codes`` as sold in the warehouse CSV.
+
+    The helper understands grouped entries where multiple warehouse codes are
+    stored in a single CSV row.  When such a row contains both sold and unsold
+    codes the function keeps the unsold codes together and duplicates the row
+    with the sold flag set for each sold code.  This mirrors how the magazyn
+    view groups cards while ensuring sold entries are removed from future
+    exports.
+
+    Parameters
+    ----------
+    codes:
+        Iterable with warehouse codes to mark as sold.  Empty or falsy entries
+        are ignored.
+    path:
+        Optional explicit path to the CSV file.  When omitted the configured
+        :data:`WAREHOUSE_CSV` is used.
+
+    Returns
+    -------
+    int
+        Number of codes that were successfully marked as sold.
+    """
+
+    codes_to_mark = [c.strip() for c in (codes or []) if str(c).strip()]
+    if not codes_to_mark:
+        return 0
+
+    csv_path = path or WAREHOUSE_CSV
+    if not csv_path:
+        return 0
+
+    try:
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f, delimiter=";")
+            rows = list(reader)
+            fieldnames = reader.fieldnames or WAREHOUSE_FIELDNAMES
+    except FileNotFoundError:
+        return 0
+
+    sold_codes: set[str] = set()
+    updated_rows: list[dict[str, str]] = []
+
+    for row in rows:
+        raw_codes = str(row.get("warehouse_code") or "")
+        split_codes = [c.strip() for c in raw_codes.split(";") if c.strip()]
+        matches = [c for c in split_codes if c in codes_to_mark]
+
+        if not matches:
+            updated_rows.append(row)
+            continue
+
+        remaining = [c for c in split_codes if c not in matches]
+        if remaining:
+            unsold_row = dict(row)
+            unsold_row["warehouse_code"] = ";".join(remaining)
+            # ensure unsold row does not inherit a sold flag
+            if str(unsold_row.get("sold") or "").lower() in {"1", "true", "yes"}:
+                unsold_row["sold"] = ""
+            updated_rows.append(unsold_row)
+
+        for code in matches:
+            sold_row = dict(row)
+            sold_row["warehouse_code"] = code
+            sold_row["sold"] = "1"
+            updated_rows.append(sold_row)
+            sold_codes.add(code)
+
+    if not sold_codes:
+        return 0
+
+    if "sold" not in fieldnames:
+        fieldnames = list(fieldnames) + ["sold"]
+
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
+        writer.writeheader()
+        writer.writerows(updated_rows)
+
+    return len(sold_codes)
+
+
 def find_duplicates(
     name: str, number: str, set_name: str, variant: str | None = None
 ):

--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3986,18 +3986,6 @@ class CardEditorApp:
         the warehouse view is refreshed.
         """
 
-        csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
-        try:
-            with open(csv_path, newline="", encoding="utf-8") as f:
-                reader = csv.DictReader(f, delimiter=";")
-                rows = list(reader)
-                fieldnames = reader.fieldnames or []
-        except FileNotFoundError:
-            return
-
-        if "sold" not in fieldnames:
-            fieldnames.append("sold")
-
         codes_to_mark = {
             c.strip()
             for item in order.get("products", [])
@@ -4012,14 +4000,9 @@ class CardEditorApp:
         if not codes_to_mark:
             return
 
-        for r in rows:
-            if r.get("warehouse_code") in codes_to_mark:
-                r["sold"] = "1"
-
-        with open(csv_path, "w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
-            writer.writeheader()
-            writer.writerows(rows)
+        marked = csv_utils.mark_warehouse_codes_as_sold(codes_to_mark)
+        if not marked:
+            return
 
         if hasattr(self, "update_inventory_stats"):
             try:
@@ -5294,33 +5277,15 @@ class CardEditorApp:
     ):
         """Mark the card as sold, update CSV and refresh views."""
 
-        csv_path = getattr(csv_utils, "WAREHOUSE_CSV", "magazyn.csv")
-        try:
-            with open(csv_path, newline="", encoding="utf-8") as f:
-                reader = csv.DictReader(f, delimiter=";")
-                rows = list(reader)
-                fieldnames = reader.fieldnames or []
-        except FileNotFoundError:
-            return
-
-        if "sold" not in fieldnames:
-            fieldnames.append("sold")
-
         codes = [
             c.strip()
             for c in str(row.get("warehouse_code", "")).split(";")
             if c.strip()
         ]
         target = warehouse_code or (codes[0] if codes else "")
-        for r in rows:
-            if r.get("warehouse_code") == target:
-                r["sold"] = "1"
-                break
-
-        with open(csv_path, "w", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter=";")
-            writer.writeheader()
-            writer.writerows(rows)
+        marked = csv_utils.mark_warehouse_codes_as_sold([target])
+        if not marked:
+            return
 
         if window is not None:
             try:

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -70,11 +70,37 @@ class ShoperClient:
             params["sort"] = sort
         return self.get("products", params=params)
 
-    def list_orders(self, filters=None, page=1, per_page=20):
-        """Return a list of orders filtered by status or other fields."""
+    def list_orders(
+        self,
+        filters=None,
+        page=1,
+        per_page=20,
+        include_products=True,
+    ):
+        """Return a list of orders filtered by status or other fields.
+
+        Parameters
+        ----------
+        filters:
+            Optional mapping of query parameters supported by the API.
+        page / per_page:
+            Pagination arguments forwarded to the API.
+        include_products:
+            When ``True`` (the default) the request automatically expands the
+            response with product data so that the caller has immediate access
+            to ordered items without issuing follow-up requests.
+        """
+
         params = {"page": page, "per-page": per_page}
         if filters:
             params.update(filters)
+        if include_products:
+            includes = params.get("with")
+            if not includes:
+                includes = "products,delivery_address,billing_address"
+            elif isinstance(includes, (list, tuple, set)):
+                includes = ",".join(str(part) for part in includes if part)
+            params["with"] = includes
         return self.get("orders", params=params)
 
     def get_order(self, order_id):

--- a/tests/test_mark_warehouse_codes_as_sold.py
+++ b/tests/test_mark_warehouse_codes_as_sold.py
@@ -1,0 +1,55 @@
+import csv
+import sys
+from pathlib import Path
+
+
+def _setup_csv_utils(tmp_path):
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+    import kartoteka.csv_utils as csv_utils
+    csv_utils.WAREHOUSE_CSV = str(tmp_path / "magazyn.csv")
+    return csv_utils
+
+
+def test_mark_codes_handles_grouped_rows(tmp_path):
+    csv_utils = _setup_csv_utils(tmp_path)
+
+    with open(csv_utils.WAREHOUSE_CSV, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["name", "warehouse_code", "price", "sold"],
+            delimiter=";",
+        )
+        writer.writeheader()
+        writer.writerow({"name": "Card", "warehouse_code": "K1;K2", "price": "1", "sold": ""})
+
+    marked = csv_utils.mark_warehouse_codes_as_sold(["K1"])
+
+    assert marked == 1
+
+    with open(csv_utils.WAREHOUSE_CSV, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f, delimiter=";"))
+
+    assert any(r["warehouse_code"] == "K1" and r.get("sold") == "1" for r in rows)
+    assert any(r["warehouse_code"] == "K2" and not r.get("sold") for r in rows)
+
+
+def test_mark_codes_returns_zero_when_missing(tmp_path):
+    csv_utils = _setup_csv_utils(tmp_path)
+
+    with open(csv_utils.WAREHOUSE_CSV, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(
+            f,
+            fieldnames=["name", "warehouse_code", "price", "sold"],
+            delimiter=";",
+        )
+        writer.writeheader()
+        writer.writerow({"name": "Card", "warehouse_code": "K1", "price": "1", "sold": ""})
+
+    marked = csv_utils.mark_warehouse_codes_as_sold(["K9"])
+
+    assert marked == 0
+
+    with open(csv_utils.WAREHOUSE_CSV, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f, delimiter=";"))
+
+    assert rows[0]["sold"] == ""

--- a/tests/test_shoper_client.py
+++ b/tests/test_shoper_client.py
@@ -16,7 +16,7 @@ def test_client_endpoints(monkeypatch):
     captured = {}
 
     def fake_get(endpoint, **kwargs):
-        captured["get"] = endpoint
+        captured.setdefault("get_calls", []).append((endpoint, kwargs))
         return {}
 
     def fake_post(endpoint, **kwargs):
@@ -27,12 +27,16 @@ def test_client_endpoints(monkeypatch):
     monkeypatch.setattr(client, "post", fake_post)
 
     client.get_attributes()
-    client.add_product_attribute(1, 2, ["val"]) 
+    client.add_product_attribute(1, 2, ["val"])
+    client.list_orders()
 
-    assert captured["get"] == "attributes"
+    assert captured["get_calls"][0][0] == "attributes"
     assert captured["post"][0] == "products-attributes"
     assert captured["post"][1]["product_id"] == 1
     assert captured["post"][1]["attribute_id"] == 2
+    orders_call = captured["get_calls"][1]
+    assert orders_call[0] == "orders"
+    assert orders_call[1]["params"]["with"] == "products,delivery_address,billing_address"
 
 
 def test_import_csv_polls_until_complete(tmp_path, monkeypatch):
@@ -82,3 +86,21 @@ def test_import_csv_raises_on_error(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError) as exc:
         client.import_csv(str(csv_file))
     assert "boom" in str(exc.value)
+
+
+def test_list_orders_respects_existing_with(monkeypatch):
+    client = ShoperClient(base_url="https://shop", token="tok")
+
+    captured = {}
+
+    def fake_get(endpoint, **kwargs):
+        captured["endpoint"] = endpoint
+        captured["params"] = kwargs.get("params")
+        return {}
+
+    monkeypatch.setattr(client, "get", fake_get)
+
+    client.list_orders(filters={"with": ["products", "payment"]})
+
+    assert captured["endpoint"] == "orders"
+    assert captured["params"]["with"] == "products,payment"


### PR DESCRIPTION
## Summary
- include product details when listing Shoper orders and respect custom expansions
- centralize warehouse code selling logic so completing or manually marking orders updates the CSV safely
- cover the new behaviour with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3703c4984832f8393f59fc30d617e