### PR TITLE
Handle RuntimeError when listing Shoper orders

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3975,7 +3975,7 @@ class CardEditorApp:
                         f" - {item.get('name')} x{item.get('quantity')} [{code}] {location}"
                     )
             widget.insert(tk.END, "\n".join(lines))
-        except requests.RequestException as e:
+        except (requests.RequestException, RuntimeError) as e:
             logger.exception("Failed to list orders")
             messagebox.showerror("Błąd", str(e))
 

--- a/tests/test_show_orders_default_widget.py
+++ b/tests/test_show_orders_default_widget.py
@@ -10,6 +10,17 @@ import kartoteka.ui as ui
 importlib.reload(ui)
 
 
+class DummyText:
+    def __init__(self):
+        self.content = ""
+
+    def delete(self, *args, **kwargs):
+        self.content = ""
+
+    def insert(self, idx, txt):
+        self.content += txt
+
+
 def test_show_orders_uses_default_widget():
     orders = {
         "list": [
@@ -23,16 +34,6 @@ def test_show_orders_uses_default_widget():
     }
     dummy_client = SimpleNamespace(list_orders=lambda params: orders)
 
-    class DummyText:
-        def __init__(self):
-            self.content = ""
-
-        def delete(self, *args, **kwargs):
-            self.content = ""
-
-        def insert(self, idx, txt):
-            self.content += txt
-
     dummy_output = DummyText()
     app = SimpleNamespace(
         shoper_client=dummy_client,
@@ -44,3 +45,27 @@ def test_show_orders_uses_default_widget():
         ui.CardEditorApp.show_orders(app)
         ch.assert_called_once()
     assert "Zamówienie #1" in dummy_output.content
+
+
+def test_show_orders_handles_runtime_error():
+    dummy_client = SimpleNamespace(
+        list_orders=MagicMock(side_effect=RuntimeError("boom"))
+    )
+    dummy_output = DummyText()
+    app = SimpleNamespace(
+        shoper_client=dummy_client,
+        orders_output=dummy_output,
+        output_data=[],
+        location_from_code=lambda code: code,
+    )
+    with (
+        patch("kartoteka.ui.choose_nearest_locations") as choose,
+        patch("kartoteka.ui.messagebox.showerror") as showerror,
+        patch("kartoteka.ui.logger.exception") as log_exception,
+    ):
+        ui.CardEditorApp.show_orders(app)
+
+    choose.assert_not_called()
+    showerror.assert_called_once()
+    log_exception.assert_called_once()
+    assert dummy_output.content == ""


### PR DESCRIPTION
## Summary
- extend `CardEditorApp.show_orders` to catch `RuntimeError` when loading orders so the UI displays the existing error message
- add a regression test ensuring runtime errors from `list_orders` are handled without propagating

## Testing
- pytest tests/test_show_orders_default_widget.py

------
https://chatgpt.com/codex/tasks/task_e_68e37e9c0698832fbf2d12710ef8bd0c