### PR TITLE
feat: support Shoper OAuth client credentials

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -119,6 +119,7 @@ RAPIDAPI_HOST = os.getenv("RAPIDAPI_HOST")
 
 SHOPER_API_URL = os.getenv("SHOPER_API_URL", "").strip()
 SHOPER_API_TOKEN = os.getenv("SHOPER_API_TOKEN", "").strip()
+SHOPER_CLIENT_ID = os.getenv("SHOPER_CLIENT_ID", "").strip()
 WEBDAV_URL = os.getenv("WEBDAV_URL")
 WEBDAV_USER = os.getenv("WEBDAV_USER")
 WEBDAV_PASSWORD = os.getenv("WEBDAV_PASSWORD")
@@ -287,6 +288,18 @@ def _normalize_requests_exceptions() -> None:
             continue
         fallback = type(f"Requests{name}", (base,), {})
         setattr(exc_mod, name, fallback)
+
+    # Ensure top-level aliases (``requests.RequestException`` etc.) exist.
+    for attr, exc_name in (
+        ("RequestException", "RequestException"),
+        ("HTTPError", "HTTPError"),
+        ("ConnectionError", "ConnectionError"),
+    ):
+        candidate = getattr(requests, attr, None)
+        resolved = getattr(exc_mod, exc_name)
+        if isinstance(candidate, type) and issubclass(candidate, BaseException):
+            continue
+        setattr(requests, attr, resolved)
 
 
 _normalize_requests_exceptions()
