### PR TITLE
Update availability handling in store stock decrement

### DIFF
--- a/kartoteka/csv_utils.py
+++ b/kartoteka/csv_utils.py
@@ -232,7 +232,9 @@ def decrement_store_stock(
     """Decrease stock values in the store CSV based on ``quantities``.
 
     Each key in ``quantities`` represents a ``product_code`` and its value the
-    number of copies to deduct.  Rows reaching zero stock are removed entirely.
+    number of copies to deduct.  Rows that reach zero availability remain in
+    the file with their ``availability`` (and ``stock`` when present) set to
+    ``"0"``.
 
     Returns the total number of stock units deducted across all products.
     """
@@ -268,8 +270,11 @@ def decrement_store_stock(
     except FileNotFoundError:
         return 0
 
+    fieldnames = list(fieldnames)
+    if "availability" not in fieldnames:
+        fieldnames.append("availability")
     if "stock" not in fieldnames:
-        fieldnames = list(fieldnames) + ["stock"]
+        fieldnames.append("stock")
 
     updated_rows: list[dict[str, str]] = []
     deducted_total = 0
@@ -281,22 +286,25 @@ def decrement_store_stock(
             updated_rows.append(row)
             continue
 
+        availability_raw = row.get("availability")
+        if availability_raw in (None, ""):
+            availability_raw = row.get("stock")
+
         try:
-            stock = int(str(row.get("stock") or "0"))
+            availability = int(str(availability_raw or "0"))
         except ValueError:
-            stock = 0
+            availability = 0
 
-        if stock <= 0:
-            continue
-
-        deducted = min(stock, qty)
-        remaining = stock - deducted
+        deducted = min(availability, qty)
+        remaining = availability - deducted
         deducted_total += deducted
 
-        if remaining > 0:
-            updated = dict(row)
-            updated["stock"] = str(remaining)
-            updated_rows.append(updated)
+        updated = dict(row)
+        remaining_str = str(max(remaining, 0))
+        updated["availability"] = remaining_str
+        if "stock" in fieldnames:
+            updated["stock"] = remaining_str
+        updated_rows.append(updated)
 
     if deducted_total == 0:
         return 0

--- a/tests/test_decrement_store_stock.py
+++ b/tests/test_decrement_store_stock.py
@@ -1,14 +1,18 @@
 import csv
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import kartoteka.csv_utils as csv_utils
 
 
-def test_decrement_store_stock_updates_rows(tmp_path):
+def test_decrement_store_stock_updates_availability(tmp_path):
     csv_path = tmp_path / "store.csv"
     csv_path.write_text(
-        "product_code;name;stock\n"
-        "PKM-SET-1C;Card A;1\n"
-        "PKM-SET-2C;Card B;3\n",
+        "product_code;name;availability;stock\n"
+        "PKM-SET-1C;Card A;1;1\n"
+        "PKM-SET-2C;Card B;3;3\n",
         encoding="utf-8",
     )
 
@@ -16,9 +20,34 @@ def test_decrement_store_stock_updates_rows(tmp_path):
     assert removed == 3
 
     with open(csv_path, newline="", encoding="utf-8") as fh:
-        rows = list(csv.DictReader(fh, delimiter=";"))
+        reader = csv.DictReader(fh, delimiter=";")
+        rows = list(reader)
 
-    assert len(rows) == 1
-    row = rows[0]
-    assert row["product_code"] == "PKM-SET-2C"
-    assert row["stock"] == "1"
+    assert len(rows) == 2
+    assert reader.fieldnames == ["product_code", "name", "availability", "stock"]
+
+    result = {row["product_code"]: row for row in rows}
+    assert result["PKM-SET-1C"]["availability"] == "0"
+    assert result["PKM-SET-1C"]["stock"] == "0"
+    assert result["PKM-SET-2C"]["availability"] == "1"
+    assert result["PKM-SET-2C"]["stock"] == "1"
+
+
+def test_decrement_store_stock_adds_availability_column(tmp_path):
+    csv_path = tmp_path / "store.csv"
+    csv_path.write_text(
+        "product_code;name;stock\n"
+        "PKM-SET-1C;Card A;2\n",
+        encoding="utf-8",
+    )
+
+    removed = csv_utils.decrement_store_stock({"PKM-SET-1C": 1}, path=str(csv_path))
+    assert removed == 1
+
+    with open(csv_path, newline="", encoding="utf-8") as fh:
+        reader = csv.DictReader(fh, delimiter=";")
+        rows = list(reader)
+
+    assert reader.fieldnames == ["product_code", "name", "stock", "availability"]
+    assert rows[0]["availability"] == "1"
+    assert rows[0]["stock"] == "1"


### PR DESCRIPTION
## Summary
- update `decrement_store_stock` to operate on the `availability` column and retain rows that reach zero
- synchronise the auxiliary `stock` field with updated availability values
- expand the tests for `decrement_store_stock` to cover availability updates and column creation

## Testing
- pytest tests/test_decrement_store_stock.py

------
https://chatgpt.com/codex/tasks/task_e_68e7a9839634832f8e459e953db9eadd