### PR TITLE
Fix Shoper order pagination parameters

### DIFF
--- a/shoper_client.py
+++ b/shoper_client.py
@@ -116,7 +116,10 @@ class ShoperClient:
             to ordered items without issuing follow-up requests.
         """
 
-        params = {"page": page, "per-page": per_page}
+        params = {"page": page}
+        limit = self._coerce_limit(per_page)
+        if limit is not None:
+            params["limit"] = limit
         if filters:
             params.update(filters)
         self._normalise_status_filters(params)
@@ -136,13 +139,39 @@ class ShoperClient:
     # New helper methods for dashboard statistics
     def get_orders(self, status=None, filters=None, page=1, per_page=20):
         """Return orders optionally filtered by status and other criteria."""
-        params = {"page": page, "per-page": per_page}
+        params = {"page": page}
+        limit = self._coerce_limit(per_page)
+        if limit is not None:
+            params["limit"] = limit
         if filters:
             params.update(filters)
         if status:
             params["filters[status]"] = status
         self._normalise_status_filters(params)
         return self.get("orders", params=params)
+
+    @staticmethod
+    def _coerce_limit(value: Optional[int]) -> Optional[int]:
+        """Return a Shoper-compatible ``limit`` value.
+
+        The orders endpoint expects ``limit`` instead of ``per-page`` used by
+        other API calls and caps it at ``50``.  The helper keeps the public
+        ``per_page`` argument for backwards compatibility while ensuring the
+        request complies with the documented contract.
+        """
+
+        if value is None:
+            return None
+
+        try:
+            limit = int(value)
+        except (TypeError, ValueError):
+            return None
+
+        if limit <= 0:
+            return None
+
+        return min(limit, 50)
 
     @staticmethod
     def _normalise_status_filters(params: dict) -> None:

--- a/tests/test_shoper_client.py
+++ b/tests/test_shoper_client.py
@@ -84,6 +84,7 @@ def test_client_endpoints(monkeypatch):
     orders_call = captured["get_calls"][1]
     assert orders_call[0] == "orders"
     assert orders_call[1]["params"]["with"] == "products,delivery_address,billing_address"
+    assert orders_call[1]["params"]["limit"] == 20
 
 
 def test_import_csv_polls_until_complete(tmp_path, monkeypatch):
@@ -151,6 +152,7 @@ def test_list_orders_respects_existing_with(monkeypatch):
 
     assert captured["endpoint"] == "orders"
     assert captured["params"]["with"] == "products,payment"
+    assert captured["params"]["limit"] == 20
 
 
 def test_list_orders_normalises_status_filters(monkeypatch):
@@ -170,6 +172,23 @@ def test_list_orders_normalises_status_filters(monkeypatch):
     assert "filters[status]" not in captured_params
 
 
+def test_list_orders_caps_limit(monkeypatch):
+    client = ShoperClient(base_url="https://shop", token="tok")
+
+    captured_params = {}
+
+    def fake_get(endpoint, **kwargs):
+        captured_params.update(kwargs.get("params", {}))
+        return {}
+
+    monkeypatch.setattr(client, "get", fake_get)
+
+    client.list_orders(page=3, per_page=100)
+
+    assert captured_params["page"] == 3
+    assert captured_params["limit"] == 50
+
+
 def test_get_orders_accepts_iterable_status(monkeypatch):
     client = ShoperClient(base_url="https://shop", token="tok")
 
@@ -184,6 +203,7 @@ def test_get_orders_accepts_iterable_status(monkeypatch):
     client.get_orders(status={"new", "processing"})
 
     assert captured_params["filters[status][in]"] in {"new,processing", "processing,new"}
+    assert captured_params["limit"] == 20
 
 
 def test_client_credentials_auth(monkeypatch):


### PR DESCRIPTION
## Summary
- switch Shoper order listing to use the documented `limit` parameter and guard against invalid values
- add helper to cap order page size at the API maximum while keeping backward-compatible arguments
- extend client tests to cover the new pagination behaviour

## Testing
- pytest tests/test_shoper_client.py

------
https://chatgpt.com/codex/tasks/task_e_68e3b662e294832f8ebb39556ada8965