@@ -7344,14 +7357,15 @@ class CardEditorApp:
         If configuration is missing or authentication fails, a configuration
         dialog is shown to the user.
         """
-        global SHOPER_API_URL, SHOPER_API_TOKEN
+        global SHOPER_API_URL, SHOPER_API_TOKEN, SHOPER_CLIENT_ID
         url = os.getenv("SHOPER_API_URL", "").strip()
         token = os.getenv("SHOPER_API_TOKEN", "").strip()
+        client_id = os.getenv("SHOPER_CLIENT_ID", "").strip()
         if not url or not token:
             self.open_config_dialog()
             return
         try:
-            client = ShoperClient(url, token)
+            client = ShoperClient(url, token, client_id or None)
             try:
                 # perform a simple request to verify credentials
                 client.get("products", params={"page": 1, "per-page": 1})
@@ -7360,8 +7374,12 @@ class CardEditorApp:
                 self.open_config_dialog()
                 return
             self.shoper_client = client
-            SHOPER_API_URL, SHOPER_API_TOKEN = url, token
-        except requests.RequestException as exc:
+            SHOPER_API_URL, SHOPER_API_TOKEN, SHOPER_CLIENT_ID = (
+                url,
+                token,
+                client_id,
+            )
+        except (requests.RequestException, RuntimeError) as exc:
             messagebox.showerror("Błąd", f"Nie można połączyć się z API Shoper: {exc}")
             self.open_config_dialog()
 
@@ -8356,46 +8374,62 @@ class CardEditorApp:
         """Display a dialog for editing Shoper API configuration."""
         url_var = tk.StringVar(value=os.getenv("SHOPER_API_URL", ""))
         token_var = tk.StringVar(value=os.getenv("SHOPER_API_TOKEN", ""))
+        client_id_var = tk.StringVar(value=os.getenv("SHOPER_CLIENT_ID", ""))
 
         top = ctk.CTkToplevel(self.root)
         top.title("Konfiguracja Shoper API")
         top.grab_set()
 
-        ctk.CTkLabel(top, text="URL API:", text_color=TEXT_COLOR).grid(
+        ctk.CTkLabel(top, text="Client ID:", text_color=TEXT_COLOR).grid(
             row=0, column=0, padx=10, pady=(10, 5), sticky="e"
         )
-        url_entry = ctk.CTkEntry(top, textvariable=url_var, width=400)
-        url_entry.grid(row=0, column=1, padx=10, pady=(10, 5))
+        client_id_entry = ctk.CTkEntry(top, textvariable=client_id_var, width=400)
+        client_id_entry.grid(row=0, column=1, padx=10, pady=(10, 5))
 
-        ctk.CTkLabel(top, text="Token API:", text_color=TEXT_COLOR).grid(
+        ctk.CTkLabel(top, text="URL API:", text_color=TEXT_COLOR).grid(
             row=1, column=0, padx=10, pady=5, sticky="e"
         )
+        url_entry = ctk.CTkEntry(top, textvariable=url_var, width=400)
+        url_entry.grid(row=1, column=1, padx=10, pady=5)
+
+        ctk.CTkLabel(top, text="Token API:", text_color=TEXT_COLOR).grid(
+            row=2, column=0, padx=10, pady=5, sticky="e"
+        )
         token_entry = ctk.CTkEntry(top, textvariable=token_var, width=400)
-        token_entry.grid(row=1, column=1, padx=10, pady=5)
+        token_entry.grid(row=2, column=1, padx=10, pady=5)
 
         def save():
             url = url_var.get().strip()
             token = token_var.get().strip()
+            client_id = client_id_var.get().strip()
             if not url or not token:
-                messagebox.showerror("Błąd", "Podaj URL i token API")
+                messagebox.showerror(
+                    "Błąd", "Podaj URL i token API (oraz Client ID jeśli wymagany)"
+                )
                 return
             set_key(ENV_FILE, "SHOPER_API_URL", url)
             set_key(ENV_FILE, "SHOPER_API_TOKEN", token)
+            set_key(ENV_FILE, "SHOPER_CLIENT_ID", client_id)
             os.environ["SHOPER_API_URL"] = url
             os.environ["SHOPER_API_TOKEN"] = token
+            os.environ["SHOPER_CLIENT_ID"] = client_id
             try:
-                client = ShoperClient(url, token)
+                client = ShoperClient(url, token, client_id or None)
                 try:
                     client.get("products", params={"page": 1, "per-page": 1})
                 except RuntimeError as exc:
                     messagebox.showerror("Błąd", f"Autoryzacja nieudana: {exc}")
                     return
                 self.shoper_client = client
-                global SHOPER_API_URL, SHOPER_API_TOKEN
-                SHOPER_API_URL, SHOPER_API_TOKEN = url, token
+                global SHOPER_API_URL, SHOPER_API_TOKEN, SHOPER_CLIENT_ID
+                SHOPER_API_URL, SHOPER_API_TOKEN, SHOPER_CLIENT_ID = (
+                    url,
+                    token,
+                    client_id,
+                )
                 messagebox.showinfo("Sukces", "Zapisano konfigurację Shoper API")
                 top.destroy()
-            except requests.RequestException as exc:
+            except (requests.RequestException, RuntimeError) as exc:
                 messagebox.showerror(
                     "Błąd", f"Nie można połączyć się z API Shoper: {exc}"
                 )
@@ -8403,7 +8437,7 @@ class CardEditorApp:
         save_btn = ctk.CTkButton(
             top, text="Zapisz", command=save, fg_color=SAVE_BUTTON_COLOR
         )
-        save_btn.grid(row=2, column=0, columnspan=2, pady=10)
+        save_btn.grid(row=3, column=0, columnspan=2, pady=10)
         top.grid_columnconfigure(1, weight=1)
         self.root.wait_window(top)
 

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -1,26 +1,41 @@
 import os
 import time
+from typing import Optional
+
 import requests
 
 
 class ShoperClient:
     """Minimal wrapper for Shoper REST API."""
 
-    def __init__(self, base_url=None, token=None):
+    def __init__(self, base_url=None, token=None, client_id=None):
         env_url = os.getenv("SHOPER_API_URL", "").strip()
         self.base_url = (base_url or env_url).rstrip("/")
         # Ensure the URL points to the REST endpoint
         if self.base_url and not self.base_url.endswith("/webapi/rest"):
             self.base_url = f"{self.base_url}/webapi/rest"
         env_token = os.getenv("SHOPER_API_TOKEN", "").strip()
-        self.token = token or env_token
-        if not self.base_url or not self.token:
-            raise ValueError("SHOPER_API_URL or SHOPER_API_TOKEN not set")
+        env_client_id = os.getenv("SHOPER_CLIENT_ID", "").strip()
+        self.client_id = (client_id or env_client_id).strip() or None
         self.session = requests.Session()
-        self.session.headers.update({
-            "Authorization": f"Bearer {self.token}",
-            "Accept": "application/json",
-        })
+        self.session.headers.update({"Accept": "application/json"})
+
+        raw_token = token or env_token
+        if not self.base_url or not raw_token:
+            raise ValueError("SHOPER_API_URL or SHOPER_API_TOKEN not set")
+
+        self._client_secret: Optional[str] = None
+        self._token_expires_at: float = 0.0
+        self.token: Optional[str] = None
+
+        if self.client_id:
+            self._client_secret = raw_token
+            self._authenticate(force=True)
+        else:
+            self.token = raw_token
+            self.session.headers.update({
+                "Authorization": f"Bearer {self.token}",
+            })
 
     def _request(self, method, endpoint, **kwargs):
         """Send a request to the Shoper API.
