### PR TITLE
Include processing orders in dashboard

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -3963,7 +3963,8 @@ class CardEditorApp:
                 widget = getattr(self, "orders_output", None)
             if widget is None:
                 return
-            orders = self.shoper_client.list_orders({"filters[status]": "new"})
+            status_filters = {"filters[status]": ["new", "processing"]}
+            orders = self.shoper_client.list_orders(status_filters)
             orders_list = orders.get("list", orders)
             self.pending_orders = orders_list
             choose_nearest_locations(orders_list, self.output_data)

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -119,6 +119,7 @@ class ShoperClient:
         params = {"page": page, "per-page": per_page}
         if filters:
             params.update(filters)
+        self._normalise_status_filters(params)
         if include_products:
             includes = params.get("with")
             if not includes:
@@ -140,7 +141,39 @@ class ShoperClient:
             params.update(filters)
         if status:
             params["filters[status]"] = status
+        self._normalise_status_filters(params)
         return self.get("orders", params=params)
+
+    @staticmethod
+    def _normalise_status_filters(params: dict) -> None:
+        """Convert list-like status filters to the API ``[in]`` form."""
+
+        if not params:
+            return
+
+        status_values = None
+        if "filters[status]" in params:
+            status_values = params.get("filters[status]")
+            key_to_remove = "filters[status]"
+        elif "filters[status][in]" in params:
+            status_values = params.get("filters[status][in]")
+            key_to_remove = "filters[status][in]"
+        else:
+            return
+
+        if isinstance(status_values, (list, tuple, set)):
+            values = [str(value) for value in status_values if value]
+        elif isinstance(status_values, str):
+            values = [part.strip() for part in status_values.split(",") if part.strip()]
+        else:
+            values = [str(status_values)] if status_values else []
+
+        if not values:
+            params.pop(key_to_remove, None)
+            return
+
+        params.pop(key_to_remove, None)
+        params["filters[status][in]"] = ",".join(dict.fromkeys(values))
 
     def get_sales_stats(self, params=None):
         """Return sales statistics using the built-in Shoper endpoint."""

--- a/tests/test_shoper_client.py
+++ b/tests/test_shoper_client.py
@@ -153,6 +153,39 @@ def test_list_orders_respects_existing_with(monkeypatch):
     assert captured["params"]["with"] == "products,payment"
 
 
+def test_list_orders_normalises_status_filters(monkeypatch):
+    client = ShoperClient(base_url="https://shop", token="tok")
+
+    captured_params = {}
+
+    def fake_get(endpoint, **kwargs):
+        captured_params.update(kwargs.get("params", {}))
+        return {}
+
+    monkeypatch.setattr(client, "get", fake_get)
+
+    client.list_orders(filters={"filters[status]": ["new", "processing", "new"]})
+
+    assert captured_params["filters[status][in]"] == "new,processing"
+    assert "filters[status]" not in captured_params
+
+
+def test_get_orders_accepts_iterable_status(monkeypatch):
+    client = ShoperClient(base_url="https://shop", token="tok")
+
+    captured_params = {}
+
+    def fake_get(endpoint, **kwargs):
+        captured_params.update(kwargs.get("params", {}))
+        return {}
+
+    monkeypatch.setattr(client, "get", fake_get)
+
+    client.get_orders(status={"new", "processing"})
+
+    assert captured_params["filters[status][in]"] in {"new,processing", "processing,new"}
+
+
 def test_client_credentials_auth(monkeypatch):
     monkeypatch.setenv("SHOPER_API_URL", "https://shop")
     monkeypatch.setenv("SHOPER_API_TOKEN", "secret")

--- a/tests/test_show_orders_default_widget.py
+++ b/tests/test_show_orders_default_widget.py
@@ -47,6 +47,40 @@ def test_show_orders_uses_default_widget():
     assert "Zamówienie #1" in dummy_output.content
 
 
+def test_show_orders_requests_processing_status():
+    orders = {
+        "list": [
+            {
+                "order_id": 2,
+                "products": [
+                    {"name": "In progress", "quantity": 3, "warehouse_code": "B2"}
+                ],
+            }
+        ]
+    }
+    captured_filters = {}
+
+    def list_orders(filters):
+        captured_filters.update(filters)
+        return orders
+
+    dummy_client = SimpleNamespace(list_orders=list_orders)
+    dummy_output = DummyText()
+    app = SimpleNamespace(
+        shoper_client=dummy_client,
+        orders_output=dummy_output,
+        output_data=[],
+        location_from_code=lambda code: code,
+    )
+    with patch("kartoteka.ui.choose_nearest_locations"):
+        ui.CardEditorApp.show_orders(app)
+
+    status_filter = captured_filters.get("filters[status]")
+    assert status_filter is not None
+    assert set(status_filter) >= {"new", "processing"}
+    assert "Zamówienie #2" in dummy_output.content
+
+
 def test_show_orders_handles_runtime_error():
     dummy_client = SimpleNamespace(
         list_orders=MagicMock(side_effect=RuntimeError("boom"))


### PR DESCRIPTION
## Summary
- include "processing" status alongside new orders in the dashboard order view
- normalise Shoper status filters to use the API-compatible filters[status][in] form when multiple values are provided
- extend unit tests for the Shoper client and UI order display to cover the new behaviour

## Testing
- pytest tests/test_shoper_client.py tests/test_show_orders_default_widget.py

------
https://chatgpt.com/codex/tasks/task_e_68e3a77601ec832fa2210ad87c253cdf