### PR TITLE
Prevent magazyn view from loading entire inventory at once

### DIFF
--- a/kartoteka/ui.py
+++ b/kartoteka/ui.py
@@ -5382,9 +5382,11 @@ class CardEditorApp:
             if per_page <= 0:
                 per_page = MAG_CARDS_PER_PAGE
 
-            if not any("era" in row for row in self.mag_card_rows):
-                per_page = max(per_page, len(indices))
-
+            # ``era`` used to be optional in magazyn exports.  Showing every card
+            # at once when the column is missing would previously disable
+            # pagination and instantiate hundreds of widgets, which could hang
+            # or crash the UI.  Keep the configured page size instead so large
+            # inventories remain responsive.
             total_cards = len(indices)
             self._mag_filtered_total = total_cards
             total_pages = max(1, math.ceil(total_cards / per_page)) if total_cards else 1


### PR DESCRIPTION
## Summary
- keep magazyn pagination enabled even when legacy magazyn exports lack the era column
- document why the behaviour stays paginated to avoid freezing the UI

## Testing
- pytest tests/test_magazyn_pagination_grid.py

------
https://chatgpt.com/codex/tasks/task_e_68e4b6b524e0832fa4d29e3f1c68d005