### PR TITLE
Add CLI helper for inspecting Shoper order statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,20 @@ The module defines shared constants such as the number of regular boxes
 details for the overflow box (`SPECIAL_BOX_NUMBER`, `SPECIAL_BOX_CAPACITY`).
 Both `storage.py` and `ui.py` import these values so any changes to the
 physical warehouse setup only need to be made in a single place.
+
+## Inspecting Shoper order statuses
+
+To verify what the Shoper API returns without any GUI filters, export your
+credentials and run the helper script:
+
+```bash
+export SHOPER_API_URL="https://twoj-sklep"
+export SHOPER_API_TOKEN="sekretny-token"
+python inspect_shoper_orders.py --per-page 5
+```
+
+The output lists each order with the textual status and the numeric
+`status.type` value used by the API. You can pass additional filters via the
+`--filter` option, for example
+`--filter filters[status.type]=2` to restrict the query to a specific type. Use
+`--raw` if you prefer the unmodified JSON response.

--- a/inspect_shoper_orders.py
+++ b/inspect_shoper_orders.py
@@ -1,0 +1,5 @@
+from kartoteka.order_inspector import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kartoteka/order_inspector.py
+++ b/kartoteka/order_inspector.py
@@ -1,0 +1,125 @@
+"""Utility for inspecting Shoper order status information.
+
+The module exposes a ``main`` function used by ``inspect_shoper_orders.py`` so
+operators can quickly query the API without the GUI defaults and check which
+status identifiers the backend is returning.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+from shoper_client import ShoperClient
+
+
+def _extract_status_type(order: Mapping[str, Any]) -> Optional[str]:
+    """Return the numeric status type exposed by the Shoper API."""
+
+    status_type: Any = order.get("status_type")
+    if isinstance(status_type, Mapping):
+        status_type = status_type.get("type") or status_type.get("id")
+    if not status_type:
+        status = order.get("status")
+        if isinstance(status, Mapping):
+            status_type = status.get("type") or status.get("id")
+    if status_type is None:
+        return None
+    return str(status_type)
+
+
+def _normalise_filters(raw_filters: Iterable[str]) -> MutableMapping[str, Any]:
+    """Convert KEY=VALUE pairs from the CLI into a mapping."""
+
+    filters: MutableMapping[str, Any] = {}
+    for item in raw_filters:
+        key, _, value = item.partition("=")
+        if not key:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if not value:
+            continue
+        filters.setdefault(key, []).append(value)
+    for key, values in list(filters.items()):
+        if len(values) == 1:
+            filters[key] = values[0]
+        else:
+            filters[key] = values
+    return filters
+
+
+def _format_order_summary(order: Mapping[str, Any]) -> str:
+    """Return a human readable summary line for console output."""
+
+    status = order.get("status")
+    if isinstance(status, Mapping):
+        status_name = status.get("name") or status.get("status")
+    else:
+        status_name = order.get("status_name") or status
+
+    status_type = _extract_status_type(order) or "?"
+    order_id = order.get("order_id") or order.get("id") or "?"
+
+    return f"#{order_id}: status={status_name!r} (type={status_type})"
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    """Entry point for the ``inspect_shoper_orders`` CLI script."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--per-page",
+        type=int,
+        default=5,
+        help="Number of orders to fetch in one request (default: 5)",
+    )
+    parser.add_argument(
+        "--page",
+        type=int,
+        default=1,
+        help="Page number to request (default: 1)",
+    )
+    parser.add_argument(
+        "--raw",
+        action="store_true",
+        help="Dump the raw JSON response instead of formatted summaries",
+    )
+    parser.add_argument(
+        "--filter",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Additional query filters, e.g. --filter filters[status.type]=2. "
+            "Repeat the option to provide multiple values."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    filters = _normalise_filters(args.filter)
+
+    client = ShoperClient()
+    response = client.list_orders(
+        filters=filters or None, page=args.page, per_page=args.per_page
+    )
+
+    orders = response.get("list", [])
+    if args.raw:
+        json.dump(response, sys.stdout, ensure_ascii=False, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    if not orders:
+        print("Brak zamówień w odpowiedzi API.")
+        return 0
+
+    print("Znaleziono", len(orders), "zamówień:")
+    for order in orders:
+        print(" -", _format_order_summary(order))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_inspect_shoper_orders.py
+++ b/tests/test_inspect_shoper_orders.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import kartoteka.order_inspector as inspector
+
+
+def test_extract_status_type_plain_number():
+    order = {"status_type": 2}
+    assert inspector._extract_status_type(order) == "2"
+
+
+def test_extract_status_type_nested_mapping():
+    order = {"status_type": {"type": 3}}
+    assert inspector._extract_status_type(order) == "3"
+
+
+def test_extract_status_type_fallback_to_status_object():
+    order = {"status": {"type": 4}}
+    assert inspector._extract_status_type(order) == "4"
+
+
+def test_extract_status_type_missing():
+    assert inspector._extract_status_type({}) is None
+
+
+def test_normalise_filters_splits_pairs():
+    filters = inspector._normalise_filters([
+        "filters[status.type]=2",
+        "filters[status.type]=3",
+        "with=products",
+    ])
+    assert filters["filters[status.type]"] == ["2", "3"]
+    assert filters["with"] == "products"
+
+
+def test_format_order_summary_handles_strings():
+    order = {"order_id": 10, "status_name": "open", "status_type": 2}
+    assert inspector._format_order_summary(order) == "#10: status='open' (type=2)"
+
+
+def test_format_order_summary_handles_status_mapping():
+    order = {
+        "order_id": 11,
+        "status": {"name": "W realizacji", "type": 2},
+    }
+    assert (
+        inspector._format_order_summary(order)
+        == "#11: status='W realizacji' (type=2)"
+    )


### PR DESCRIPTION
## Summary
- add a CLI entry point that lets operators fetch Shoper orders without GUI filters
- expose reusable inspection helpers in `kartoteka.order_inspector`
- document the workflow in the README and cover the helpers with unit tests

## Testing
- pytest tests/test_inspect_shoper_orders.py

------
https://chatgpt.com/codex/tasks/task_e_68e4e03b2d04832f89b38f14ff05a609