@@ -34,18 +49,30 @@ class ShoperClient:
         """
 
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
-        try:
-            resp = self.session.request(method, url, timeout=15, **kwargs)
-            resp.raise_for_status()
+        self._ensure_token()
+        attempt = 0
+        while True:
+            try:
+                resp = self.session.request(method, url, timeout=15, **kwargs)
+            except requests.RequestException as exc:
+                raise RuntimeError(f"API request failed: {exc}") from exc
+
+            if resp.status_code == 401 and self.client_id and attempt == 0:
+                # Access token expired – refresh and retry once.
+                self._authenticate(force=True)
+                attempt += 1
+                continue
+
+            try:
+                resp.raise_for_status()
+            except requests.HTTPError as exc:
+                if exc.response is not None and exc.response.status_code == 404:
+                    return {}
+                raise RuntimeError(f"API request failed: {exc}") from exc
+
             if resp.text:
                 return resp.json()
             return {}
-        except requests.HTTPError as exc:
-            if exc.response is not None and exc.response.status_code == 404:
-                return {}
-            raise RuntimeError(f"API request failed: {exc}") from exc
-        except requests.RequestException as exc:
-            raise RuntimeError(f"API request failed: {exc}") from exc
 
     def get(self, endpoint, **kwargs):
         return self._request("GET", endpoint, **kwargs)
@@ -164,3 +191,47 @@ class ShoperClient:
             "values": values,
         }
         return self.post("products-attributes", json=payload)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _ensure_token(self):
+        """Refresh the OAuth token when using client credentials."""
+
+        if not self.client_id:
+            return
+        if not self.token or time.time() >= (self._token_expires_at - 60):
+            self._authenticate(force=True)
+
+    def _authenticate(self, force=False):
+        if not self.client_id or not self._client_secret:
+            raise RuntimeError("Shoper client credentials are not configured")
+        if not force and self.token and time.time() < (self._token_expires_at - 60):
+            return
+
+        url = f"{self.base_url}/auth"
+        payload = {
+            "client_id": self.client_id,
+            "client_secret": self._client_secret,
+            "grant_type": "client_credentials",
+        }
+        try:
+            resp = self.session.post(url, json=payload, timeout=15)
+            resp.raise_for_status()
+            data = resp.json()
+        except (requests.RequestException, ValueError) as exc:
+            raise RuntimeError(f"Failed to authenticate with Shoper API: {exc}") from exc
+
+        access_token = data.get("access_token")
+        if not access_token:
+            raise RuntimeError("Shoper API did not return an access token")
+
+        expires_in = data.get("expires_in")
+        try:
+            expires = float(expires_in)
+        except (TypeError, ValueError):
+            expires = 3600.0
+
+        self.token = access_token
+        self._token_expires_at = time.time() + max(expires, 60.0)
+        self.session.headers.update({"Authorization": f"Bearer {self.token}"})

--- a/tests/test_shoper_client.py
+++ b/tests/test_shoper_client.py
@@ -1,6 +1,38 @@
 import time
+
+import sys
+import time
+from pathlib import Path
+
 import pytest
+import requests
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 from shoper_client import ShoperClient
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, data=None, text=""):
+        self.status_code = status_code
+        self._data = data or {}
+        if text:
+            self.text = text
+        elif self._data:
+            import json
+
+            self.text = json.dumps(self._data)
+        else:
+            self.text = ""
+        self.headers = {}
+
+    def raise_for_status(self):
+        if 400 <= self.status_code < 600:
+            error = requests.HTTPError(f"{self.status_code} error")
+            error.response = self
+            raise error
+
+    def json(self):
+        return self._data
 
 
 def test_env_vars_trimmed(monkeypatch):
@@ -104,3 +136,73 @@ def test_list_orders_respects_existing_with(monkeypatch):
 
     assert captured["endpoint"] == "orders"
     assert captured["params"]["with"] == "products,payment"
+
+
+def test_client_credentials_auth(monkeypatch):
+    monkeypatch.setenv("SHOPER_API_URL", "https://shop")
+    monkeypatch.setenv("SHOPER_API_TOKEN", "secret")
+    monkeypatch.setenv("SHOPER_CLIENT_ID", "client")
+
+    auth_payloads = []
+    request_headers = []
+
+    class FakeSession:
+        def __init__(self):
+            self.headers = {}
+
+        def post(self, url, json=None, timeout=15, **kwargs):
+            auth_payloads.append((url, json))
+            return DummyResponse(200, {"access_token": "token1", "expires_in": 120})
+
+        def request(self, method, url, timeout=15, **kwargs):
+            request_headers.append(self.headers.get("Authorization"))
+            return DummyResponse(200, {"ok": True})
+
+    monkeypatch.setattr(requests, "Session", FakeSession)
+
+    client = ShoperClient()
+    result = client.get("orders")
+
+    assert auth_payloads[0][0] == "https://shop/webapi/rest/auth"
+    assert auth_payloads[0][1]["client_id"] == "client"
+    assert request_headers[0] == "Bearer token1"
+    assert result == {"ok": True}
+
+
+def test_reauth_on_401(monkeypatch):
+    monkeypatch.setenv("SHOPER_API_URL", "https://shop")
+    monkeypatch.setenv("SHOPER_API_TOKEN", "secret")
+    monkeypatch.setenv("SHOPER_CLIENT_ID", "client")
+
+    tokens = iter(["token1", "token2"])
+
+    class FakeSession:
+        def __init__(self):
+            self.headers = {}
+            self.calls = 0
+
+        def post(self, url, json=None, timeout=15, **kwargs):
+            return DummyResponse(200, {"access_token": next(tokens), "expires_in": 120})
+
+        def request(self, method, url, timeout=15, **kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                return DummyResponse(401)
+            return DummyResponse(200, {"ok": True})
+
+    session_holder = {}
+
+    def make_session():
+        session = FakeSession()
+        session_holder["session"] = session
+        return session
+
+    monkeypatch.setattr(requests, "Session", make_session)
+
+    client = ShoperClient()
+    result = client.get("orders")
+
+    session = session_holder["session"]
+    assert session.calls == 2
+    assert session.headers["Authorization"] == "Bearer token2"
+    assert result == {"ok": True}


### PR DESCRIPTION
## Summary
- add OAuth client credential handling to the Shoper client with automatic token refresh and retry on 401 responses
- expose Client ID in the Shoper configuration dialog and persist it in the environment settings while hardening mocked requests exception fallbacks
- expand unit coverage for the new authentication flow and ensure the orders view keeps handling runtime failures

## Testing
- pytest tests/test_shoper_client.py tests/test_show_orders_default_widget.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e37d4678e0832fb176f9f014df6177