### PR TITLE
Add logging for Shoper order retrieval

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -4236,11 +4236,28 @@ class CardEditorApp:
             if widget is None:
                 return
             status_filters = {"filters[status.type]": [1, 2, 3, 4]}
+            logger.info(
+                "Requesting Shoper orders with filters: %s",
+                status_filters,
+            )
             orders = self.shoper_client.list_orders(status_filters)
             orders_list_raw = orders.get("list", orders)
             if isinstance(orders_list_raw, Mapping):
                 orders_list_raw = orders_list_raw.get("list", [])
             orders_list = [o for o in orders_list_raw if o]
+            if orders_list:
+                order_ids = [
+                    order.get("order_id") or order.get("id")
+                    for order in orders_list
+                    if isinstance(order, Mapping)
+                ]
+                logger.info(
+                    "Received %d Shoper orders, sample ids: %s",
+                    len(orders_list),
+                    order_ids[:5],
+                )
+            else:
+                logger.info("Received 0 Shoper orders")
             self.pending_orders = orders_list
             choose_nearest_locations(orders_list, self.output_data)
 

--- a/shoper_client.py
+++ b/shoper_client.py
@@ -1,8 +1,12 @@
+import logging
 import os
 import time
 from typing import Optional
 
 import requests
+
+
+logger = logging.getLogger(__name__)
 
 
 class ShoperClient:
@@ -67,6 +71,13 @@ class ShoperClient:
                 if exc.response is not None and exc.response.status_code == 404:
                     return {}
                 raise RuntimeError(f"API request failed: {exc}") from exc
+
+            logger.info(
+                "Shoper API %s %s succeeded with status %s",
+                method.upper(),
+                url,
+                resp.status_code,
+            )
 
             if resp.text:
                 return resp.json()


### PR DESCRIPTION
## Summary
- add informative logging around order retrieval in the UI to trace filters and returned IDs
- log successful Shoper API requests with method, URL, and status codes for better observability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b15a7dfc832f88e1cb1d0540e4eb